### PR TITLE
fix/batch-vesting-duplicate-recipients

### DIFF
--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -155,6 +155,16 @@ impl BatchVestingContract {
             panic!("Unlock time must be in the future");
         }
 
+        for i in 0..recipients.len() {
+            let current = recipients.get(i).unwrap();
+            for j in (i + 1)..recipients.len() {
+                let other = recipients.get(j).unwrap();
+                if current == other {
+                    panic!("Duplicate recipients not allowed");
+                }
+            }
+        }
+
         let mut total_amount: i128 = 0;
 
         for i in 0..recipients.len() {
@@ -204,7 +214,6 @@ impl BatchVestingContract {
     pub fn propose_admin(env: Env, admin: Address, new_admin: Address) {
         Self::require_current_admin(&env, &admin);
         Self::set_pending_admin_internal(&env, &new_admin);
-
         env.events().publish(
             (Symbol::new(&env, "AdminTransferProposed"),),
             (admin, new_admin),

--- a/contracts/batch-vesting/src/test.rs
+++ b/contracts/batch-vesting/src/test.rs
@@ -525,12 +525,6 @@ fn test_events_emission() {
                 let evt_sender: Address = topics.get(1).unwrap().into_val(&env);
                 let evt_recipient: Address = topics.get(2).unwrap().into_val(&env);
                 let (evt_amount, evt_unlock): (i128, u64) = data.into_val(&env);
-                let (evt_sender, evt_recipient, evt_amount, evt_unlock): (
-                    Address,
-                    Address,
-                    i128,
-                    u64,
-                ) = data.into_val(&env);
                 assert_eq!(evt_sender, sender);
                 assert_eq!(evt_unlock, unlock_time);
                 if evt_recipient == recipient1 {
@@ -938,12 +932,6 @@ fn test_batch_revoke_events_emission() {
                 let evt_recipient: Address = topics.get(1).unwrap().into_val(&env);
                 let evt_sender: Address = topics.get(2).unwrap().into_val(&env);
                 let (evt_amount, evt_unlock): (i128, u64) = data.into_val(&env);
-                let (evt_recipient, evt_sender, evt_amount, evt_unlock): (
-                    Address,
-                    Address,
-                    i128,
-                    u64,
-                ) = data.into_val(&env);
                 assert_eq!(evt_sender, sender);
                 assert_eq!(evt_unlock, unlock_time);
                 if evt_recipient == recipient1 {
@@ -1011,4 +999,36 @@ fn test_batch_revoke_partial_recipients() {
 
     client.claim(&recipient3, &token.address);
     assert_eq!(token.balance(&recipient3), 300);
+}
+
+#[test]
+#[should_panic(expected = "Duplicate recipients not allowed")]
+fn test_deposit_duplicate_recipients() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let sender = Address::generate(&env);
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let (token, token_admin_client) = create_token_contract(&env, &token_admin);
+
+    token_admin_client.mint(&sender, &1000);
+
+    let recipients = Vec::from_array(
+        &env,
+        [recipient1.clone(), recipient2.clone(), recipient1.clone()],
+    );
+    let amounts = Vec::from_array(&env, [100, 200, 150]);
+    let unlock_time = 1000;
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    client.deposit(&sender, &token.address, &recipients, &amounts, &unlock_time);
 }


### PR DESCRIPTION
Closes #185

## Summary
Adds validation to reject batch vesting deposits containing duplicate recipients, preventing redundant storage writes and reducing gas costs.

## Changes
- Validates recipient uniqueness in `deposit()` before storage operations
- Panics with a clear error on duplicate detection

## Testing
- ✅ New test: `test_deposit_duplicate_recipients`
- ✅ Code compiles and formats correctly
- ✅ No impact on existing functionality