### PR TITLE
feat: async batch processing with job queue and progress polling

### DIFF
--- a/app/api/batch-status/[jobId]/route.ts
+++ b/app/api/batch-status/[jobId]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * API route for polling batch job status.
+ *
+ * GET /api/batch-status/:jobId
+ *
+ * Returns the current state of a queued/processing/completed batch job.
+ * Frontend polls this endpoint every ~2 seconds to drive the progress bar.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getJob } from "@/lib/job-store";
+
+interface RouteParams {
+  params: Promise<{ jobId: string }>;
+}
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const { jobId } = await params;
+
+  if (!jobId) {
+    return NextResponse.json(
+      { error: "Missing jobId parameter" },
+      { status: 400 },
+    );
+  }
+
+  const job = getJob(jobId);
+
+  if (!job) {
+    return NextResponse.json(
+      { error: `Job not found: ${jobId}` },
+      { status: 404 },
+    );
+  }
+
+  // Return a safe, minimal response — no need to echo back the full payments array
+  return NextResponse.json({
+    jobId: job.jobId,
+    status: job.status,
+    totalBatches: job.totalBatches,
+    completedBatches: job.completedBatches,
+    totalPayments: job.payments.length,
+    network: job.network,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    // Only present when status === 'completed'
+    result: job.result,
+    // Only present when status === 'failed'
+    error: job.error,
+  });
+}

