### PR TITLE
fix: handle BigInt serialization in API responses

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -17,6 +17,7 @@ import {
   Memo,
   StrKey,
 } from "stellar-sdk";
+import { safeJsonResponse } from "@/lib/safe-json";
 
 import { createBatches, parseAsset } from "@/lib/stellar/batcher";
 import {
@@ -134,7 +135,7 @@ export async function POST(request: NextRequest) {
       sourceAccount.incrementSequenceNumber();
     }
 
-    return NextResponse.json({
+    return safeJsonResponse({
       xdrs,
       batchCount: batches.length,
       network,
@@ -142,12 +143,12 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     console.error("Batch build error:", error);
-    return NextResponse.json(
+    return safeJsonResponse(
       {
         error:
           error instanceof Error ? error.message : "Internal server error",
       },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/api/batch-status/[jobId]/route.ts
+++ b/app/api/batch-status/[jobId]/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getJob } from "@/lib/job-store";
+import { safeJsonResponse } from "@/lib/safe-json";
 
 interface RouteParams {
   params: Promise<{ jobId: string }>;
@@ -33,8 +34,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     );
   }
 
-  // Return a safe, minimal response — no need to echo back the full payments array
-  return NextResponse.json({
+  // Return a safe, minimal response — no need to echo back the full payments array.
+  // Use safeJsonResponse to handle any BigInt values from Stellar SDK results.
+  return safeJsonResponse({
     jobId: job.jobId,
     status: job.status,
     totalBatches: job.totalBatches,

--- a/app/api/batch-submit-signed/route.ts
+++ b/app/api/batch-submit-signed/route.ts
@@ -9,6 +9,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { TransactionBuilder, Horizon, Networks } from "stellar-sdk";
+import { safeJsonResponse } from "@/lib/safe-json";
 
 interface RequestBody {
     signedXdr: string;
@@ -54,7 +55,7 @@ export async function POST(request: NextRequest) {
 
         const result = await server.submitTransaction(transaction);
 
-        return NextResponse.json({
+        return safeJsonResponse({
             success: true,
             hash: result.hash,
             ledger: result.ledger,
@@ -69,7 +70,7 @@ export async function POST(request: NextRequest) {
                     .response?.data?.extras?.result_codes
                 : undefined;
 
-        return NextResponse.json(
+        return safeJsonResponse(
             {
                 success: false,
                 error:

--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { validatePaymentInstructions } from "@/lib/stellar";
+import { safeJsonResponse } from "@/lib/safe-json";
 import { createJob } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
 import type { PaymentInstruction } from "@/lib/stellar/types";
@@ -65,7 +66,7 @@ export async function POST(request: NextRequest) {
     void processJobInBackground(jobId, payments, network, secretKey);
 
     // Return 202 Accepted with the job ID for polling
-    return NextResponse.json(
+    return safeJsonResponse(
       {
         jobId,
         status: "queued",
@@ -79,7 +80,7 @@ export async function POST(request: NextRequest) {
     );
   } catch (error) {
     console.error("Batch submission error:", error);
-    return NextResponse.json(
+    return safeJsonResponse(
       {
         error: error instanceof Error ? error.message : "Internal server error",
       },

--- a/lib/safe-json.ts
+++ b/lib/safe-json.ts
@@ -1,0 +1,38 @@
+/**
+ * JSON serialization helper that safely converts BigInt values to strings.
+ *
+ * Next.js API routes use JSON.stringify internally, which throws a TypeError
+ * when the payload contains BigInt values (common in Stellar SDK responses).
+ * This module provides a drop-in NextResponse.json replacement that handles
+ * BigInt serialization transparently.
+ */
+
+import { NextResponse } from "next/server";
+
+/**
+ * JSON replacer that converts BigInt values to strings.
+ */
+function bigIntReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+/**
+ * Drop-in replacement for NextResponse.json() that safely handles BigInt.
+ *
+ * Usage:
+ *   return safeJsonResponse({ ledger: 123n, hash: "abc" });
+ *   return safeJsonResponse({ error: "..." }, { status: 400 });
+ */
+export function safeJsonResponse(
+  data: unknown,
+  init?: ResponseInit,
+): NextResponse {
+  const body = JSON.stringify(data, bigIntReplacer);
+  return new NextResponse(body, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
+}

--- a/tests/safe-json.test.ts
+++ b/tests/safe-json.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Test suite for BigInt-safe JSON serialization
+ */
+
+import { describe, test, expect } from "vitest";
+
+// Test the BigInt replacer logic directly since safeJsonResponse depends on Next.js
+function bigIntReplacer(_key: string, value: unknown): unknown {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+function safeStringify(data: unknown): string {
+  return JSON.stringify(data, bigIntReplacer);
+}
+
+describe("BigInt-safe JSON serialization", () => {
+  test("converts BigInt to string", () => {
+    const data = { ledger: BigInt(123456) };
+    const result = safeStringify(data);
+    expect(result).toBe('{"ledger":"123456"}');
+  });
+
+  test("handles nested BigInt values", () => {
+    const data = {
+      result: {
+        ledger: BigInt(999),
+        sequence: BigInt("18446744073709551615"),
+      },
+    };
+    const result = JSON.parse(safeStringify(data));
+    expect(result.result.ledger).toBe("999");
+    expect(result.result.sequence).toBe("18446744073709551615");
+  });
+
+  test("preserves non-BigInt values", () => {
+    const data = {
+      hash: "abc123",
+      success: true,
+      count: 42,
+      items: [1, 2, 3],
+      nested: { key: "value" },
+      empty: null,
+    };
+    const result = JSON.parse(safeStringify(data));
+    expect(result).toEqual(data);
+  });
+
+  test("handles mixed BigInt and regular values", () => {
+    const data = {
+      hash: "abc",
+      ledger: BigInt(100),
+      success: true,
+    };
+    const result = JSON.parse(safeStringify(data));
+    expect(result.hash).toBe("abc");
+    expect(result.ledger).toBe("100");
+    expect(result.success).toBe(true);
+  });
+
+  test("handles BigInt in arrays", () => {
+    const data = { values: [BigInt(1), BigInt(2), BigInt(3)] };
+    const result = JSON.parse(safeStringify(data));
+    expect(result.values).toEqual(["1", "2", "3"]);
+  });
+
+  test("does not throw on BigInt values", () => {
+    const data = { value: BigInt(123) };
+    expect(() => safeStringify(data)).not.toThrow();
+  });
+
+  test("regular JSON.stringify throws on BigInt", () => {
+    const data = { value: BigInt(123) };
+    expect(() => JSON.stringify(data)).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `safeJsonResponse` helper in `lib/safe-json.ts` that converts BigInt values to strings before JSON serialization
- Replace `NextResponse.json()` with `safeJsonResponse()` in all API routes that return Stellar SDK data (`batch-build`, `batch-submit`, `batch-submit-signed`, `batch-status`)
- Add tests verifying BigInt serialization (nested, arrays, mixed types) and confirming standard `JSON.stringify` throws on BigInt

## Test plan

- [x] All 81 tests pass via `bun test`
- [ ] Submit a signed transaction and verify no serialization error in the response
- [ ] Poll batch-status after a batch job completes and verify no serialization error

Closes #158