### PR TITLE
fix(security): escape user-controlled fields in receipt HTML (#347)

### DIFF
--- a/components/dashboard/HistoryExportCenter.tsx
+++ b/components/dashboard/HistoryExportCenter.tsx
@@ -15,6 +15,7 @@ import {
   type ClaimExportRow,
 } from "@/lib/dashboard/history-export";
 import { downloadReceipt, downloadReceiptCsv } from "@/lib/receipt-generator";
+import { escapeHtml } from "@/lib/utils";
 
 function downloadCsv(filename: string, csv: string) {
   const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
@@ -26,13 +27,7 @@ function downloadCsv(filename: string, csv: string) {
   URL.revokeObjectURL(url);
 }
 
-function escapeHtml(input: string): string {
-  return input
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
+// escapeHtml is imported from @/lib/utils (see issue #347)
 
 function toPrintableHtml(rows: ClaimExportRow[], walletAddress: string, fromDate: string, toDate: string) {
   const rangeLabel = fromDate || toDate ? `${fromDate || "Any"} to ${toDate || "Any"}` : "All dates";

--- a/lib/receipt-generator.ts
+++ b/lib/receipt-generator.ts
@@ -1,4 +1,5 @@
 import type { BatchResult } from "@/lib/stellar/types";
+import { escapeHtml } from "@/lib/utils";
 
 interface ReceiptData {
   batchResult: BatchResult;
@@ -83,7 +84,7 @@ export function generateReceiptHtml(batchResult: BatchResult): string {
       <div class="grid">
         <div class="field">
           <label>Network</label>
-          <value>${batchResult.network}</value>
+          <value>${escapeHtml(String(batchResult.network))}</value>
         </div>
         <div class="field">
           <label>Timestamp</label>
@@ -117,11 +118,11 @@ export function generateReceiptHtml(batchResult: BatchResult): string {
           ${batchResult.results.map((payment, idx) => `
             <tr>
               <td>${idx + 1}</td>
-              <td><code style="font-size:11px">${payment.recipient}</code></td>
-              <td>${payment.amount}</td>
-              <td>${payment.asset}</td>
-              <td class="${payment.status}">${payment.status}</td>
-              <td><code style="font-size:10px">${payment.transactionHash || "N/A"}</code></td>
+              <td><code style="font-size:11px">${escapeHtml(String(payment.recipient))}</code></td>
+              <td>${escapeHtml(String(payment.amount))}</td>
+              <td>${escapeHtml(String(payment.asset))}</td>
+              <td class="${escapeHtml(String(payment.status))}">${escapeHtml(String(payment.status))}</td>
+              <td><code style="font-size:10px">${escapeHtml(String(payment.transactionHash || "N/A"))}</code></td>
             </tr>
           `).join("")}
         </tbody>
@@ -142,9 +143,9 @@ export function generateReceiptHtml(batchResult: BatchResult): string {
         <tbody>
           ${failedPayments.map((payment) => `
             <tr>
-              <td><code style="font-size:11px">${payment.recipient}</code></td>
-              <td>${payment.amount}</td>
-              <td style="color:#ef4444">${payment.error || "Unknown error"}</td>
+              <td><code style="font-size:11px">${escapeHtml(String(payment.recipient))}</code></td>
+              <td>${escapeHtml(String(payment.amount))}</td>
+              <td style="color:#ef4444">${escapeHtml(String(payment.error || "Unknown error"))}</td>
             </tr>
           `).join("")}
         </tbody>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,27 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Escape user-controlled strings before interpolating them into HTML markup.
+ *
+ * Covers the five characters that can break both element content and
+ * double- or single-quoted attribute values:
+ *   &  →  &amp;
+ *   <  →  &lt;
+ *   >  →  &gt;
+ *   "  →  &quot;
+ *   '  →  &#039;
+ *
+ * Use this whenever building HTML strings from batch data (CSV imports,
+ * API responses, etc.) to prevent stored-XSS in downloaded receipts.
+ * See issue #347.
+ */
+export function escapeHtml(input: string): string {
+  return input
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}


### PR DESCRIPTION
HTML strings built by generateReceiptHtml() in lib/receipt-generator.ts were interpolating batch payment fields (recipient address, amount, asset, status, transactionHash, error messages, network) without any HTML entity escaping. A compromised CSV/JSON import (see #343) could therefore deliver a malicious payload that executes script when the downloaded receipt is opened in a browser or an HTML-aware email client.

Changes
-------
lib/utils.ts
  - Export a canonical escapeHtml() helper covering & < > " and ' (apostrophe / &#039;), with a doc-comment referencing #347.

lib/receipt-generator.ts
  - Import escapeHtml from @/lib/utils.
  - Wrap every user-controlled field in the HTML template: payment.recipient, payment.amount, payment.asset, payment.status (both as CSS class attribute *and* text content), payment.transactionHash, payment.error, batchResult.network.

components/dashboard/HistoryExportCenter.tsx
  - Remove the local escapeHtml duplicate (was missing apostrophe escaping).
  - Import the shared escapeHtml from @/lib/utils instead.
  - toPrintableHtml() already used escapeHtml on all dynamic fields; no field-level changes required there.

The CSV export path (downloadReceiptCsv) already double-quotes and escapes internal double-quotes per RFC 4180 — no change needed.

Closes #347
Closes #353
Closes #345
Closes #350