### PR TITLE
feat: CSV validation error highlighting and batch upload chunking limits

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -28,6 +28,7 @@ import {
 } from "@/lib/stellar/validator";
 import type { PaymentInstruction } from "@/lib/stellar/types";
 import { getRecommendedFee } from "@/lib/stellar/fee-service";
+import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
 
 interface RequestBody {
   payments: PaymentInstruction[];
@@ -60,6 +61,13 @@ export async function POST(request: NextRequest) {
     if (!Array.isArray(payments) || payments.length === 0) {
       return NextResponse.json(
         { error: "payments must be a non-empty array" },
+        { status: 400 }
+      );
+    }
+
+    if (payments.length > MAX_UPLOAD_ROWS) {
+      return NextResponse.json(
+        { error: `Batch exceeds the maximum of ${MAX_UPLOAD_ROWS} payments per upload.` },
         { status: 400 }
       );
     }

--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { validatePaymentInstructions } from "@/lib/stellar";
+import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
 import { safeJsonResponse } from "@/lib/safe-json";
 import { createJob } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
@@ -36,6 +37,13 @@ export async function POST(request: NextRequest) {
     if (!Array.isArray(payments) || payments.length === 0) {
       return NextResponse.json(
         { error: "Invalid request: payments must be a non-empty array" },
+        { status: 400 },
+      );
+    }
+
+    if (payments.length > MAX_UPLOAD_ROWS) {
+      return NextResponse.json(
+        { error: `Batch exceeds the maximum of ${MAX_UPLOAD_ROWS} payments per upload.` },
         { status: 400 },
       );
     }

--- a/app/dashboard/new-batch/page.tsx
+++ b/app/dashboard/new-batch/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { FileUpload } from "@/components/file-upload";
 import { ConnectWalletButton } from "@/components/connect-wallet-button";
 import { BatchDryRun } from "@/components/dashboard/BatchDryRun";
 import { CsvValidationErrors } from "@/components/csv-validation-errors";
+import { JobProgress } from "@/components/job-progress";
 import { useWallet } from "@/contexts/WalletContext";
 import { parsePaymentFile, getBatchSummary } from "@/lib/stellar";
-import type { ParsedPaymentFile, BatchResult } from "@/lib/stellar/types";
+import type { ParsedPaymentFile, BatchResult, JobStatus } from "@/lib/stellar/types";
 import { Send, Info, Lightbulb, Check, AlertCircle, BookOpen } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
@@ -30,6 +31,47 @@ export default function NewBatchPaymentPage() {
   } | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [result, setResult] = useState<BatchResult | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [jobStatus, setJobStatus] = useState<JobStatus>("queued");
+  const [completedBatches, setCompletedBatches] = useState(0);
+  const [totalBatches, setTotalBatches] = useState(0);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback((id: string) => {
+    stopPolling();
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(`/api/batch-status/${id}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        setJobStatus(data.status);
+        setCompletedBatches(data.completedBatches ?? 0);
+        setTotalBatches(data.totalBatches ?? 0);
+        if (data.status === "completed") {
+          stopPolling();
+          setResult(data.result ?? null);
+          setIsSubmitting(false);
+          setStep(4);
+          toast.success("Batch submitted successfully");
+        } else if (data.status === "failed") {
+          stopPolling();
+          setIsSubmitting(false);
+          toast.error(data.error ?? "Batch processing failed");
+        }
+      } catch {
+        // ignore transient fetch errors
+      }
+    }, 2000);
+  }, [stopPolling]);
+
+  useEffect(() => () => stopPolling(), [stopPolling]);
   const [skippedIndices, setSkippedIndices] = useState<number[]>([]);
   const [convertedIndices, setConvertedIndices] = useState<number[]>([]);
   const { publicKey, signTx } = useWallet();
@@ -266,14 +308,15 @@ export default function NewBatchPaymentPage() {
                 if (!response.ok) {
                   throw new Error(data.error || 'Failed to submit batch');
                 }
-                setResult(data);
-                setStep(4);
-                toast.success('Batch submitted successfully');
+                setJobId(data.jobId);
+                setJobStatus("queued");
+                setCompletedBatches(0);
+                setTotalBatches(0);
+                startPolling(data.jobId);
               } catch (error) {
                 console.error('Batch submission error:', error);
-                toast.error(error instanceof Error ? error.message : 'Failed to submit batch');
-              } finally {
                 setIsSubmitting(false);
+                toast.error(error instanceof Error ? error.message : 'Failed to submit batch');
               }
             }}
           />
@@ -285,6 +328,25 @@ export default function NewBatchPaymentPage() {
           )}
 
           <BatchDryRun result={validationResult} />
+        </div>
+      )}
+
+      {/* Processing progress — shown while batch job is running */}
+      {isSubmitting && jobId && (
+        <div className="space-y-4 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <Card className="bg-slate-900/50 border-slate-800">
+            <CardHeader>
+              <CardTitle className="text-lg text-white">Processing Batch</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <JobProgress
+                status={jobStatus}
+                completedBatches={completedBatches}
+                totalBatches={totalBatches}
+                totalPayments={validationResult?.validPayments.length ?? 0}
+              />
+            </CardContent>
+          </Card>
         </div>
       )}
 

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -10,11 +10,13 @@ import { ConnectWalletButton } from "@/components/connect-wallet-button";
 import { useFreighter } from "@/hooks/use-freighter";
 import { useToast } from "@/components/ui/use-toast";
 import { parseInput, parseFileStream, validatePaymentInstructions } from "@/lib/stellar";
+import { CsvValidationErrors } from "@/components/csv-validation-errors";
 import type {
   PaymentInstruction,
   BatchResult,
   PaymentResult,
   JobStatus,
+  ParsedPaymentFile,
 } from "@/lib/stellar/types";
 import { useBatchHistory } from "@/hooks/use-batch-history";
 import { Navbar } from "@/components/landing/navbar";
@@ -29,6 +31,7 @@ export default function Home() {
   const [network, setNetwork] = useState<"testnet" | "mainnet">("testnet");
   const [result, setResult] = useState<BatchResult | null>(null);
   const [error, setError] = useState("");
+  const [validationResult, setValidationResult] = useState<ParsedPaymentFile | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
 
@@ -312,8 +315,11 @@ export default function Home() {
               <h2 className="text-xl font-semibold mb-4">
                 Upload Payment File
               </h2>
-              <FileUpload onFileSelect={handleFileSelect} />
+              <FileUpload onFileSelect={handleFileSelect} onValidationResult={setValidationResult} />
             </div>
+            {validationResult && validationResult.invalidCount > 0 && (
+              <CsvValidationErrors validationResult={validationResult} />
+            )}
           </div>
         )}
 

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -3,15 +3,43 @@
 import React, { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/use-toast';
+import { parsePaymentFile } from '@/lib/stellar/parser';
+import type { ParsedPaymentFile } from '@/lib/stellar/types';
 
 interface FileUploadProps {
   onFileSelect: (file: File, format: 'json' | 'csv') => void;
+  onValidationResult?: (result: ParsedPaymentFile) => void;
   disabled?: boolean;
 }
 
-export function FileUpload({ onFileSelect, disabled }: FileUploadProps) {
+export function FileUpload({ onFileSelect, onValidationResult, disabled }: FileUploadProps) {
   const [fileName, setFileName] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const processFile = async (file: File, ext: string) => {
+    setFileName(file.name);
+    onFileSelect(file, ext as 'json' | 'csv');
+
+    if (onValidationResult) {
+      try {
+        const content = await file.text();
+        const result = parsePaymentFile(content, ext as 'json' | 'csv');
+        onValidationResult(result);
+      } catch (err) {
+        // Parsing failed — surface as a single-row error result
+        onValidationResult({
+          rows: [{
+            rowNumber: 1,
+            instruction: { address: '', amount: '', asset: '' },
+            valid: false,
+            error: err instanceof Error ? err.message : 'Failed to parse file',
+          }],
+          validPayments: [],
+          invalidCount: 1,
+        });
+      }
+    }
+  };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -27,8 +55,7 @@ export function FileUpload({ onFileSelect, disabled }: FileUploadProps) {
       return;
     }
 
-    setFileName(file.name);
-    onFileSelect(file, ext as 'json' | 'csv');
+    processFile(file, ext as string);
   };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
@@ -48,8 +75,7 @@ export function FileUpload({ onFileSelect, disabled }: FileUploadProps) {
       return;
     }
 
-    setFileName(file.name);
-    onFileSelect(file, ext as 'json' | 'csv');
+    processFile(file, ext as string);
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {

--- a/lib/stellar/index.ts
+++ b/lib/stellar/index.ts
@@ -3,7 +3,7 @@
  * NOTE: StellarService is NOT exported here - use lib/stellar/server.ts server-side only
  */
 
-export { parseInput, parseJSON, parseCSV, parseFileStream, analyzeParsedPayments, parsePaymentFile } from './parser';
+export { parseInput, parseJSON, parseCSV, parseFileStream, analyzeParsedPayments, parsePaymentFile, MAX_UPLOAD_ROWS } from './parser';
 export { createBatches, parseAsset, getBatchSummary } from './batcher';
 export { validatePaymentInstruction, validateBatchConfig, validatePaymentInstructions } from './validator';
 export { fetchFeeStats, getRecommendedFee, getFeeForOperations, clearFeeCache } from './fee-service';

--- a/lib/stellar/parser.ts
+++ b/lib/stellar/parser.ts
@@ -6,6 +6,8 @@ import Papa from 'papaparse';
 import { ParsedPaymentFile, PaymentInstruction, MemoType } from './types';
 import { validatePaymentInstruction } from './validator';
 
+export const MAX_UPLOAD_ROWS = 1000;
+
 /**
  * Sanitizes a string value to prevent CSV injection (Formula Injection)
  * and strips HTML tags to prevent XSS.
@@ -166,6 +168,9 @@ export function analyzeParsedPayments(
 
 export function parsePaymentFile(content: string, format: 'json' | 'csv'): ParsedPaymentFile {
   const instructions = parseInput(content, format);
+  if (instructions.length > MAX_UPLOAD_ROWS) {
+    throw new Error(`Upload exceeds the maximum of ${MAX_UPLOAD_ROWS} rows. Your file has ${instructions.length} rows. Please split it into smaller files.`);
+  }
   return analyzeParsedPayments(instructions, format === 'csv' ? 2 : 1);
 }
 
@@ -191,6 +196,13 @@ export function parseFileStream(
 
       for (let i = 0; i < data.length; i++) {
         const row = data[i];
+
+        if (rowCount + i >= MAX_UPLOAD_ROWS) {
+          aborted = true;
+          parser.abort();
+          callbacks.onError(new Error(`Upload exceeds the maximum of ${MAX_UPLOAD_ROWS} rows. Please split your file into smaller files.`));
+          return;
+        }
 
         const instruction: PaymentInstruction = {
           address: sanitizeValue(String(row.address || '')),


### PR DESCRIPTION
## Summary

closes #269 
closes #270.

### #269 — CSV Upload Validation and Error Highlighting

- Added `onValidationResult` optional prop to `FileUpload` component
- On file selection, reads content and calls `parsePaymentFile` client-side
- Parse failures are surfaced as a single-row error result
- Wired `CsvValidationErrors` into the demo page upload state — errors appear immediately before submission, preventing unnecessary API calls
- The `new-batch` dashboard flow already had this wired; demo page was the gap

### #270 — Chunking Limits for Large Batch Uploads

- Added `MAX_UPLOAD_ROWS = 1000` constant in `lib/stellar/parser.ts`
- Enforced in `parsePaymentFile` (throws with clear message) and `parseFileStream` (aborts stream)
- Exported from `lib/stellar/index.ts`
- Server-side enforcement in `/api/batch-build` and `/api/batch-submit` (returns 400)
- Wired `JobProgress` into `new-batch` page with 2s polling via `/api/batch-status/:jobId`
- Progress card shows chunk-by-chunk `completedBatches / totalBatches` during processing

## What was tested

- TypeScript type check passes with no new errors (pre-existing errors in `new-batch/page.tsx` are unchanged)
- Limit enforcement is consistent across client parse, streaming parse, and both API routes