### PR TITLE
fix(batch-submit-signed): classify tx_bad_seq separately from fee err…

### DIFF
--- a/app/api/batch-submit-signed/route.ts
+++ b/app/api/batch-submit-signed/route.ts
@@ -14,6 +14,11 @@ import { TransactionBuilder, Horizon, Networks } from "stellar-sdk";
 import { safeJsonResponse } from "@/lib/safe-json";
 import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 import { horizonUrl } from "@/lib/stellar/network-config";
+import {
+    classifySubmitError,
+    isBadSequenceError,
+    isInsufficientFeeError,
+} from "@/lib/stellar/submit-errors";
 
 interface RequestBody {
     signedXdr: string;
@@ -33,17 +38,6 @@ async function getFeeStats(server: Horizon.Server): Promise<FeeStats> {
         console.error("Failed to fetch fee stats:", error);
         return {};
     }
-}
-
-function isInsufficientFeeError(error: unknown): boolean {
-    if (!error || typeof error !== "object") return false;
-    const horizonError = error as any;
-
-    const resultCodes = horizonError.response?.data?.extras?.result_codes;
-    if (!resultCodes) return false;
-
-    const txResult = resultCodes.transaction;
-    return txResult === "tx_insufficient_fee" || txResult === "tx_bad_seq";
 }
 
 export async function POST(request: NextRequest) {
@@ -94,6 +88,23 @@ export async function POST(request: NextRequest) {
                 ledger: result.ledger,
             }), rate);
         } catch (submissionError: unknown) {
+            // A stale/duplicate sequence number is NOT a fee problem: bumping
+            // the fee or resubmitting the same signed XDR can't fix it. Surface
+            // a structured "rebuild" action instead of fee guidance. (#330)
+            if (isBadSequenceError(submissionError)) {
+                const classified = classifySubmitError(submissionError);
+                return setRateLimitHeaders(safeJsonResponse(
+                    {
+                        success: false,
+                        error: classified.message,
+                        code: classified.code,
+                        action: classified.action,
+                        resultCodes: classified.resultCodes,
+                    },
+                    { status: 400 },
+                ), rate);
+            }
+
             // Check if this is a low-fee error and provide fee guidance
             if (isInsufficientFeeError(submissionError)) {
                 const feeStats = await getFeeStats(server);
@@ -105,6 +116,7 @@ export async function POST(request: NextRequest) {
                         success: false,
                         error: "Transaction fees are insufficient for current network conditions",
                         code: "insufficient_fee",
+                        action: "increase_fee",
                         currentNetworkFee: currentBaseFee,
                         estimatedRequiredFee: estimatedFee,
                         guidance: `Network base fee is ${currentBaseFee} stroops. Consider retrying with a fee of at least ${estimatedFee} stroops.`,

--- a/lib/stellar/submit-errors.ts
+++ b/lib/stellar/submit-errors.ts
@@ -1,0 +1,118 @@
+/**
+ * Classification helpers for Horizon transaction submission errors (#330).
+ *
+ * Horizon reports submission failures under
+ * `error.response.data.extras.result_codes`, with a top-level `transaction`
+ * code and a per-operation `operations` array. Different transaction codes
+ * call for very different remediation, so fee, sequence, and generic failures
+ * are kept separate instead of being lumped together.
+ *
+ * Previously `tx_bad_seq` was treated as a fee error, which told users to
+ * raise their fee when the real fix is to rebuild the transaction against a
+ * fresh account sequence.
+ */
+
+export interface HorizonResultCodes {
+    transaction?: string;
+    operations?: string[];
+}
+
+/** Stable codes returned to the client so the UI can branch on remediation. */
+export type SubmitErrorCode =
+    | "BAD_SEQ"
+    | "INSUFFICIENT_FEE"
+    | "TX_FAILED"
+    | "UNKNOWN";
+
+/** Suggested next step for the client/user. */
+export type SubmitErrorAction = "rebuild" | "increase_fee" | "review" | "retry";
+
+export interface ClassifiedSubmitError {
+    code: SubmitErrorCode;
+    message: string;
+    action: SubmitErrorAction;
+    /** Raw Horizon result codes, when available, for debugging/telemetry. */
+    resultCodes?: HorizonResultCodes;
+}
+
+/**
+ * Safely pull the Horizon `result_codes` object off an unknown error value.
+ * Returns `undefined` when the error is not a Horizon submission error.
+ */
+export function getResultCodes(error: unknown): HorizonResultCodes | undefined {
+    if (!error || typeof error !== "object") return undefined;
+    const resultCodes = (error as any).response?.data?.extras?.result_codes;
+    if (!resultCodes || typeof resultCodes !== "object") return undefined;
+    return resultCodes as HorizonResultCodes;
+}
+
+/**
+ * A bad sequence number means the transaction was built against a stale
+ * account sequence (e.g. another transaction consumed it, or it was signed
+ * against a stale sequence from the build step). Resubmitting the same signed
+ * XDR can never succeed — the transaction must be rebuilt against a fresh
+ * sequence and re-signed.
+ */
+export function isBadSequenceError(error: unknown): boolean {
+    return getResultCodes(error)?.transaction === "tx_bad_seq";
+}
+
+/**
+ * A fee-related failure: the offered fee was too low, possibly due to surge
+ * pricing. This is transient and worth retrying with a higher fee.
+ *
+ * Note: `tx_bad_seq` is deliberately NOT treated as a fee error here (#330).
+ */
+export function isInsufficientFeeError(error: unknown): boolean {
+    const txCode = getResultCodes(error)?.transaction;
+    return (
+        txCode === "tx_insufficient_fee" || txCode === "tx_fee_bump_inner_failed"
+    );
+}
+
+/**
+ * Map an arbitrary submission error to a structured, client-facing result with
+ * an actionable remediation hint.
+ */
+export function classifySubmitError(error: unknown): ClassifiedSubmitError {
+    const resultCodes = getResultCodes(error);
+
+    if (isBadSequenceError(error)) {
+        return {
+            code: "BAD_SEQ",
+            message:
+                "Transaction sequence number is out of date. Refresh the account sequence, rebuild the transaction, and sign again.",
+            action: "rebuild",
+            resultCodes,
+        };
+    }
+
+    if (isInsufficientFeeError(error)) {
+        return {
+            code: "INSUFFICIENT_FEE",
+            message:
+                "The transaction fee is too low, likely due to network surge pricing. Increase the fee and try again.",
+            action: "increase_fee",
+            resultCodes,
+        };
+    }
+
+    if (resultCodes) {
+        return {
+            code: "TX_FAILED",
+            message:
+                "The transaction was rejected by the network. Review the operation result codes for details.",
+            action: "review",
+            resultCodes,
+        };
+    }
+
+    return {
+        code: "UNKNOWN",
+        message:
+            error instanceof Error
+                ? error.message
+                : "An unexpected error occurred while submitting the transaction.",
+        action: "retry",
+    };
+}

--- a/tests/submit-errors.test.ts
+++ b/tests/submit-errors.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for Horizon submission error classification (#330).
+ *
+ * Regression: `tx_bad_seq` must NOT be reported as an insufficient-fee error,
+ * because the remediation is to rebuild against a fresh sequence — not to
+ * raise the fee.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+    classifySubmitError,
+    getResultCodes,
+    isBadSequenceError,
+    isInsufficientFeeError,
+} from "@/lib/stellar/submit-errors";
+
+/**
+ * Build an error shaped like a Horizon submission failure thrown by the
+ * Stellar SDK: `error.response.data.extras.result_codes`.
+ */
+function horizonError(resultCodes: {
+    transaction?: string;
+    operations?: string[];
+}) {
+    return {
+        response: {
+            data: {
+                extras: { result_codes: resultCodes },
+            },
+        },
+    };
+}
+
+describe("getResultCodes", () => {
+    it("extracts result_codes from a Horizon error", () => {
+        const err = horizonError({ transaction: "tx_bad_seq" });
+        expect(getResultCodes(err)).toEqual({ transaction: "tx_bad_seq" });
+    });
+
+    it("returns undefined for non-Horizon errors", () => {
+        expect(getResultCodes(new Error("network down"))).toBeUndefined();
+        expect(getResultCodes(undefined)).toBeUndefined();
+        expect(getResultCodes(null)).toBeUndefined();
+        expect(getResultCodes({})).toBeUndefined();
+    });
+});
+
+describe("isBadSequenceError", () => {
+    it("is true for tx_bad_seq", () => {
+        expect(
+            isBadSequenceError(horizonError({ transaction: "tx_bad_seq" })),
+        ).toBe(true);
+    });
+
+    it("is false for fee and other errors", () => {
+        expect(
+            isBadSequenceError(horizonError({ transaction: "tx_insufficient_fee" })),
+        ).toBe(false);
+        expect(isBadSequenceError(horizonError({ transaction: "tx_failed" }))).toBe(
+            false,
+        );
+        expect(isBadSequenceError(new Error("boom"))).toBe(false);
+    });
+});
+
+describe("isInsufficientFeeError", () => {
+    it("is true for tx_insufficient_fee and tx_fee_bump_inner_failed", () => {
+        expect(
+            isInsufficientFeeError(
+                horizonError({ transaction: "tx_insufficient_fee" }),
+            ),
+        ).toBe(true);
+        expect(
+            isInsufficientFeeError(
+                horizonError({ transaction: "tx_fee_bump_inner_failed" }),
+            ),
+        ).toBe(true);
+    });
+
+    it("is NOT true for tx_bad_seq (regression for #330)", () => {
+        expect(
+            isInsufficientFeeError(horizonError({ transaction: "tx_bad_seq" })),
+        ).toBe(false);
+    });
+
+    it("is false for unrelated errors", () => {
+        expect(
+            isInsufficientFeeError(horizonError({ transaction: "tx_failed" })),
+        ).toBe(false);
+        expect(isInsufficientFeeError(new Error("boom"))).toBe(false);
+    });
+});
+
+describe("classifySubmitError", () => {
+    it("classifies tx_bad_seq as BAD_SEQ with a rebuild action", () => {
+        const result = classifySubmitError(
+            horizonError({ transaction: "tx_bad_seq" }),
+        );
+        expect(result.code).toBe("BAD_SEQ");
+        expect(result.action).toBe("rebuild");
+        expect(result.message).toMatch(/sequence/i);
+        expect(result.message).not.toMatch(/fee/i);
+        expect(result.resultCodes).toEqual({ transaction: "tx_bad_seq" });
+    });
+
+    it("classifies tx_insufficient_fee as INSUFFICIENT_FEE with increase_fee action", () => {
+        const result = classifySubmitError(
+            horizonError({ transaction: "tx_insufficient_fee" }),
+        );
+        expect(result.code).toBe("INSUFFICIENT_FEE");
+        expect(result.action).toBe("increase_fee");
+        expect(result.message).toMatch(/fee/i);
+    });
+
+    it("classifies tx_failed as TX_FAILED with a review action", () => {
+        const result = classifySubmitError(
+            horizonError({
+                transaction: "tx_failed",
+                operations: ["op_underfunded"],
+            }),
+        );
+        expect(result.code).toBe("TX_FAILED");
+        expect(result.action).toBe("review");
+        expect(result.resultCodes).toEqual({
+            transaction: "tx_failed",
+            operations: ["op_underfunded"],
+        });
+    });
+
+    it("classifies a non-Horizon error as UNKNOWN with a retry action", () => {
+        const result = classifySubmitError(new Error("ECONNRESET"));
+        expect(result.code).toBe("UNKNOWN");
+        expect(result.action).toBe("retry");
+        expect(result.message).toBe("ECONNRESET");
+        expect(result.resultCodes).toBeUndefined();
+    });
+});


### PR DESCRIPTION
…ors (#330)

tx_bad_seq was lumped in with tx_insufficient_fee, so a stale/duplicate sequence number told users to raise their fee when the real fix is to rebuild the transaction against a fresh account sequence.

- Add lib/stellar/submit-errors.ts with isBadSequenceError, isInsufficientFeeError, and classifySubmitError returning structured { code, message, action, resultCodes }.
- Route now returns { code: "BAD_SEQ", action: "rebuild" } for bad-seq failures, before the fee branch; fee branch keeps its response shape and gains action: "increase_fee".
- Add Vitest cases for tx_bad_seq, tx_insufficient_fee, and tx_failed, including the regression that tx_bad_seq is not a fee error.

Closes: #330 