### PR TITLE
fix(batch-vesting): add safe admin ownership transfer (#177)

### DIFF
--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     Vesting(Address, u32), // (recipient, index) — granular per-schedule key
     VestingCount(Address), // total number of schedules for a recipient
     Admin,
+    PendingAdmin,
     Paused,
 }
 
@@ -30,6 +31,32 @@ impl BatchVestingContract {
         env.storage().persistent().set(&DataKey::Admin, admin);
     }
 
+    fn remove_admin_internal(env: &Env) {
+        env.storage().persistent().remove(&DataKey::Admin);
+    }
+
+    fn get_pending_admin(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::PendingAdmin)
+    }
+
+    fn set_pending_admin_internal(env: &Env, admin: &Address) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, admin);
+    }
+
+    fn remove_pending_admin_internal(env: &Env) {
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+    }
+
+    fn require_current_admin(env: &Env, admin: &Address) {
+        admin.require_auth();
+        let stored_admin = Self::get_admin(env).expect("Admin must be set");
+        if admin != &stored_admin {
+            panic!("Only admin can perform this action");
+        }
+    }
+
     fn is_authorized(env: &Env, caller: &Address, schedule_sender: &Address) -> bool {
         let is_sender = caller == schedule_sender;
         let is_admin = match Self::get_admin(env) {
@@ -40,7 +67,10 @@ impl BatchVestingContract {
     }
 
     fn is_paused(env: &Env) -> bool {
-        env.storage().persistent().get(&DataKey::Paused).unwrap_or(false)
+        env.storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
     }
 
     fn panic_if_paused(env: &Env) {
@@ -166,29 +196,56 @@ impl BatchVestingContract {
         Self::set_admin_internal(&env, &admin);
     }
 
-    /// Toggle contract pause state. Only admin can toggle pause.
-    pub fn toggle_pause(env: Env, admin: Address, paused: bool) {
-        admin.require_auth();
-        let stored_admin = Self::get_admin(&env).expect("Admin must be set to toggle pause");
-        if admin != stored_admin {
-            panic!("Only admin can toggle pause");
-        }
-        env.storage().persistent().set(&DataKey::Paused, &paused);
+    /// Propose a new admin. Only the current admin can nominate a successor.
+    pub fn propose_admin(env: Env, admin: Address, new_admin: Address) {
+        Self::require_current_admin(&env, &admin);
+        Self::set_pending_admin_internal(&env, &new_admin);
 
         env.events().publish(
-            (Symbol::new(&env, "PauseToggled"),),
-            (admin, paused),
+            (Symbol::new(&env, "AdminTransferProposed"),),
+            (admin, new_admin),
         );
     }
 
+    /// Accept a pending admin transfer.
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        let pending_admin = Self::get_pending_admin(&env).expect("No admin transfer proposed");
+        if new_admin != pending_admin {
+            panic!("Only pending admin can accept transfer");
+        }
+
+        let previous_admin = Self::get_admin(&env).expect("Admin must be set");
+        Self::set_admin_internal(&env, &new_admin);
+        Self::remove_pending_admin_internal(&env);
+
+        env.events().publish(
+            (Symbol::new(&env, "AdminTransferred"),),
+            (previous_admin, new_admin),
+        );
+    }
+
+    /// Renounce admin rights and clear any in-flight transfer.
+    pub fn renounce_admin(env: Env, admin: Address) {
+        Self::require_current_admin(&env, &admin);
+        Self::remove_admin_internal(&env);
+        Self::remove_pending_admin_internal(&env);
+
+        env.events()
+            .publish((Symbol::new(&env, "AdminRenounced"),), admin);
+    }
+
+    /// Toggle contract pause state. Only admin can toggle pause.
+    pub fn toggle_pause(env: Env, admin: Address, paused: bool) {
+        Self::require_current_admin(&env, &admin);
+        env.storage().persistent().set(&DataKey::Paused, &paused);
+
+        env.events()
+            .publish((Symbol::new(&env, "PauseToggled"),), (admin, paused));
+    }
+
     /// Revoke unvested schedule by recipient/unlock time.
-    pub fn revoke(
-        env: Env,
-        caller: Address,
-        recipient: Address,
-        token: Address,
-        unlock_time: u64,
-    ) {
+    pub fn revoke(env: Env, caller: Address, recipient: Address, token: Address, unlock_time: u64) {
         Self::panic_if_paused(&env);
         caller.require_auth();
 
@@ -339,7 +396,11 @@ impl BatchVestingContract {
         }
 
         let token_client = token::Client::new(&env, &token);
-        token_client.transfer(&env.current_contract_address(), &recipient, &amount_to_transfer);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &recipient,
+            &amount_to_transfer,
+        );
 
         env.events().publish(
             (Symbol::new(&env, "VestingClaimed"),),

--- a/contracts/batch-vesting/src/test.rs
+++ b/contracts/batch-vesting/src/test.rs
@@ -176,6 +176,92 @@ fn test_revoke_by_admin() {
 }
 
 #[test]
+fn test_admin_transfer_requires_explicit_acceptance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pending_admin = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.propose_admin(&admin, &pending_admin);
+
+    client.toggle_pause(&admin, &true);
+    client.accept_admin(&pending_admin);
+    client.toggle_pause(&pending_admin, &false);
+}
+
+#[test]
+#[should_panic(expected = "Only admin can perform this action")]
+fn test_only_current_admin_can_propose_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let pending_admin = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.propose_admin(&attacker, &pending_admin);
+}
+
+#[test]
+#[should_panic(expected = "Only pending admin can accept transfer")]
+fn test_only_pending_admin_can_accept_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pending_admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.propose_admin(&admin, &pending_admin);
+    client.accept_admin(&attacker);
+}
+
+#[test]
+fn test_admin_can_renounce() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pending_admin = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.propose_admin(&admin, &pending_admin);
+    client.renounce_admin(&admin);
+}
+
+#[test]
+#[should_panic(expected = "Admin must be set")]
+fn test_renounced_admin_loses_privileges() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.renounce_admin(&admin);
+    client.toggle_pause(&admin, &true);
+}
+
+#[test]
 #[should_panic(expected = "Unauthorized revoke attempt")]
 fn test_revoke_unauthorized() {
     let env = Env::default();
@@ -360,7 +446,12 @@ fn test_events_emission() {
         if contract == contract_id && topics.len() == 1 {
             let topic: Symbol = topics.get(0).unwrap().into_val(&env);
             if topic == deposit_symbol {
-                let (evt_sender, evt_recipient, evt_amount, evt_unlock): (Address, Address, i128, u64) = data.into_val(&env);
+                let (evt_sender, evt_recipient, evt_amount, evt_unlock): (
+                    Address,
+                    Address,
+                    i128,
+                    u64,
+                ) = data.into_val(&env);
                 assert_eq!(evt_sender, sender);
                 assert_eq!(evt_unlock, unlock_time);
                 if evt_recipient == recipient1 {
@@ -373,7 +464,10 @@ fn test_events_emission() {
             }
         }
     }
-    assert_eq!(deposit_found, 2, "Should find 2 deposit events with correct data");
+    assert_eq!(
+        deposit_found, 2,
+        "Should find 2 deposit events with correct data"
+    );
 
     // Advance time and claim 1
     env.ledger().with_mut(|li| {
@@ -498,7 +592,10 @@ fn test_batch_revoke_by_sender() {
     let (token, token_admin_client) = create_token_contract(&env, &token_admin);
     token_admin_client.mint(&sender, &1000);
 
-    let recipients = Vec::from_array(&env, [recipient1.clone(), recipient2.clone(), recipient3.clone()]);
+    let recipients = Vec::from_array(
+        &env,
+        [recipient1.clone(), recipient2.clone(), recipient3.clone()],
+    );
     let amounts = Vec::from_array(&env, [100, 200, 300]);
     let unlock_time = 1000;
 
@@ -577,7 +674,7 @@ fn test_batch_revoke_multiple_senders() {
 
     let token_admin = Address::generate(&env);
     let (token, token_admin_client) = create_token_contract(&env, &token_admin);
-    
+
     token_admin_client.mint(&sender1, &1000);
     token_admin_client.mint(&sender2, &1000);
 
@@ -757,7 +854,12 @@ fn test_batch_revoke_events_emission() {
         if contract == contract_id && topics.len() == 1 {
             let topic: Symbol = topics.get(0).unwrap().into_val(&env);
             if topic == revoke_symbol {
-                let (evt_recipient, evt_sender, evt_amount, evt_unlock): (Address, Address, i128, u64) = data.into_val(&env);
+                let (evt_recipient, evt_sender, evt_amount, evt_unlock): (
+                    Address,
+                    Address,
+                    i128,
+                    u64,
+                ) = data.into_val(&env);
                 assert_eq!(evt_sender, sender);
                 assert_eq!(evt_unlock, unlock_time);
                 if evt_recipient == recipient1 {
@@ -770,7 +872,10 @@ fn test_batch_revoke_events_emission() {
             }
         }
     }
-    assert_eq!(revoke_found, 2, "Should find 2 revoke events with correct data");
+    assert_eq!(
+        revoke_found, 2,
+        "Should find 2 revoke events with correct data"
+    );
 }
 
 #[test]
@@ -790,7 +895,10 @@ fn test_batch_revoke_partial_recipients() {
     let (token, token_admin_client) = create_token_contract(&env, &token_admin);
     token_admin_client.mint(&sender, &1000);
 
-    let recipients = Vec::from_array(&env, [recipient1.clone(), recipient2.clone(), recipient3.clone()]);
+    let recipients = Vec::from_array(
+        &env,
+        [recipient1.clone(), recipient2.clone(), recipient3.clone()],
+    );
     let amounts = Vec::from_array(&env, [100, 200, 300]);
     let unlock_time = 1000;
 


### PR DESCRIPTION
Closes #177

Changes
add propose_admin so only the current admin can nominate a new admin
add accept_admin so the nominated admin must explicitly accept ownership
add renounce_admin so the current admin can clear contract-level ownership
store a PendingAdmin during handoff and clear it on accept or renounce
reuse a shared admin authorization check for admin-only actions like toggle_pause
add tests covering successful transfer, unauthorized proposal, unauthorized acceptance, and renounce behavior
Testing
cargo fmt -p batch-vesting
cargo test -p batch-vesting (blocked locally: missing MSVC linker link.exe on this machine)