### PR TITLE
fix: reentrancy guard, batch persistence, secret backends, transaction progress (#250-259)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -40,6 +40,60 @@ export NODE_ENV="production"
 vercel env add STELLAR_SECRET_KEY
 ```
 
+## Keeper Bot Secret Management (#257)
+
+The keeper bot (`scripts/keeper.ts`) reads `KEEPER_SECRET` from a pluggable
+backend configured by `SECRET_BACKEND`.
+
+### Backend: `env` (local development only)
+
+```bash
+export SECRET_BACKEND=env
+export KEEPER_SECRET="S..."   # .env or shell — never commit
+npx ts-node scripts/keeper.ts
+```
+
+A warning is printed at startup when using this backend in non-development
+environments.
+
+### Backend: `aws` (recommended for production)
+
+1. Store the keeper secret in AWS Secrets Manager:
+   ```bash
+   aws secretsmanager create-secret \
+     --name KEEPER_SECRET \
+     --secret-string '{"KEEPER_SECRET":"S..."}'
+   ```
+2. Attach an IAM policy granting `secretsmanager:GetSecretValue` to the role
+   running the keeper bot.
+3. Set environment variables:
+   ```bash
+   export SECRET_BACKEND=aws
+   export AWS_REGION=us-east-1
+   # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY or use instance/task role
+   ```
+
+### Backend: `github` (GitHub Actions CI/CD)
+
+1. Add `KEEPER_SECRET` in your repository:
+   **Settings → Secrets and variables → Actions → New repository secret**
+2. Reference in your workflow:
+   ```yaml
+   jobs:
+     keeper:
+       steps:
+         - name: Run keeper
+           env:
+             SECRET_BACKEND: github
+             KEEPER_SECRET: ${{ secrets.KEEPER_SECRET }}
+           run: npx ts-node scripts/keeper.ts
+   ```
+
+No secret is written to disk, logs, or intermediate environment files in the
+`aws` or `github` backends.
+
+---
+
 ## Smart Contract Deployment
 
 Follow these steps to deploy and initialize the Soroban smart contract.

--- a/components/resume-batch.tsx
+++ b/components/resume-batch.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * ResumeBatch — surface prior incomplete batches and let the user retry
+ * only the unconfirmed transactions (#255).
+ */
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  listBatches,
+  deleteBatch,
+  getPendingTransactions,
+  type PersistedBatch,
+} from "@/lib/batch-persistence";
+
+interface ResumeBatchProps {
+  /** Called when the user chooses to resume a specific batch. */
+  onResume: (batch: PersistedBatch) => void;
+}
+
+export function ResumeBatch({ onResume }: ResumeBatchProps) {
+  const [batches, setBatches] = useState<PersistedBatch[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    listBatches()
+      .then((all) => {
+        // Only show batches that still have unconfirmed transactions
+        setBatches(all.filter((b) => getPendingTransactions(b).length > 0));
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading || batches.length === 0) return null;
+
+  async function handleDiscard(jobId: string) {
+    await deleteBatch(jobId);
+    setBatches((prev) => prev.filter((b) => b.jobId !== jobId));
+  }
+
+  return (
+    <Card className="border-amber-500/40 bg-amber-500/5">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-amber-400 text-sm font-semibold">
+          <AlertTriangle className="size-4" />
+          Incomplete batch{batches.length > 1 ? "es" : ""} detected
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-slate-400">
+          A previous submission did not complete. Resuming will retry only the
+          transactions that were not confirmed — already-confirmed transactions
+          will be skipped.
+        </p>
+        {batches.map((batch) => {
+          const pending = getPendingTransactions(batch);
+          return (
+            <div
+              key={batch.jobId}
+              className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 px-3 py-2"
+            >
+              <div className="space-y-0.5">
+                <p className="text-xs font-medium text-white">
+                  {batch.network === "mainnet" ? "Mainnet" : "Testnet"} batch
+                </p>
+                <p className="text-[0.65rem] text-slate-500">
+                  {pending.length} of {batch.transactions.length} transaction
+                  {batch.transactions.length > 1 ? "s" : ""} pending ·{" "}
+                  {new Date(batch.createdAt).toLocaleString()}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7 border-white/10 text-xs"
+                  onClick={() => onResume(batch)}
+                >
+                  <RefreshCw className="mr-1 size-3" />
+                  Resume
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs text-slate-500 hover:text-red-400"
+                  onClick={() => handleDiscard(batch.jobId)}
+                >
+                  <Trash2 className="size-3" />
+                </Button>
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/transaction-progress.tsx
+++ b/components/transaction-progress.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+/**
+ * TransactionProgress — real-time progress visualizer for batch submission (#259).
+ *
+ * Tracks each stage of a multi-transaction batch:
+ *   Building → Signing → Submitting → Confirming
+ * and shows per-transaction progress (e.g. "Submitting transaction 3 of 7")
+ * with a link to the block explorer for the current hash.
+ */
+
+import { CheckCircle2, Circle, Loader2, XCircle, ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type BatchStage = "building" | "signing" | "submitting" | "confirming" | "done" | "error";
+
+export interface TransactionProgressProps {
+  stage: BatchStage;
+  /** Current 1-based transaction index (for multi-tx batches). */
+  currentTx?: number;
+  /** Total number of transactions in the batch. */
+  totalTx?: number;
+  /** Hash of the transaction currently being submitted / confirmed. */
+  currentHash?: string;
+  /** Human-readable error message when stage === "error". */
+  errorMessage?: string;
+  /** Stellar network for block explorer links. */
+  network?: "testnet" | "mainnet";
+  className?: string;
+}
+
+const STAGES: { key: BatchStage; label: string }[] = [
+  { key: "building", label: "Building" },
+  { key: "signing", label: "Signing" },
+  { key: "submitting", label: "Submitting" },
+  { key: "confirming", label: "Confirming" },
+];
+
+const STAGE_ORDER: Record<BatchStage, number> = {
+  building: 0,
+  signing: 1,
+  submitting: 2,
+  confirming: 3,
+  done: 4,
+  error: 4,
+};
+
+function explorerUrl(hash: string, network: "testnet" | "mainnet"): string {
+  const base =
+    network === "mainnet"
+      ? "https://stellar.expert/explorer/public/tx"
+      : "https://stellar.expert/explorer/testnet/tx";
+  return `${base}/${hash}`;
+}
+
+export function TransactionProgress({
+  stage,
+  currentTx,
+  totalTx,
+  currentHash,
+  errorMessage,
+  network = "testnet",
+  className,
+}: TransactionProgressProps) {
+  const currentStageOrder = STAGE_ORDER[stage];
+  const isError = stage === "error";
+  const isDone = stage === "done";
+
+  return (
+    <div className={cn("rounded-xl border border-white/10 bg-white/5 p-4 space-y-4", className)}>
+      {/* Stage stepper */}
+      <ol className="flex items-center gap-0">
+        {STAGES.map((s, i) => {
+          const order = STAGE_ORDER[s.key];
+          const isActive = s.key === stage;
+          const isComplete = !isError && currentStageOrder > order;
+          const isPending = !isError && currentStageOrder < order;
+
+          return (
+            <li key={s.key} className="flex flex-1 items-center">
+              <div className="flex flex-col items-center gap-1">
+                <span
+                  className={cn(
+                    "flex size-7 items-center justify-center rounded-full text-xs font-bold transition-colors",
+                    isActive && !isError
+                      ? "bg-emerald-500 text-white"
+                      : isComplete
+                        ? "bg-emerald-500/20 text-emerald-400"
+                        : isError && isActive
+                          ? "bg-red-500/20 text-red-400"
+                          : "bg-white/10 text-white/30",
+                  )}
+                >
+                  {isComplete ? (
+                    <CheckCircle2 className="size-4" />
+                  ) : isActive && !isError ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : isError && i === currentStageOrder ? (
+                    <XCircle className="size-4" />
+                  ) : (
+                    <Circle className="size-4" />
+                  )}
+                </span>
+                <span
+                  className={cn(
+                    "text-[0.6rem] font-semibold uppercase tracking-wider",
+                    isActive && !isError
+                      ? "text-emerald-400"
+                      : isComplete
+                        ? "text-emerald-400/60"
+                        : "text-white/30",
+                  )}
+                >
+                  {s.label}
+                </span>
+              </div>
+              {i < STAGES.length - 1 && (
+                <div
+                  className={cn(
+                    "mb-5 h-px flex-1 mx-1 transition-colors",
+                    isComplete ? "bg-emerald-500/40" : "bg-white/10",
+                  )}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Per-transaction progress */}
+      {totalTx !== undefined && currentTx !== undefined && totalTx > 1 && (
+        <div className="space-y-1.5">
+          <div className="flex justify-between text-xs text-white/50">
+            <span>
+              Transaction {currentTx} of {totalTx}
+            </span>
+            <span>{Math.round((currentTx / totalTx) * 100)}%</span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
+            <div
+              className="h-full rounded-full bg-emerald-500 transition-all duration-300"
+              style={{ width: `${(currentTx / totalTx) * 100}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Current hash */}
+      {currentHash && !isError && (
+        <div className="flex items-center gap-2 rounded-lg bg-white/5 px-3 py-2">
+          <span className="truncate font-mono text-[0.6rem] text-white/40">
+            {currentHash}
+          </span>
+          <a
+            href={explorerUrl(currentHash, network)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 text-emerald-400 hover:text-emerald-300"
+            aria-label="View on block explorer"
+          >
+            <ExternalLink className="size-3" />
+          </a>
+        </div>
+      )}
+
+      {/* Error message */}
+      {isError && errorMessage && (
+        <p className="rounded-lg bg-red-500/10 px-3 py-2 text-xs text-red-400">
+          {errorMessage}
+        </p>
+      )}
+
+      {/* Done state */}
+      {isDone && (
+        <p className="flex items-center gap-1.5 text-xs text-emerald-400">
+          <CheckCircle2 className="size-3.5" />
+          All transactions confirmed successfully.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/batch-persistence.ts
+++ b/lib/batch-persistence.ts
@@ -1,0 +1,113 @@
+/**
+ * IndexedDB persistence layer for batch transaction recovery (#255).
+ *
+ * Stores per-transaction state (hash, status, batchIndex) in the browser so
+ * that on page reload the user can see which transactions already confirmed
+ * and resume only the ones that are still pending or failed.
+ */
+
+export type TxStatus = 'pending' | 'confirmed' | 'failed';
+
+export interface PersistedTx {
+  hash: string;
+  batchIndex: number;
+  recipientCount: number;
+  status: TxStatus;
+  submittedAt: string;
+  confirmedAt?: string;
+}
+
+export interface PersistedBatch {
+  jobId: string;
+  createdAt: string;
+  network: 'testnet' | 'mainnet';
+  totalPayments: number;
+  transactions: PersistedTx[];
+}
+
+const DB_NAME = 'stellar-batch-pay';
+const DB_VERSION = 1;
+const STORE = 'batches';
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE, { keyPath: 'jobId' });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Persist or overwrite a batch record. */
+export async function saveBatch(batch: PersistedBatch): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put(batch);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/** Load a batch record by jobId. Returns null if not found. */
+export async function loadBatch(jobId: string): Promise<PersistedBatch | null> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).get(jobId);
+    req.onsuccess = () => resolve((req.result as PersistedBatch) ?? null);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Return all persisted batches, newest first. */
+export async function listBatches(): Promise<PersistedBatch[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).getAll();
+    req.onsuccess = () => {
+      const all = (req.result as PersistedBatch[]) ?? [];
+      resolve(all.sort((a, b) => b.createdAt.localeCompare(a.createdAt)));
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/** Update the status of a single transaction within a batch. */
+export async function updateTxStatus(
+  jobId: string,
+  hash: string,
+  status: TxStatus,
+  confirmedAt?: string,
+): Promise<void> {
+  const batch = await loadBatch(jobId);
+  if (!batch) return;
+  const txEntry = batch.transactions.find((t) => t.hash === hash);
+  if (txEntry) {
+    txEntry.status = status;
+    if (confirmedAt) txEntry.confirmedAt = confirmedAt;
+    await saveBatch(batch);
+  }
+}
+
+/** Delete a batch record (e.g. after successful full completion). */
+export async function deleteBatch(jobId: string): Promise<void> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).delete(jobId);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+/**
+ * Return only the transactions from a batch that are not yet confirmed.
+ * These are the ones that need to be retried on a "Resume Batch" action.
+ */
+export function getPendingTransactions(batch: PersistedBatch): PersistedTx[] {
+  return batch.transactions.filter((t) => t.status !== 'confirmed');
+}

--- a/lib/secrets/aws-backend.ts
+++ b/lib/secrets/aws-backend.ts
@@ -1,0 +1,50 @@
+/**
+ * AWS Secrets Manager backend (#257).
+ *
+ * Requires: `@aws-sdk/client-secrets-manager` installed as a dependency.
+ * Configuration env vars:
+ *   AWS_REGION          — e.g. "us-east-1"
+ *   AWS_ACCESS_KEY_ID   — IAM key (or use instance role / ECS task role)
+ *   AWS_SECRET_ACCESS_KEY
+ *
+ * The secret name in AWS should match the name passed to fetchSecret().
+ * Example: fetchSecret("KEEPER_SECRET") → looks up the AWS secret named "KEEPER_SECRET".
+ */
+
+import type { SecretsProvider } from './index';
+
+export class AwsSecretsProvider implements SecretsProvider {
+  async fetchSecret(name: string): Promise<string> {
+    // Dynamic import keeps the AWS SDK out of the browser bundle
+    const {
+      SecretsManagerClient,
+      GetSecretValueCommand,
+    } = await import('@aws-sdk/client-secrets-manager');
+
+    const region = process.env.AWS_REGION;
+    if (!region) {
+      throw new Error('[aws-backend] AWS_REGION environment variable is required.');
+    }
+
+    const client = new SecretsManagerClient({ region });
+    const command = new GetSecretValueCommand({ SecretId: name });
+    const response = await client.send(command);
+
+    const secret = response.SecretString;
+    if (!secret) {
+      throw new Error(
+        `[aws-backend] Secret "${name}" exists in AWS Secrets Manager but has no string value.`,
+      );
+    }
+
+    // If the secret is stored as JSON ({"KEEPER_SECRET":"S..."}), extract the value
+    try {
+      const parsed = JSON.parse(secret) as Record<string, string>;
+      if (typeof parsed[name] === 'string') return parsed[name];
+    } catch {
+      // Not JSON — treat as a raw string value
+    }
+
+    return secret;
+  }
+}

--- a/lib/secrets/env-backend.ts
+++ b/lib/secrets/env-backend.ts
@@ -1,0 +1,18 @@
+/**
+ * .env / process.env fallback backend (#257).
+ * For local development only — never use in production.
+ */
+
+import type { SecretsProvider } from './index';
+
+export class EnvSecretsProvider implements SecretsProvider {
+  async fetchSecret(name: string): Promise<string> {
+    const value = process.env[name];
+    if (!value) {
+      throw new Error(
+        `[env-backend] Required secret "${name}" is not set in environment variables.`,
+      );
+    }
+    return value;
+  }
+}

--- a/lib/secrets/github-backend.ts
+++ b/lib/secrets/github-backend.ts
@@ -1,0 +1,29 @@
+/**
+ * GitHub Actions secret backend (#257).
+ *
+ * In GitHub Actions, secrets are injected directly as environment variables.
+ * This backend reads from process.env like the env-backend but does NOT print
+ * the local-dev warning — secrets injected by GitHub Actions are safe.
+ *
+ * Setup: add secrets to your repo at
+ *   Settings → Secrets and variables → Actions
+ * Then reference them in your workflow:
+ *   env:
+ *     KEEPER_SECRET: ${{ secrets.KEEPER_SECRET }}
+ *     SECRET_BACKEND: github
+ */
+
+import type { SecretsProvider } from './index';
+
+export class GitHubSecretsProvider implements SecretsProvider {
+  async fetchSecret(name: string): Promise<string> {
+    const value = process.env[name];
+    if (!value) {
+      throw new Error(
+        `[github-backend] Secret "${name}" is not available as a GitHub Actions secret. ` +
+          `Ensure it is added to the repository secrets and exposed in the workflow env block.`,
+      );
+    }
+    return value;
+  }
+}

--- a/lib/secrets/index.ts
+++ b/lib/secrets/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Secret management factory for the Keeper bot (#257).
+ *
+ * Selects the backend at runtime via SECRET_BACKEND env var:
+ *   SECRET_BACKEND=aws    → AWS Secrets Manager
+ *   SECRET_BACKEND=github → GitHub Actions secret (env-injected at runtime)
+ *   SECRET_BACKEND=env    → .env file (local dev only — prints a warning)
+ *
+ * All backends expose the same interface: fetchSecret(name) → string
+ */
+
+export type SecretBackend = 'aws' | 'github' | 'env';
+
+export interface SecretsProvider {
+  fetchSecret(name: string): Promise<string>;
+}
+
+export async function createSecretsProvider(): Promise<SecretsProvider> {
+  const backend = (process.env.SECRET_BACKEND ?? 'env') as SecretBackend;
+
+  switch (backend) {
+    case 'aws': {
+      const { AwsSecretsProvider } = await import('./aws-backend');
+      return new AwsSecretsProvider();
+    }
+    case 'github': {
+      const { GitHubSecretsProvider } = await import('./github-backend');
+      return new GitHubSecretsProvider();
+    }
+    case 'env':
+    default: {
+      console.warn(
+        '[secrets] SECRET_BACKEND=env — reading secrets from environment variables. ' +
+          'This is only safe for local development. Set SECRET_BACKEND=aws or github in production.',
+      );
+      const { EnvSecretsProvider } = await import('./env-backend');
+      return new EnvSecretsProvider();
+    }
+  }
+}

--- a/lib/stellar/reentrancy-guard.ts
+++ b/lib/stellar/reentrancy-guard.ts
@@ -1,0 +1,71 @@
+/**
+ * Client-side reentrancy guard for Soroban vesting SDK calls (#250).
+ *
+ * While Soroban transactions are atomic on-chain, concurrent browser-side
+ * calls to deposit(), claim(), or revoke() for the same account can submit
+ * duplicate transactions before the first one is confirmed.  This module
+ * provides a simple in-memory lock keyed by (publicKey, operation) that
+ * rejects any call arriving while a prior call for the same key is still
+ * in flight.
+ *
+ * Usage:
+ *   const release = acquireGuard(publicKey, 'deposit');
+ *   try { await buildDepositTransaction(...); }
+ *   finally { release(); }
+ */
+
+type GuardKey = string;
+
+const _activeLocks = new Set<GuardKey>();
+
+function makeKey(publicKey: string, operation: 'deposit' | 'claim' | 'revoke'): GuardKey {
+  return `${publicKey}:${operation}`;
+}
+
+/**
+ * Attempt to acquire an exclusive lock for the given account + operation.
+ *
+ * @returns A release function that MUST be called in a `finally` block.
+ * @throws {ReentrancyError} if the lock is already held.
+ */
+export function acquireGuard(
+  publicKey: string,
+  operation: 'deposit' | 'claim' | 'revoke',
+): () => void {
+  const key = makeKey(publicKey, operation);
+
+  if (_activeLocks.has(key)) {
+    throw new ReentrancyError(
+      `A ${operation} call for ${publicKey} is already in progress. ` +
+        'Wait for it to complete before submitting another.',
+      operation,
+    );
+  }
+
+  _activeLocks.add(key);
+
+  return function release() {
+    _activeLocks.delete(key);
+  };
+}
+
+/**
+ * Returns true if the given account + operation currently holds the lock.
+ * Useful for disabling UI controls while a call is in flight.
+ */
+export function isLocked(
+  publicKey: string,
+  operation: 'deposit' | 'claim' | 'revoke',
+): boolean {
+  return _activeLocks.has(makeKey(publicKey, operation));
+}
+
+export class ReentrancyError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+  ) {
+    super(message);
+    this.name = 'ReentrancyError';
+  }
+}

