### PR TITLE
feat: implement   MetricsGrid component into the Batch History page

### DIFF
--- a/app/dashboard/history/page.tsx
+++ b/app/dashboard/history/page.tsx
@@ -1,19 +1,28 @@
-"use client"
+"use client";
 
-import { motion } from "framer-motion"
-import { HistoryFilterBar } from "@/components/dashboard/HistoryFilterBar"
-import { HistoryTable } from "@/components/dashboard/HistoryTable"
-import { Pagination } from "@/components/dashboard/Pagination"
-import { Card, CardContent } from "@/components/ui/card"
+import { motion } from "framer-motion";
+import { HistoryFilterBar } from "@/components/dashboard/HistoryFilterBar";
+import { HistoryTable } from "@/components/dashboard/HistoryTable";
+import { Pagination } from "@/components/dashboard/Pagination";
+import { MetricsGrid } from "@/components/dashboard/MetricsGrid";
+import { Card, CardContent } from "@/components/ui/card";
 
 export default function HistoryPage() {
   return (
     <div className="space-y-8">
       {/* Header Section */}
       <div className="flex flex-col gap-2">
-        <h1 className="text-3xl font-bold tracking-tight text-white">Batch Payment History</h1>
-        <p className="text-gray-400">Search and filter your past batch payment operations</p>
+        <h1 className="text-3xl font-bold tracking-tight text-white">
+          Batch Payment History
+        </h1>
+        <p className="text-gray-400">
+          Review past batch transactions, track payment statuses, and access
+          detailed reports.
+        </p>
       </div>
+
+      {/* Metrics Grid */}
+      <MetricsGrid />
 
       {/* Filter Bar */}
       <Card className="border-[#1F2937] bg-[#121827] shadow-lg">
@@ -27,10 +36,10 @@ export default function HistoryPage() {
         <CardContent className="p-0 sm:p-6">
           <HistoryTable />
           <div className="px-4 pb-4 sm:px-0 sm:pb-0">
-             <Pagination />
+            <Pagination />
           </div>
         </CardContent>
       </Card>
     </div>
-  )
+  );
 }

--- a/components/dashboard/MetricCard.tsx
+++ b/components/dashboard/MetricCard.tsx
@@ -1,0 +1,34 @@
+import { LucideIcon } from "lucide-react";
+import { Card } from "@/components/ui/card";
+
+interface MetricCardProps {
+  icon: LucideIcon;
+  title: string;
+  value: string | number;
+  iconBgColor?: string;
+  iconColor?: string;
+}
+
+export function MetricCard({
+  icon: Icon,
+  title,
+  value,
+  iconBgColor = "bg-emerald-500/10",
+  iconColor = "text-emerald-500",
+}: MetricCardProps) {
+  return (
+    <Card className="bg-slate-900/50 border-slate-800 p-6">
+      <div className="flex flex-col gap-4">
+        <div
+          className={`w-12 h-12 rounded-lg ${iconBgColor} flex items-center justify-center`}
+        >
+          <Icon className={`w-6 h-6 ${iconColor}`} />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-slate-400">{title}</p>
+          <p className="text-3xl font-bold text-white">{value}</p>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/dashboard/MetricsGrid.tsx
+++ b/components/dashboard/MetricsGrid.tsx
@@ -1,0 +1,55 @@
+import { Layers, Send, CheckCircle2, Coins } from "lucide-react";
+import { MetricCard } from "./MetricCard";
+
+interface MetricsData {
+  totalBatches: number;
+  totalPayments: number;
+  successRate: string;
+  totalVolume: string;
+}
+
+interface MetricsGridProps {
+  data?: MetricsData;
+}
+
+export function MetricsGrid({ data }: MetricsGridProps) {
+  const metrics = data || {
+    totalBatches: 247,
+    totalPayments: 12458,
+    successRate: "98.7%",
+    totalVolume: "2.4M XLM",
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <MetricCard
+        icon={Layers}
+        title="Total Batches"
+        value={metrics.totalBatches}
+        iconBgColor="bg-emerald-500/10"
+        iconColor="text-emerald-500"
+      />
+      <MetricCard
+        icon={Send}
+        title="Total Payments"
+        value={metrics.totalPayments.toLocaleString()}
+        iconBgColor="bg-emerald-500/10"
+        iconColor="text-emerald-500"
+      />
+      <MetricCard
+        icon={CheckCircle2}
+        title="Success Rate"
+        value={metrics.successRate}
+        iconBgColor="bg-emerald-500/10"
+        iconColor="text-emerald-500"
+      />
+      <MetricCard
+        icon={Coins}
+        title="Total Volume"
+        value={metrics.totalVolume}
+        iconBgColor="bg-emerald-500/10"
+        iconColor="text-emerald-500"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION

Implemented a horizontal metrics grid component displaying key batch payment statistics on the history page.

## Changes Made

### New Components

- **`MetricCard.tsx`** - Reusable metric card component with icon, title, and value display
- **`MetricsGrid.tsx`** - Grid layout component containing four metric cards

### Updated Pages

- **`app/dashboard/history/page.tsx`** - Integrated MetricsGrid component between header and filter bar

## Features

The metrics grid displays:

- **Total Batches** - Total number of batch payments processed
- **Total Payments** - Aggregate count of individual payments
- **Success Rate** - Percentage of successful transactions
- **Total Volume** - Total XLM volume processed

## Design Details

- Consistent emerald accent colors across all cards
- Dark theme styling matching existing UI
- Responsive grid layout (1 col mobile, 2 col tablet, 4 col desktop)
- Icon containers with background styling
- Large, bold value typography
- Proper spacing and alignment


<img width="1861" height="660" alt="image" src="https://github.com/user-attachments/assets/aefb1080-96c7-4df7-ade0-9a6a5a8325ff" />


closes #59