### PR TITLE
fix: convertedIndices filter, Horizon amount units, demo attribution, JSON sanitization

### DIFF
--- a/app/api/dashboard-metrics/route.ts
+++ b/app/api/dashboard-metrics/route.ts
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
       .call();
 
     let totalPayments = 0;
-    let totalAmountSent = 0; // in stroops for XLM
+    let totalAmountSent = 0; // in XLM display units (Horizon returns decimal strings)
     let assetCounts: { [key: string]: number } = {};
     let successfulPayments = 0;
 
@@ -82,8 +82,8 @@ export async function GET(request: NextRequest) {
 
         // Handle amount based on asset type
         if (op.asset_type === "native") {
-          // XLM amount in stroops
-          totalAmountSent += parseFloat(op.amount) * 10000000; // Convert to stroops
+          // Horizon returns amount as a human-readable decimal (e.g. "10.5000000") — no conversion needed
+          totalAmountSent += parseFloat(op.amount);
           assetCounts["XLM"] = (assetCounts["XLM"] || 0) + parseFloat(op.amount);
         } else {
           // Issued asset

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -126,8 +126,10 @@ export default function Home() {
       let failCount = 0;
       const startTime = new Date().toISOString();
 
-      // Calculate payments per batch for result attribution
-      const paymentsPerBatch = Math.min(MAX_OPS, payments.length);
+      // Calculate payments per batch for result attribution.
+      // Math.ceil(total / xdrCount) distributes payments evenly across XDRs,
+      // so e.g. 250 payments across 3 XDRs → 84 / 84 / 82 instead of 250 / 0 / 0.
+      const paymentsPerBatch = xdrs.length > 0 ? Math.ceil(payments.length / xdrs.length) : payments.length;
 
       for (let i = 0; i < xdrs.length; i++) {
         const xdr = xdrs[i];

--- a/components/dashboard/BatchReview.tsx
+++ b/components/dashboard/BatchReview.tsx
@@ -102,7 +102,7 @@ export function BatchReview({
     if (!publicKey) {
       return;
     }
-    const filteredPayments = payments.filter((_, idx) => !skippedIndices.includes(idx));
+    const filteredPayments = payments.filter((_, idx) => !skippedIndices.includes(idx) && !convertedIndices.includes(idx));
     setIsSubmitting(true);
     try {
       await onSubmit(filteredPayments);

--- a/lib/stellar/parser.ts
+++ b/lib/stellar/parser.ts
@@ -40,15 +40,15 @@ export function parseJSON(content: string): PaymentInstruction[] {
 
     return rawInstructions.map((item: Record<string, unknown>) => {
       const instruction: PaymentInstruction = {
-        address: String(item.address ?? ''),
-        amount: String(item.amount ?? ''),
-        asset: String(item.asset ?? ''),
+        address: sanitizeValue(String(item.address ?? '')),
+        amount: sanitizeValue(String(item.amount ?? '')),
+        asset: sanitizeValue(String(item.asset ?? '')),
       };
 
       if (item.memo != null && String(item.memo).trim() !== '') {
-        instruction.memo = String(item.memo).trim();
+        instruction.memo = sanitizeValue(String(item.memo).trim());
         if (item.memoType != null) {
-          const mt = String(item.memoType).toLowerCase();
+          const mt = sanitizeValue(String(item.memoType)).toLowerCase();
           if (mt === 'text' || mt === 'id' || mt === 'none') {
             instruction.memoType = mt as MemoType;
           }


### PR DESCRIPTION
Closes #324
Closes #325
Closes #327
Closes #343

## Changes

**components/dashboard/BatchReview.tsx**
- `handleSubmit` now filters `convertedIndices` in addition to `skippedIndices`, matching the existing validation filter — converted rows are no longer silently included in the submitted payload (#327)

**app/api/dashboard-metrics/route.ts**
- Removed `* 10000000` from XLM amount accumulation — Horizon returns `amount` as a human-readable decimal string, not stroops; totals now reflect actual XLM sent (#324)

**app/demo/page.tsx**
- `paymentsPerBatch` now computed as `Math.ceil(payments.length / xdrs.length)` so 250 payments across 3 XDRs maps as 84/84/82 instead of 250/0/0 — fixes mis-attributed tx hashes for batches >100 (#325)

**lib/stellar/parser.ts**
- `parseJSON` now runs `sanitizeValue()` on `address`, `amount`, `asset`, and `memo` fields, matching the existing CSV path and neutralizing formula-injection payloads in JSON uploads (#343)