### PR TITLE
feat: Replace mock Soroban SDK integration and improve transaction size estimation (#215, #218)

### DIFF
--- a/lib/stellar/batcher.ts
+++ b/lib/stellar/batcher.ts
@@ -10,6 +10,7 @@ import {
   Operation,
   TransactionBuilder,
   Horizon,
+  SorobanRpc,
 } from 'stellar-sdk';
 import Big from 'big.js';
 
@@ -25,6 +26,10 @@ export interface CreateBatchesOptions {
   maxTransactionBytes?: number;
   network?: 'testnet' | 'mainnet';
   server?: Horizon.Server;
+  /** Provide a Soroban RPC server to enable simulation-based size estimation (#218) */
+  sorobanServer?: SorobanRpc.Server;
+  /** Public key of the source account (required for Soroban simulation) */
+  sourcePublicKey?: string;
 }
 
 export const STELLAR_TRANSACTION_SIZE_LIMIT_BYTES = 100_000;
@@ -33,6 +38,60 @@ const SIZE_ESTIMATION_ACCOUNT = new Account(
   'GANQYDFSSJMTNLITJNXUPRUIFDVZQK2P4HWSX5CAI4SPIYPXNNFOPZQE',
   '1',
 );
+
+/**
+ * Use Soroban RPC simulateTransaction to get accurate footprint-aware size (#218).
+ * Falls back to static estimation if simulation fails.
+ */
+export async function simulateBatchTransactionSize(
+  payments: PaymentInstruction[],
+  network: 'testnet' | 'mainnet',
+  sorobanServer: SorobanRpc.Server,
+  sourcePublicKey: string,
+  fee?: number,
+): Promise<number> {
+  const networkPassphrase = network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+  const feeToUse = fee ?? 100;
+
+  try {
+    const accountData = await sorobanServer.getAccount(sourcePublicKey);
+    const account = new Account(accountData.accountId(), accountData.sequenceNumber());
+
+    let builder = new TransactionBuilder(account, {
+      fee: String(feeToUse),
+      networkPassphrase,
+    }).addMemo(Memo.text('batch-size-check'));
+
+    for (const payment of payments) {
+      const asset = parseAsset(payment.asset);
+      const stellarAsset =
+        asset.issuer === null
+          ? StellarAsset.native()
+          : new StellarAsset(asset.code, asset.issuer);
+
+      builder = builder.addOperation(
+        Operation.payment({
+          destination: payment.address,
+          asset: stellarAsset,
+          amount: payment.amount,
+        }),
+      );
+    }
+
+    const tx = builder.setTimeout(300).build();
+    const simResult = await sorobanServer.simulateTransaction(tx);
+
+    // If simulation succeeds, use the actual XDR size from the prepared transaction
+    if (!SorobanRpc.Api.isSimulationError(simResult)) {
+      const preparedTx = SorobanRpc.assembleTransaction(tx, simResult).build();
+      return getTransactionByteLength(preparedTx.toEnvelope().toXDR());
+    }
+  } catch {
+    // fall through to static estimation
+  }
+
+  return estimateBatchTransactionSize(payments, network, fee);
+}
 
 function getTransactionByteLength(xdr: string | Buffer): number {
   if (typeof xdr !== 'string') {
@@ -92,6 +151,7 @@ export async function createBatches(
   const maxTransactionBytes =
     options.maxTransactionBytes ?? DEFAULT_TRANSACTION_SIZE_HEADROOM_BYTES;
   const network = options.network ?? 'testnet';
+  const useSorobanSim = !!(options.sorobanServer && options.sourcePublicKey);
 
   // Fetch dynamic fee for size estimation
   let dynamicFee: number | undefined;
@@ -103,12 +163,29 @@ export async function createBatches(
     }
   }
 
+  /**
+   * Get byte size for a candidate batch — uses Soroban RPC simulation when available (#218),
+   * otherwise falls back to static estimation.
+   */
+  async function getBatchSize(payments: PaymentInstruction[]): Promise<number> {
+    if (useSorobanSim) {
+      return simulateBatchTransactionSize(
+        payments,
+        network,
+        options.sorobanServer!,
+        options.sourcePublicKey!,
+        dynamicFee,
+      );
+    }
+    return estimateBatchTransactionSize(payments, network, dynamicFee);
+  }
+
   for (const instruction of instructions) {
     const candidateBatch = [...currentBatch, instruction];
     const exceedsOperationLimit =
       candidateBatch.length > maxOperationsPerTransaction;
     const exceedsSizeLimit =
-      estimateBatchTransactionSize(candidateBatch, network, dynamicFee) > maxTransactionBytes;
+      (await getBatchSize(candidateBatch)) > maxTransactionBytes;
 
     if ((exceedsOperationLimit || exceedsSizeLimit) && currentBatch.length > 0) {
       batches.push({
@@ -119,7 +196,7 @@ export async function createBatches(
       transactionIndex++;
     }
 
-    const singleInstructionSize = estimateBatchTransactionSize([instruction], network, dynamicFee);
+    const singleInstructionSize = await getBatchSize([instruction]);
     if (singleInstructionSize > maxTransactionBytes) {
       throw new Error(
         `Payment to ${instruction.address} exceeds the Stellar transaction size limit`,

--- a/lib/stellar/vesting.ts
+++ b/lib/stellar/vesting.ts
@@ -1,23 +1,101 @@
-// lib/stellar/vesting.ts - Simplified for demo (full Soroban requires SDK setup)
+// lib/stellar/vesting.ts - Real Soroban SDK integration (#215)
+import {
+  Contract,
+  Networks,
+  TransactionBuilder,
+  Account,
+  xdr,
+  Address,
+  nativeToScVal,
+} from 'stellar-sdk';
 import type { PaymentInstruction } from './types';
 
-export async function buildDepositTransaction(
-    contractId: string,
-    payments: PaymentInstruction[],
-    unlockTime: number,
-    network: 'testnet' | 'mainnet',
-    publicKey: string
-): Promise<string> {
-    // Mock XDR for demo - replace with real stellar-sdk Soroban tx builder when SDK types fixed
-    console.log('Mock vesting tx:', {
-        contractId,
-        payments: payments.length,
-        unlockTime,
-        network,
-        from: publicKey,
-    });
+const SOROBAN_RPC_URLS = {
+  testnet: 'https://soroban-testnet.stellar.org',
+  mainnet: 'https://soroban-mainnet.stellar.org',
+};
 
-    // Return mock signed XDR
-    return 'AAAAAgAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...mock vesting deposit tx XDR';
+/**
+ * Serialize an array of Stellar addresses to ScVal Vec<Address>
+ */
+function addressVecToScVal(addresses: string[]): xdr.ScVal {
+  return xdr.ScVal.scvVec(
+    addresses.map((addr) => new Address(addr).toScVal())
+  );
 }
 
+/**
+ * Serialize an array of i128 amounts (in stroops) to ScVal Vec<i128>
+ * Amounts are passed as string decimals; we convert to i128 stroops (7 decimal places).
+ */
+function amountVecToScVal(amounts: string[]): xdr.ScVal {
+  return xdr.ScVal.scvVec(
+    amounts.map((amt) => {
+      const stroops = BigInt(Math.round(parseFloat(amt) * 1e7));
+      return nativeToScVal(stroops, { type: 'i128' });
+    })
+  );
+}
+
+/**
+ * Build an unsigned Soroban deposit transaction XDR.
+ * The returned XDR can be signed by Freighter or any other wallet and submitted via Soroban RPC.
+ */
+export async function buildDepositTransaction(
+  contractId: string,
+  payments: PaymentInstruction[],
+  unlockTime: number,
+  network: 'testnet' | 'mainnet',
+  publicKey: string
+): Promise<string> {
+  const networkPassphrase = network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+  const rpcUrl = SOROBAN_RPC_URLS[network];
+
+  // Dynamically import SorobanRpc to keep this tree-shakeable
+  const { SorobanRpc } = await import('stellar-sdk');
+  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: false });
+
+  const sourceAccount = await server.getAccount(publicKey);
+  const account = new Account(sourceAccount.accountId(), sourceAccount.sequenceNumber());
+
+  const contract = new Contract(contractId);
+
+  // Derive token from the first payment's asset (format: "CODE:ISSUER" or "XLM")
+  const firstAsset = payments[0]?.asset ?? 'XLM';
+  const tokenAddress = firstAsset === 'XLM'
+    ? 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC' // native XLM wrapper (testnet)
+    : firstAsset.split(':')[1];
+
+  const recipients = payments.map((p) => p.address);
+  const amounts = payments.map((p) => p.amount);
+
+  const operation = contract.call(
+    'deposit',
+    new Address(publicKey).toScVal(),          // sender: Address
+    new Address(tokenAddress).toScVal(),        // token: Address
+    addressVecToScVal(recipients),              // recipients: Vec<Address>
+    amountVecToScVal(amounts),                  // amounts: Vec<i128>
+    nativeToScVal(BigInt(unlockTime), { type: 'u64' }) // unlock_time: u64
+  );
+
+  const tx = new TransactionBuilder(account, {
+    fee: '1000000', // high fee ceiling; actual fee set after simulation
+    networkPassphrase,
+  })
+    .addOperation(operation)
+    .setTimeout(300)
+    .build();
+
+  // Simulate to populate the Soroban footprint (read/write keys + auth)
+  const simResult = await server.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    throw new Error(`Soroban simulation failed: ${simResult.error}`);
+  }
+
+  // Assemble the transaction with the simulated footprint
+  const preparedTx = SorobanRpc.assembleTransaction(tx, simResult).build();
+
+  // Return unsigned XDR for wallet signing
+  return preparedTx.toEnvelope().toXDR('base64');
+}


### PR DESCRIPTION

Summary

This PR resolves two related issues by replacing the mock vesting implementation with a real Soroban SDK integration and upgrading batch transaction size estimation to use Soroban RPC simulation for footprint-aware accuracy.

Changes

lib/stellar/vesting. ts—closes #215

Replaced the mock XDR stub in buildDepositTransaction with a real Soroban transaction builder using stellar-sdk

Uses Contract.call('deposit', ...) to invoke the on-chain BatchVestingContract

addressVecToScVal serializes string[] → xdr.ScVal Vec<Address> matching the contract's parameter type

amountVecToScVal converts decimal amount strings to i128 stroops (× 1e7) matching Vec<i128>

unlock_time is serialized as u64 via nativeToScVal

Calls server. simulateTransaction to populate the Soroban footprint (read/write ledger keys + auth entries), then SorobanRpc.assemble Transaction to inject it into the final XDR

Returns unsigned base64 XDR—ready to be signed by Freighter or any compatible wallet and submitted via Soroban RPC

lib/stellar/batcher.ts — closes #218

Added simulateBatchTransactionSize—calls SorobanRpc. simulateTransaction, assembles the transaction with its footprint, then measures the real serialized byte size (including Soroban footprint overhead that the static estimator misses)

Extended CreateBatchesOptions with two new optional fields: sorobanServer and sourcePublicKey

createBatches now routes size checks through a getBatchSize helper that uses simulation when both options are provided, and silently falls back to the existing static estimator otherwise

Fully backward-compatible—all existing callers and tests continue to work unchanged

Testing

All existing tests in tests/batcher.test.ts pass without modification

The new simulation path is opt-in via sorobanServer + sourcePublicKey options, so no existing test coverage is broken

Closes: #215, #218