### PR TITLE
feat: add contract version query function

### DIFF
--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec};
 
 #[contract]
 pub struct BatchVestingContract;
@@ -246,6 +246,11 @@ impl BatchVestingContract {
             &caller,
             &total_revoked,
         );
+    }
+
+    /// Return the contract version string.
+    pub fn version(env: Env) -> String {
+        String::from_str(&env, "1.0.0")
     }
 
     /// Claim the vested funds.

--- a/contracts/batch-vesting/src/test.rs
+++ b/contracts/batch-vesting/src/test.rs
@@ -3,7 +3,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
-    token, Address, Env, IntoVal, Symbol, Vec,
+    token, Address, Env, IntoVal, String, Symbol, Vec,
 };
 use token::Client as TokenClient;
 use token::StellarAssetClient as TokenAdminClient;
@@ -17,6 +17,14 @@ fn create_token_contract<'a>(
         TokenClient::new(env, &contract_id),
         TokenAdminClient::new(env, &contract_id),
     )
+}
+
+#[test]
+fn test_version() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+    assert_eq!(client.version(), String::from_str(&env, "1.0.0"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds `pub fn version(env: Env) -> String` to `BatchVestingContract` returning `"1.0.0"`
- Minimal implementation as specified — hardcoded version string, no extra complexity

## Test plan
- [x] New `test_version()` test verifying return value equals `"1.0.0"`
- [x] All 20 cargo tests pass

Closes #161