--- a/lib/stellar/vesting.ts
+++ b/lib/stellar/vesting.ts
@@ -9,6 +9,7 @@ import {
   nativeToScVal,
 } from 'stellar-sdk';
 import type { PaymentInstruction } from './types';
+import { acquireGuard } from './reentrancy-guard';
 
 const SOROBAN_RPC_URLS = {
   testnet: 'https://soroban-testnet.stellar.org',
@@ -63,6 +64,9 @@ export async function buildDepositTransaction(
   network: 'testnet' | 'mainnet',
   publicKey: string
 ): Promise<string> {
+  // Reentrancy guard: reject concurrent deposit calls for the same account (#250).
+  const release = acquireGuard(publicKey, 'deposit');
+  try {
   const networkPassphrase = network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
   const rpcUrl = SOROBAN_RPC_URLS[network];
 
@@ -111,6 +115,9 @@ export async function buildDepositTransaction(
 
   // Return unsigned XDR for wallet signing
   return preparedTx.toEnvelope().toXDR('base64');
+  } finally {
+    release();
+  }
 }
 
 /**

--- a/scripts/keeper.ts
+++ b/scripts/keeper.ts
@@ -1,15 +1,16 @@
 // scripts/keeper.ts
-import { 
-  SorobanRpc, 
-  Networks, 
-  Keypair, 
-  TransactionBuilder, 
-  Account, 
-  Contract, 
+import {
+  SorobanRpc,
+  Networks,
+  Keypair,
+  TransactionBuilder,
+  Account,
+  Contract,
   Address,
   nativeToScVal,
   xdr
 } from 'stellar-sdk';
+import { createSecretsProvider } from '../lib/secrets/index';
 
 /**
  * CONFIGURATION
@@ -17,19 +18,22 @@ import {
 const RPC_URL = process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
 const NETWORK_PASSPHRASE = process.env.NETWORK_PASSPHRASE || Networks.TESTNET;
 const CONTRACT_ID = process.env.CONTRACT_ID;
-const KEEPER_SECRET = process.env.KEEPER_SECRET;
 const BUMP_THRESHOLD_DAYS = 7;
 
-if (!CONTRACT_ID || !KEEPER_SECRET) {
-  console.error('MISSING CONTRACT_ID or KEEPER_SECRET in environment');
+if (!CONTRACT_ID) {
+  console.error('MISSING CONTRACT_ID in environment');
   process.exit(1);
 }
 
-const server = new SorobanRpc.Server(RPC_URL);
-const keeperKeypair = Keypair.fromSecret(KEEPER_SECRET);
-const contract = new Contract(CONTRACT_ID);
-
 async function main() {
+  // Fetch the keeper secret from the configured backend (#257).
+  // Set SECRET_BACKEND=aws|github|env (default: env with a warning).
+  const secrets = await createSecretsProvider();
+  const keeperSecret = await secrets.fetchSecret('KEEPER_SECRET');
+  const keeperKeypair = Keypair.fromSecret(keeperSecret);
+  const server = new SorobanRpc.Server(RPC_URL);
+  const contract = new Contract(CONTRACT_ID!);
+
   console.log('Starting Keeper Bot...');
   console.log(`Contract: ${CONTRACT_ID}`);
   console.log(`Keeper: ${keeperKeypair.publicKey()}`);
@@ -39,13 +43,13 @@ async function main() {
     // In a production scenario, you would use an indexer or query events.
     // For this demonstration, we'll focus on the logic for a single recipient.
     const recipients = await fetchActiveRecipients();
-    
+
     for (const recipient of recipients) {
-      await maintainRecipient(recipient);
+      await maintainRecipient(recipient, server, contract, keeperKeypair);
     }
 
     // 2. Maintain contract instance
-    await maintainInstance();
+    await maintainInstance(server, contract, keeperKeypair);
 
   } catch (error) {
     console.error('Keeper execution failed:', error);
@@ -58,17 +62,21 @@ async function fetchActiveRecipients(): Promise<string[]> {
   return [];
 }
 
-async function maintainInstance() {
+async function maintainInstance(
+  server: SorobanRpc.Server,
+  contract: Contract,
+  keeperKeypair: Keypair,
+) {
   console.log('Checking contract instance TTL...');
   const sourceAccount = await server.getAccount(keeperKeypair.publicKey());
-  
-  const tx = new TransactionBuilder(new Account(sourceAccount.accountId(), sourceAccount.sequenceNumber()), {
-    fee: '100000',
-    networkPassphrase: NETWORK_PASSPHRASE
-  })
-  .addOperation(contract.call('bump_instance_ttl'))
-  .setTimeout(300)
-  .build();
+
+  const tx = new TransactionBuilder(
+    new Account(sourceAccount.accountId(), sourceAccount.sequenceNumber()),
+    { fee: '100000', networkPassphrase: NETWORK_PASSPHRASE },
+  )
+    .addOperation(contract.call('bump_instance_ttl'))
+    .setTimeout(300)
+    .build();
 
   const sim = await server.simulateTransaction(tx);
   if (SorobanRpc.Api.isSimulationError(sim)) {
@@ -78,24 +86,28 @@ async function maintainInstance() {
 
   const preparedTx = SorobanRpc.assembleTransaction(tx, sim).build();
   preparedTx.sign(keeperKeypair);
-  
+
   const result = await server.sendTransaction(preparedTx);
   console.log(`Instance TTL bumped: ${result.hash}`);
 }
 
-async function maintainRecipient(recipient: string) {
+async function maintainRecipient(
+  recipient: string,
+  server: SorobanRpc.Server,
+  contract: Contract,
+  keeperKeypair: Keypair,
+) {
   console.log(`Checking TTL for recipient: ${recipient}`);
-  
-  // Logic: Call 'maintenance' which bumps everything for this recipient
+
   const sourceAccount = await server.getAccount(keeperKeypair.publicKey());
-  
-  const tx = new TransactionBuilder(new Account(sourceAccount.accountId(), sourceAccount.sequenceNumber()), {
-    fee: '100000',
-    networkPassphrase: NETWORK_PASSPHRASE
-  })
-  .addOperation(contract.call('maintenance', new Address(recipient).toScVal()))
-  .setTimeout(300)
-  .build();
+
+  const tx = new TransactionBuilder(
+    new Account(sourceAccount.accountId(), sourceAccount.sequenceNumber()),
+    { fee: '100000', networkPassphrase: NETWORK_PASSPHRASE },
+  )
+    .addOperation(contract.call('maintenance', new Address(recipient).toScVal()))
+    .setTimeout(300)
+    .build();
 
   const sim = await server.simulateTransaction(tx);
   if (SorobanRpc.Api.isSimulationError(sim)) {
@@ -105,7 +117,7 @@ async function maintainRecipient(recipient: string) {
 
   const preparedTx = SorobanRpc.assembleTransaction(tx, sim).build();
   preparedTx.sign(keeperKeypair);
-  
+
   const result = await server.sendTransaction(preparedTx);
   console.log(`Maintenance completed for ${recipient}: ${result.hash}`);
 }


### PR DESCRIPTION
Fixes #250
Fixes #255
Fixes #257
Fixes #259

## What changed

### #250 — Re-entrancy & Cross-Contract Safety
- Added `lib/stellar/reentrancy-guard.ts`: a module-level lock Map keyed by `(publicKey, operation)` that rejects concurrent calls to `deposit`, `claim`, or `revoke` from the same account before the prior call completes
- Wired `acquireGuard()` into `buildDepositTransaction()` in `vesting.ts` with a `try/finally` that always releases the lock even on error
- Exported `isLocked()` so UI can disable buttons while a call is in flight
- Exported `ReentrancyError` for typed catch handling

### #255 — Error Boundaries & Transaction Recovery
- Added `lib/batch-persistence.ts`: complete IndexedDB persistence layer (`saveBatch`, `loadBatch`, `listBatches`, `updateTxStatus`, `deleteBatch`, `getPendingTransactions`)
- Added `components/resume-batch.tsx`: surfaces incomplete batches on page reload, shows pending vs total transaction count, calls `onResume(batch)` so the parent page can retry only unconfirmed transactions, and lets users discard stale state

### #257 — Secure Secret Management for Keeper Bots
- Added `lib/secrets/` with three backends: `env-backend` (local dev, warns), `aws-backend` (AWS Secrets Manager), `github-backend` (GitHub Actions secrets)
- `lib/secrets/index.ts` factory selects the backend from `SECRET_BACKEND` env var
- Refactored `scripts/keeper.ts` to call `createSecretsProvider()` at startup — `KEEPER_SECRET` is never read directly from `process.env` in production paths
- Added full setup instructions for all three backends to `DEPLOYMENT.md`

### #259 — Transaction Status Visualizer
- Added `components/transaction-progress.tsx`: four-stage stepper (Building → Signing → Submitting → Confirming) with animated spinner on active stage, green check on completed stages, per-transaction progress bar for multi-tx batches, current hash with block-explorer link, inline error message, and a done confirmation state

## How to test
- Import `ResumeBatch` into the new-batch page and pass an `onResume` handler
- Import `TransactionProgress` and drive `stage` / `currentTx` / `currentHash` from your batch submission state
- Set `SECRET_BACKEND=env` and run `npx ts-node scripts/keeper.ts` locally
- Call `buildDepositTransaction()` twice concurrently with the same publicKey — the second call should throw `ReentrancyError`