### PR TITLE
feat(api): add tiered rate limiting across POST routes

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -29,6 +29,7 @@ import {
 import type { PaymentInstruction } from "@/lib/stellar/types";
 import { getRecommendedFee } from "@/lib/stellar/fee-service";
 import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 interface RequestBody {
   payments: PaymentInstruction[];
@@ -39,6 +40,9 @@ interface RequestBody {
 const MAX_OPS = 100;
 
 export async function POST(request: NextRequest) {
+  const rate = applyRateLimit(request, "batch-build");
+  if (rate.blocked) return rate.response!;
+
   try {
     const body = (await request.json()) as RequestBody;
     const { payments, network, publicKey } = body;
@@ -175,20 +179,20 @@ export async function POST(request: NextRequest) {
       sourceAccount.incrementSequenceNumber();
     }
 
-    return safeJsonResponse({
+    return setRateLimitHeaders(safeJsonResponse({
       xdrs,
       batchCount: batches.length,
       network,
       publicKey,
-    });
+    }), rate);
   } catch (error) {
     console.error("Batch build error:", error);
-    return safeJsonResponse(
+    return setRateLimitHeaders(safeJsonResponse(
       {
         error:
           error instanceof Error ? error.message : "Internal server error",
       },
       { status: 500 },
-    );
+    ), rate);
   }
 }

--- a/app/api/batch-submit-signed/route.ts
+++ b/app/api/batch-submit-signed/route.ts
@@ -12,6 +12,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { TransactionBuilder, Horizon, Networks } from "stellar-sdk";
 import { safeJsonResponse } from "@/lib/safe-json";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 interface RequestBody {
     signedXdr: string;
@@ -45,6 +46,9 @@ function isInsufficientFeeError(error: unknown): boolean {
 }
 
 export async function POST(request: NextRequest) {
+    const rate = applyRateLimit(request, "batch-submit-signed");
+    if (rate.blocked) return rate.response!;
+
     try {
         const body = (await request.json()) as RequestBody;
         const { signedXdr, network } = body;
@@ -84,11 +88,11 @@ export async function POST(request: NextRequest) {
         try {
             const result = await server.submitTransaction(transaction);
 
-            return safeJsonResponse({
+            return setRateLimitHeaders(safeJsonResponse({
                 success: true,
                 hash: result.hash,
                 ledger: result.ledger,
-            });
+            }), rate);
         } catch (submissionError: unknown) {
             // Check if this is a low-fee error and provide fee guidance
             if (isInsufficientFeeError(submissionError)) {
@@ -96,7 +100,7 @@ export async function POST(request: NextRequest) {
                 const currentBaseFee = Number(feeStats.last_ledger_base_fee || "100");
                 const estimatedFee = (currentBaseFee * 300).toString(); // 300 ops is typical batch size
 
-                return safeJsonResponse(
+                return setRateLimitHeaders(safeJsonResponse(
                     {
                         success: false,
                         error: "Transaction fees are insufficient for current network conditions",
@@ -106,7 +110,7 @@ export async function POST(request: NextRequest) {
                         guidance: `Network base fee is ${currentBaseFee} stroops. Consider retrying with a fee of at least ${estimatedFee} stroops.`,
                     },
                     { status: 400 },
-                );
+                ), rate);
             }
 
             throw submissionError;
@@ -121,7 +125,7 @@ export async function POST(request: NextRequest) {
                     .response?.data?.extras?.result_codes
                 : undefined;
 
-        return safeJsonResponse(
+        return setRateLimitHeaders(safeJsonResponse(
             {
                 success: false,
                 error:
@@ -129,6 +133,6 @@ export async function POST(request: NextRequest) {
                 resultCodes: horizonExtras,
             },
             { status: 400 },
-        );
+        ), rate);
     }
 }

--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -16,6 +16,7 @@ import { safeJsonResponse } from "@/lib/safe-json";
 import { createJob } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
 import type { PaymentInstruction } from "@/lib/stellar/types";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 interface RequestBody {
   payments?: PaymentInstruction[];
@@ -25,6 +26,9 @@ interface RequestBody {
 }
 
 export async function POST(request: NextRequest) {
+  const rate = applyRateLimit(request, "batch-submit");
+  if (rate.blocked) return rate.response!;
+
   try {
     // Parse request body
     const body = (await request.json()) as RequestBody;
@@ -60,7 +64,7 @@ export async function POST(request: NextRequest) {
       const jobId = createJob([], network, signedTransactions);
       void processJobInBackground(jobId, [], network, undefined, signedTransactions);
 
-      return safeJsonResponse(
+      return setRateLimitHeaders(safeJsonResponse(
         {
           jobId,
           status: "queued",
@@ -71,7 +75,7 @@ export async function POST(request: NextRequest) {
             " for progress.",
         },
         { status: 202 },
-      );
+      ), rate);
     }
 
     // Mode 2: Server-side signing (legacy, requires STELLAR_SECRET_KEY)
@@ -125,7 +129,7 @@ export async function POST(request: NextRequest) {
     void processJobInBackground(jobId, payments, network, secretKey);
 
     // Return 202 Accepted with the job ID for polling
-    return safeJsonResponse(
+    return setRateLimitHeaders(safeJsonResponse(
       {
         jobId,
         status: "queued",
@@ -136,14 +140,14 @@ export async function POST(request: NextRequest) {
           " for progress.",
       },
       { status: 202 },
-    );
+    ), rate);
   } catch (error) {
     console.error("Batch submission error:", error);
-    return safeJsonResponse(
+    return setRateLimitHeaders(safeJsonResponse(
       {
         error: error instanceof Error ? error.message : "Internal server error",
       },
       { status: 500 },
-    );
+    ), rate);
   }
 }

--- a/app/api/webhooks/register/route.ts
+++ b/app/api/webhooks/register/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { registerWebhook, getWebhooks, unregisterWebhook } from "@/lib/webhooks";
 import { safeJsonResponse } from "@/lib/safe-json";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 export async function GET() {
   return safeJsonResponse({ webhooks: getWebhooks() });
 }
 
 export async function POST(request: NextRequest) {
+  const rate = applyRateLimit(request, "webhook-register");
+  if (rate.blocked) return rate.response!;
+
   try {
     const { url, events, secret } = await request.json();
 
@@ -15,9 +19,12 @@ export async function POST(request: NextRequest) {
     }
 
     const webhook = registerWebhook(url, events, secret);
-    return safeJsonResponse({ message: "Webhook registered successfully", webhook }, { status: 201 });
+    return setRateLimitHeaders(
+      safeJsonResponse({ message: "Webhook registered successfully", webhook }, { status: 201 }),
+      rate,
+    );
   } catch (error) {
-    return safeJsonResponse({ error: "Internal server error" }, { status: 500 });
+    return setRateLimitHeaders(safeJsonResponse({ error: "Internal server error" }, { status: 500 }), rate);
   }
 }
 

--- a/lib/api-rate-limit.ts
+++ b/lib/api-rate-limit.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type Tier = "free" | "pro" | "enterprise";
+type EndpointKey = "batch-build" | "batch-submit" | "batch-submit-signed" | "webhook-register";
+
+type EndpointLimit = {
+  free: number;
+  pro: number;
+  enterprise: number;
+  windowMs: number;
+};
+
+type RateBucket = {
+  remaining: number;
+  resetAt: number;
+};
+
+const endpointLimits: Record<EndpointKey, EndpointLimit> = {
+  "batch-build": { free: 8, pro: 20, enterprise: 60, windowMs: 60_000 },
+  "batch-submit": { free: 5, pro: 15, enterprise: 45, windowMs: 60_000 },
+  "batch-submit-signed": { free: 5, pro: 15, enterprise: 45, windowMs: 60_000 },
+  "webhook-register": { free: 3, pro: 10, enterprise: 30, windowMs: 60_000 },
+};
+
+const buckets = new Map<string, RateBucket>();
+
+function resolveTier(request: NextRequest): Tier {
+  const rawTier = (request.headers.get("x-api-tier") || "free").toLowerCase();
+  if (rawTier === "enterprise") return "enterprise";
+  if (rawTier === "pro") return "pro";
+  return "free";
+}
+
+function resolveIdentifier(request: NextRequest): string {
+  const auth = request.headers.get("authorization");
+  if (auth && auth.startsWith("Bearer ")) {
+    return `auth:${auth.slice(7, 31)}`;
+  }
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const ip = forwarded.split(",")[0]?.trim();
+    if (ip) return `ip:${ip}`;
+  }
+  const cfIp = request.headers.get("cf-connecting-ip");
+  if (cfIp) return `ip:${cfIp}`;
+  return "ip:unknown";
+}
+
+export function applyRateLimit(request: NextRequest, endpoint: EndpointKey): {
+  blocked: boolean;
+  remaining: number;
+  retryAfterSec: number;
+  limit: number;
+  response?: NextResponse;
+} {
+  const tier = resolveTier(request);
+  const policy = endpointLimits[endpoint];
+  const limit = policy[tier];
+  const now = Date.now();
+  const key = `${endpoint}:${tier}:${resolveIdentifier(request)}`;
+  const existing = buckets.get(key);
+
+  if (!existing || now >= existing.resetAt) {
+    buckets.set(key, {
+      remaining: limit - 1,
+      resetAt: now + policy.windowMs,
+    });
+    return {
+      blocked: false,
+      remaining: Math.max(0, limit - 1),
+      retryAfterSec: Math.ceil(policy.windowMs / 1000),
+      limit,
+    };
+  }
+
+  if (existing.remaining <= 0) {
+    const retryAfterSec = Math.max(1, Math.ceil((existing.resetAt - now) / 1000));
+    const response = NextResponse.json(
+      { error: "Too Many Requests", detail: "Rate limit exceeded for this endpoint." },
+      { status: 429 },
+    );
+    response.headers.set("Retry-After", String(retryAfterSec));
+    response.headers.set("X-RateLimit-Remaining", "0");
+    response.headers.set("X-RateLimit-Limit", String(limit));
+    return { blocked: true, remaining: 0, retryAfterSec, limit, response };
+  }
+
+  existing.remaining -= 1;
+  const retryAfterSec = Math.max(1, Math.ceil((existing.resetAt - now) / 1000));
+  return {
+    blocked: false,
+    remaining: existing.remaining,
+    retryAfterSec,
+    limit,
+  };
+}
+
+export function setRateLimitHeaders(response: NextResponse, state: {
+  remaining: number;
+  retryAfterSec: number;
+  limit: number;
+}) {
+  response.headers.set("X-RateLimit-Remaining", String(Math.max(0, state.remaining)));
+  response.headers.set("X-RateLimit-Limit", String(state.limit));
+  response.headers.set("Retry-After", String(state.retryAfterSec));
+  return response;
+}
+


### PR DESCRIPTION
## Summary
- add shared middleware-style rate limiting utility (`lib/api-rate-limit.ts`) with:
  - per-endpoint policies
  - per-tier limits (`free`, `pro`, `enterprise`)
  - caller keying by bearer token (fallback to IP)
- enforce rate limiting on all `POST` API routes:
  - `/api/batch-build`
  - `/api/batch-submit`
  - `/api/batch-submit-signed`
  - `/api/webhooks/register`
- return `429 Too Many Requests` when limits are exceeded
- include rate-limit headers on guarded responses:
  - `X-RateLimit-Remaining`
  - `X-RateLimit-Limit`
  - `Retry-After`

## Validation
- `npm test -- tests/tx-status.test.ts` *(fails locally: `vitest` command not found in this clone environment)*

Closes #309
Closes #310
Closes #312
Closes #313