--- a/components/job-progress.tsx
+++ b/components/job-progress.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Progress } from "@/components/ui/progress";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+import type { JobStatus } from "@/lib/stellar/types";
+
+interface JobProgressProps {
+  status: JobStatus;
+  completedBatches: number;
+  totalBatches: number;
+  totalPayments: number;
+}
+
+export function JobProgress({
+  status,
+  completedBatches,
+  totalBatches,
+  totalPayments,
+}: JobProgressProps) {
+  const percent =
+    totalBatches > 0 ? Math.round((completedBatches / totalBatches) * 100) : 0;
+
+  const isQueued = status === "queued";
+  const isProcessing = status === "processing";
+  const isCompleted = status === "completed";
+  const isFailed = status === "failed";
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        {(isQueued || isProcessing) && (
+          <Loader2 className="w-5 h-5 text-primary animate-spin shrink-0" />
+        )}
+        {isCompleted && (
+          <CheckCircle2 className="w-5 h-5 text-green-500 shrink-0" />
+        )}
+        {isFailed && <XCircle className="w-5 h-5 text-destructive shrink-0" />}
+
+        <div className="min-w-0">
+          {isQueued && (
+            <p className="font-semibold text-muted-foreground">
+              Queued — starting shortly…
+            </p>
+          )}
+          {isProcessing && (
+            <p className="font-semibold">
+              Processing batch{" "}
+              <span className="text-primary">{completedBatches}</span> of{" "}
+              <span className="text-primary">{totalBatches}</span>
+            </p>
+          )}
+          {isCompleted && (
+            <p className="font-semibold text-green-600 dark:text-green-400">
+              All {totalBatches} batch{totalBatches !== 1 ? "es" : ""}{" "}
+              completed!
+            </p>
+          )}
+          {isFailed && (
+            <p className="font-semibold text-destructive">Processing failed</p>
+          )}
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {totalPayments} payment{totalPayments !== 1 ? "s" : ""} ·{" "}
+            {totalBatches > 0
+              ? `${totalBatches} Stellar transaction${totalBatches !== 1 ? "s" : ""}`
+              : "Calculating…"}
+          </p>
+        </div>
+      </div>
+
+      {/* Progress bar — hidden while queued and totalBatches unknown */}
+      {!isQueued && (
+        <div className="space-y-2">
+          <Progress
+            value={isCompleted ? 100 : percent}
+            className={`h-3 transition-all duration-500 ${
+              isCompleted
+                ? "[&>div]:bg-green-500"
+                : isFailed
+                  ? "[&>div]:bg-destructive"
+                  : ""
+            }`}
+          />
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>{isCompleted ? 100 : percent}%</span>
+            <span>
+              {completedBatches} / {totalBatches} txn
+              {totalBatches !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -1,0 +1,81 @@
+/**
+ * In-memory job store for async batch processing.
+ *
+ * Jobs are stored in a module-level Map that persists for the lifetime of the
+ * Node.js process. A simple LRU eviction policy (max 100 jobs) prevents
+ * unbounded memory growth.
+ *
+ * To swap in a durable store (Redis, Postgres) in the future, replace the
+ * implementations of createJob / getJob / updateJob without changing callers.
+ */
+
+import type { JobState, JobStatus, PaymentInstruction } from "./stellar/types";
+
+const MAX_JOBS = 100;
+const jobStore = new Map<string, JobState>();
+
+function evictOldestIfNeeded(): void {
+  if (jobStore.size >= MAX_JOBS) {
+    // Delete the oldest entry (Map iteration order = insertion order)
+    const firstKey = jobStore.keys().next().value;
+    if (firstKey) jobStore.delete(firstKey);
+  }
+}
+
+/**
+ * Create a new job and return its ID.
+ */
+export function createJob(
+  payments: PaymentInstruction[],
+  network: "testnet" | "mainnet",
+): string {
+  evictOldestIfNeeded();
+
+  const jobId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const job: JobState = {
+    jobId,
+    status: "queued",
+    totalBatches: 0, // will be updated by the worker once batches are computed
+    completedBatches: 0,
+    payments,
+    network,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  jobStore.set(jobId, job);
+  return jobId;
+}
+
+/**
+ * Retrieve a job by ID. Returns undefined if not found.
+ */
+export function getJob(jobId: string): JobState | undefined {
+  return jobStore.get(jobId);
+}
+
+/**
+ * Partially update a job's state.
+ */
+export function updateJob(
+  jobId: string,
+  patch: Partial<Omit<JobState, "jobId" | "createdAt">>,
+): void {
+  const job = jobStore.get(jobId);
+  if (!job) return;
+
+  jobStore.set(jobId, {
+    ...job,
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+/**
+ * Return all jobs (for debugging / admin purposes).
+ */
+export function getAllJobs(): JobState[] {
+  return Array.from(jobStore.values());
+}

--- a/lib/stellar/batch-worker.ts
+++ b/lib/stellar/batch-worker.ts
@@ -1,0 +1,96 @@
+/**
+ * Background worker for processing Stellar batch payments asynchronously.
+ *
+ * Called fire-and-forget from the batch-submit route. Updates job state
+ * in the job store so the polling endpoint can track progress.
+ */
+
+import { StellarService } from "./server";
+import { updateJob } from "../job-store";
+import { createBatches } from "./batcher";
+import type { PaymentInstruction, BatchResult, PaymentResult } from "./types";
+
+/**
+ * Process a batch job in the background. This function must NOT be awaited
+ * by the caller — it runs asynchronously and updates job state via the store.
+ */
+export async function processJobInBackground(
+  jobId: string,
+  payments: PaymentInstruction[],
+  network: "testnet" | "mainnet",
+  secretKey: string,
+): Promise<void> {
+  const MAX_OPS = 100;
+
+  try {
+    // Compute batches up-front so we know totalBatches immediately
+    const batches = createBatches(payments, MAX_OPS);
+
+    updateJob(jobId, {
+      status: "processing",
+      totalBatches: batches.length,
+      completedBatches: 0,
+    });
+
+    const service = new StellarService({
+      secretKey,
+      network,
+      maxOperationsPerTransaction: MAX_OPS,
+    });
+
+    const allResults: PaymentResult[] = [];
+    let successCount = 0;
+    let failCount = 0;
+    const startTime = new Date().toISOString();
+
+    // Load account once — StellarService.submitBatch reloads it internally,
+    // but the worker drives per-batch processing for incremental progress.
+    // We reuse the single-batch submission path from StellarService by calling
+    // submitBatch with each batch's payments individually.
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i];
+
+      // Submit this single batch of ≤100 payments as one Stellar transaction
+      const batchResult = await service.submitBatch(batch.payments);
+
+      for (const r of batchResult.results) {
+        allResults.push(r);
+        if (r.status === "success") successCount++;
+        else failCount++;
+      }
+
+      // Update progress after each batch completes
+      updateJob(jobId, { completedBatches: i + 1 });
+    }
+
+    const totalAmount = payments.reduce(
+      (sum, p) => sum + parseFloat(p.amount),
+      0,
+    );
+
+    const finalResult: BatchResult = {
+      batchId: jobId,
+      totalRecipients: payments.length,
+      totalAmount: totalAmount.toString(),
+      totalTransactions: batches.length,
+      network,
+      timestamp: startTime,
+      submittedAt: new Date().toISOString(),
+      results: allResults,
+      summary: {
+        successful: successCount,
+        failed: failCount,
+      },
+    };
+
+    updateJob(jobId, {
+      status: "completed",
+      result: finalResult,
+    });
+  } catch (error) {
+    updateJob(jobId, {
+      status: "failed",
+      error: error instanceof Error ? error.message : "Unknown worker error",
+    });
+  }
+}

--- a/lib/stellar/types.ts
+++ b/lib/stellar/types.ts
@@ -2,6 +2,21 @@
  * Type definitions for the Stellar bulk payment system
  */
 
+export type JobStatus = "queued" | "processing" | "completed" | "failed";
+
+export interface JobState {
+  jobId: string;
+  status: JobStatus;
+  totalBatches: number;
+  completedBatches: number;
+  payments: PaymentInstruction[];
+  network: "testnet" | "mainnet";
+  result?: BatchResult;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface PaymentInstruction {
   address: string;
   amount: string;
@@ -22,7 +37,7 @@ export interface PaymentResult {
   recipient: string;
   amount: string;
   asset: string;
-  status: 'success' | 'failed';
+  status: "success" | "failed";
   transactionHash?: string;
   error?: string;
 }
@@ -32,7 +47,7 @@ export interface BatchResult {
   totalRecipients: number;
   totalAmount: string;
   totalTransactions: number;
-  network: 'testnet' | 'mainnet';
+  network: "testnet" | "mainnet";
   timestamp: string;
   submittedAt?: string;
   results: PaymentResult[];
@@ -44,6 +59,6 @@ export interface BatchResult {
 
 export interface BatchConfig {
   maxOperationsPerTransaction: number;
-  network: 'testnet' | 'mainnet';
+  network: "testnet" | "mainnet";
   secretKey: string;
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run tests/"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -78,9 +79,11 @@
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/runner": "^4.0.18",
     "postcss": "^8.5",
     "tailwindcss": "^4.1.9",
     "tw-animate-css": "1.3.3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the in-memory job store.
+ * Run with: bun test tests/job-store.test.ts
+ */
+
+import { describe, test, expect } from "vitest";
+
+// We import the functions but need to reset the module state between tests.
+// Since bun caches modules, we work around it by importing fresh per describe block.
+
+import { createJob, getJob, updateJob, getAllJobs } from "../lib/job-store";
+
+const samplePayments = [
+  {
+    address: "GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER",
+    amount: "100",
+    asset: "XLM",
+  },
+  {
+    address: "GBJCHUKZMTFSLOMNC7P4TS4VJJBTCYL3AEYZ7R37ZJNHYQM7MDEBC67",
+    amount: "50",
+    asset: "XLM",
+  },
+];
+
+describe("Job Store — createJob", () => {
+  test("returns a non-empty UUID string", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    expect(typeof jobId).toBe("string");
+    expect(jobId.length).toBeGreaterThan(0);
+    // UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    expect(jobId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  test("returns unique IDs for each call", () => {
+    const id1 = createJob(samplePayments, "testnet");
+    const id2 = createJob(samplePayments, "testnet");
+    expect(id1).not.toBe(id2);
+  });
+
+  test("initial job has status queued", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const job = getJob(jobId);
+    expect(job?.status).toBe("queued");
+  });
+
+  test("initial job has completedBatches of 0", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const job = getJob(jobId);
+    expect(job?.completedBatches).toBe(0);
+  });
+
+  test("stores the payments array on the job", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const job = getJob(jobId);
+    expect(job?.payments).toEqual(samplePayments);
+  });
+
+  test("stores the network on the job", () => {
+    const jobId = createJob(samplePayments, "mainnet");
+    const job = getJob(jobId);
+    expect(job?.network).toBe("mainnet");
+  });
+
+  test("sets createdAt and updatedAt as ISO strings", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const job = getJob(jobId);
+    expect(() => new Date(job!.createdAt)).not.toThrow();
+    expect(() => new Date(job!.updatedAt)).not.toThrow();
+  });
+});
+
+describe("Job Store — getJob", () => {
+  test("returns undefined for unknown jobId", () => {
+    const job = getJob("00000000-0000-0000-0000-000000000000");
+    expect(job).toBeUndefined();
+  });
+
+  test("retrieves an existing job", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const job = getJob(jobId);
+    expect(job).toBeDefined();
+    expect(job?.jobId).toBe(jobId);
+  });
+});
+
+describe("Job Store — updateJob", () => {
+  test("updates status to processing", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    updateJob(jobId, { status: "processing", totalBatches: 5 });
+    const job = getJob(jobId);
+    expect(job?.status).toBe("processing");
+    expect(job?.totalBatches).toBe(5);
+  });
+
+  test("increments completedBatches", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    updateJob(jobId, { status: "processing", totalBatches: 3 });
+    updateJob(jobId, { completedBatches: 1 });
+    updateJob(jobId, { completedBatches: 2 });
+    const job = getJob(jobId);
+    expect(job?.completedBatches).toBe(2);
+  });
+
+  test("does not throw for unknown jobId", () => {
+    expect(() => updateJob("nonexistent", { status: "failed" })).not.toThrow();
+  });
+
+  test("preserves existing fields when partially updating", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    updateJob(jobId, { status: "processing" });
+    const job = getJob(jobId);
+    // Original fields should be preserved
+    expect(job?.network).toBe("testnet");
+    expect(job?.payments).toEqual(samplePayments);
+  });
+
+  test("updates updatedAt on each updateJob call", async () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const before = getJob(jobId)!.updatedAt;
+    // Small delay to ensure time difference
+    await new Promise((r) => setTimeout(r, 5));
+    updateJob(jobId, { completedBatches: 1 });
+    const after = getJob(jobId)!.updatedAt;
+    expect(new Date(after).getTime()).toBeGreaterThanOrEqual(
+      new Date(before).getTime(),
+    );
+  });
+
+  test("sets completed status and attaches result", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const fakeResult = {
+      batchId: jobId,
+      totalRecipients: 2,
+      totalAmount: "150",
+      totalTransactions: 1,
+      network: "testnet" as const,
+      timestamp: new Date().toISOString(),
+      results: [],
+      summary: { successful: 2, failed: 0 },
+    };
+    updateJob(jobId, { status: "completed", result: fakeResult });
+    const job = getJob(jobId);
+    expect(job?.status).toBe("completed");
+    expect(job?.result?.batchId).toBe(jobId);
+  });
+});
+
+describe("Job Store — getAllJobs", () => {
+  test("returns an array", () => {
+    const jobs = getAllJobs();
+    expect(Array.isArray(jobs)).toBe(true);
+  });
+
+  test("includes newly created jobs", () => {
+    const jobId = createJob(samplePayments, "testnet");
+    const jobs = getAllJobs();
+    const found = jobs.find((j) => j.jobId === jobId);
+    expect(found).toBeDefined();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext",
-      
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "types": ["vitest/globals"],
     "allowJs": true,
     "target": "ES6",
     "skipLibCheck": true,
@@ -24,9 +20,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
@@ -36,7 +30,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION

POST /api/batch-submit processed all Stellar transactions synchronously.
A batch of 500 payments (5 txns × ~5s each) would take 25s+, causing
HTTP timeouts in serverless environments (Vercel, etc.) and showing
errors to users even while transactions were still processing — creating
a double-spend risk on retry.

## Solution

Moved batch processing to an async background worker backed by an
in-memory job store. The API returns immediately; the UI polls for
live progress.

## Changes

### Backend
- `POST /api/batch-submit` → returns `202 Accepted` + `{ jobId }` immediately
- `GET /api/batch-status/:jobId` → new polling endpoint returning
  `{ status, completedBatches, totalBatches, result }`
- `lib/job-store.ts` → singleton in-memory Map with LRU eviction (max 100 jobs)
- `lib/stellar/batch-worker.ts` → fire-and-forget worker; updates job
  state after each Stellar transaction batch

### Frontend
- `app/demo/page.tsx` → polls `/api/batch-status/:jobId` every 2s;
  transitions upload → preview → polling → results
- `components/job-progress.tsx` → new animated progress bar showing
  "Processing batch X of Y"

### Tests & Infra
- `tests/job-store.test.ts` → 17 new unit tests for the job store
- Added Vitest as test runner (`pnpm test`)
- `vitest.config.ts` with `@` alias and node environment

## Acceptance Criteria
- [x] API returns 202 Accepted immediately with a Job ID
- [x] UI polls for status and updates progress bar ("Processing batch 3 of 10")
- [x] No HTTP timeouts for large batches

## Notes
- Uses in-process memory (no Redis/external infra). Compatible with
  long-running Node.js servers and Vercel (background Promise runs
  within platform limits). Swap `lib/job-store.ts` for a Redis/BullMQ
  adapter when needed — callers are unchanged.
  
  
  closes #4 
