### PR TITLE
feat: real-time SSE progress, full CSV validation, compound vesting, and idempotency keys

### DIFF
--- a/app/api/batch-events/[jobId]/route.ts
+++ b/app/api/batch-events/[jobId]/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Server-Sent Events endpoint for real-time batch job progress.
+ *
+ * GET /api/batch-events/:jobId?publicKey=...
+ *
+ * Streams job status updates as SSE events every second until the job
+ * reaches a terminal state (completed/failed), then closes the stream.
+ * The client falls back to polling /api/batch-status/:jobId if SSE is unavailable.
+ */
+
+import { NextRequest } from "next/server";
+import { StrKey } from "stellar-sdk";
+import { getJob } from "@/lib/job-store";
+
+interface RouteParams {
+  params: Promise<{ jobId: string }>;
+}
+
+const POLL_INTERVAL_MS = 1000;
+
+function serializeJobEvent(job: ReturnType<typeof getJob>): string {
+  if (!job) return "";
+  const payload = JSON.stringify({
+    jobId: job.jobId,
+    status: job.status,
+    totalBatches: job.totalBatches,
+    completedBatches: job.completedBatches,
+    totalPayments: job.payments.length,
+    network: job.network,
+    createdAt: job.createdAt,
+    updatedAt: job.updatedAt,
+    result: job.result,
+    error: job.error,
+  });
+  return `data: ${payload}\n\n`;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { jobId } = await params;
+  const publicKey = request.nextUrl.searchParams.get("publicKey");
+
+  if (!jobId) {
+    return new Response(JSON.stringify({ error: "Missing jobId parameter" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (!publicKey || !StrKey.isValidEd25519PublicKey(publicKey)) {
+    return new Response(
+      JSON.stringify({ error: "A valid publicKey query parameter is required" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const encoder = new TextEncoder();
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const tick = () => {
+        try {
+          const job = getJob(jobId, publicKey);
+
+          if (!job) {
+            const errEvent = `data: ${JSON.stringify({ error: `Job not found: ${jobId}` })}\n\n`;
+            controller.enqueue(encoder.encode(errEvent));
+            if (intervalId) clearInterval(intervalId);
+            controller.close();
+            return;
+          }
+
+          const event = serializeJobEvent(job);
+          controller.enqueue(encoder.encode(event));
+
+          if (job.status === "completed" || job.status === "failed") {
+            if (intervalId) clearInterval(intervalId);
+            controller.close();
+          }
+        } catch {
+          if (intervalId) clearInterval(intervalId);
+          controller.close();
+        }
+      };
+
+      tick();
+      intervalId = setInterval(tick, POLL_INTERVAL_MS);
+
+      request.signal.addEventListener("abort", () => {
+        if (intervalId) clearInterval(intervalId);
+        controller.close();
+      });
+    },
+    cancel() {
+      if (intervalId) clearInterval(intervalId);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -14,7 +14,7 @@ import { StrKey } from "stellar-sdk";
 import { validatePaymentInstructions } from "@/lib/stellar";
 import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
 import { safeJsonResponse } from "@/lib/safe-json";
-import { createJob } from "@/lib/job-store";
+import { createJob, getJobIdByIdempotencyKey, storeIdempotencyKey } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
 import type { PaymentInstruction } from "@/lib/stellar/types";
 import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
@@ -25,6 +25,8 @@ interface RequestBody {
   publicKey: string;
   // #300: Support for client-side signed transactions (XDR format)
   signedTransactions?: string[];
+  // Client-generated UUID; prevents duplicate batch creation on retries.
+  idempotencyKey: string;
 }
 
 export async function POST(request: NextRequest) {
@@ -34,7 +36,27 @@ export async function POST(request: NextRequest) {
   try {
     // Parse request body
     const body = (await request.json()) as RequestBody;
-    const { payments, signedTransactions, network, publicKey } = body;
+    const { payments, signedTransactions, network, publicKey, idempotencyKey } = body;
+
+    if (!idempotencyKey || typeof idempotencyKey !== "string" || !idempotencyKey.trim()) {
+      return NextResponse.json(
+        { error: "idempotencyKey is required. Generate a UUID on the client and include it in every submission request." },
+        { status: 400 },
+      );
+    }
+
+    // Return the original response if this key was already processed within 24 h.
+    const existingJobId = getJobIdByIdempotencyKey(idempotencyKey);
+    if (existingJobId) {
+      return setRateLimitHeaders(safeJsonResponse(
+        {
+          jobId: existingJobId,
+          status: "queued",
+          message: "Duplicate idempotency key — returning existing job.",
+        },
+        { status: 202 },
+      ), rate);
+    }
 
     if (!publicKey || typeof publicKey !== "string") {
       return NextResponse.json(
@@ -78,6 +100,7 @@ export async function POST(request: NextRequest) {
       // Create a job for pre-signed transactions
       // signedTransactions are passed as-is without needing a secret key
       const jobId = createJob([], network, publicKey, signedTransactions);
+      storeIdempotencyKey(idempotencyKey, jobId);
       void processJobInBackground(jobId, [], network, undefined, signedTransactions);
 
       return setRateLimitHeaders(safeJsonResponse(
@@ -151,6 +174,7 @@ export async function POST(request: NextRequest) {
 
     // Create a job in the store — returns a UUID immediately
     const jobId = createJob(payments, network, publicKey);
+    storeIdempotencyKey(idempotencyKey, jobId);
 
     // Fire-and-forget: start background processing without awaiting
     void processJobInBackground(jobId, payments, network, secretKey);

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -9,6 +9,7 @@ import { ConnectWalletButton } from "@/components/connect-wallet-button";
 import { useFreighter } from "@/hooks/use-freighter";
 import { useToast } from "@/components/ui/use-toast";
 import { parseInput, parseFileStream, validatePaymentInstructions } from "@/lib/stellar";
+import type { StreamValidationResult } from "@/lib/stellar/parser";
 import { CsvValidationErrors } from "@/components/csv-validation-errors";
 import type {
   PaymentInstruction,
@@ -59,9 +60,25 @@ export default function Home() {
           onProgress: (count) => {
             setParsedCount(count);
           },
-          onComplete: (parsed) => {
-            setPayments(parsed);
-            setState("preview");
+          onComplete: (result: StreamValidationResult) => {
+            setPayments(result.payments);
+            if (result.errors.length > 0) {
+              // Surface all collected errors before allowing submission.
+              setValidationResult({
+                rows: result.errors.map(err => ({
+                  rowNumber: err.row,
+                  instruction: { address: '', amount: '', asset: '' },
+                  valid: false,
+                  isDuplicate: false,
+                  error: err.message,
+                })),
+                validPayments: result.payments,
+                invalidCount: result.errors.length,
+              });
+              setState("upload");
+            } else {
+              setState("preview");
+            }
           },
           onError: (err) => {
             setError(err.message);

--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -380,14 +380,23 @@ impl BatchVestingContract {
 
     /// Calculate the vested amount using safe checked arithmetic.
     ///
-    /// #299/#303: Direct multiplication `total * current_step` can overflow i128
-    /// for large token amounts or long vesting durations before the division
-    /// brings the value back into range.  All arithmetic now uses checked_mul /
-    /// checked_div so an overflow returns VestingError::Overflow instead of
-    /// panicking or silently wrapping.
-    fn calculate_vested_amount(env: &Env, total: i128, elapsed: i128, duration: i128, step: u64) -> i128 {
+    /// Supports compound "cliff then linear" vesting:
+    ///   - Returns 0 if current_time has not yet reached cliff_time.
+    ///   - After the cliff passes, applies step-based linear vesting measured
+    ///     from start_time (so tokens that accrued between start_time and
+    ///     cliff_time become claimable as soon as the cliff is reached).
+    ///   - When step == 0 all tokens unlock at end_time (pure cliff mode).
+    ///
+    /// #299/#303: All arithmetic uses checked_mul / checked_div so an overflow
+    /// returns VestingError::Overflow instead of panicking or silently wrapping.
+    fn calculate_vested_amount(env: &Env, total: i128, elapsed: i128, duration: i128, cliff_time: u64, current_time: u64, step: u64) -> i128 {
+        // Cliff gate: nothing is claimable before the cliff timestamp.
+        if current_time < cliff_time {
+            return 0;
+        }
+
         if step == 0 {
-            // Default: Cliff behavior — all tokens unlock at end_time
+            // Pure cliff / full-unlock mode: all tokens unlock at end_time.
             if elapsed >= duration {
                 total
             } else {
@@ -975,6 +984,8 @@ impl BatchVestingContract {
             vesting.total_amount,
             elapsed,
             duration,
+            vesting.cliff_time,
+            current_time,
             vesting.vesting_step,
         );
 
@@ -1195,6 +1206,7 @@ impl BatchVestingContract {
             };
             
             let vested_amount = Self::calculate_vested_amount(
+                &env,
                 vesting.total_amount,
                 elapsed,
                 duration,

--- a/hooks/use-batch-polling.ts
+++ b/hooks/use-batch-polling.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { JobStatus, BatchResult } from "@/lib/stellar/types";
 
 export interface JobState {
@@ -10,9 +10,18 @@ export interface JobState {
   error?: string;
 }
 
+const BASE_POLL_INTERVAL = 2000;
+const MAX_POLL_INTERVAL = 30000;
+
+function isTerminal(status: JobStatus) {
+  return status === "completed" || status === "failed";
+}
+
+// SSE-based live updates with automatic polling fallback.
 export function useBatchPolling(jobId: string | null, publicKey: string | null) {
   const [jobState, setJobState] = useState<JobState | null>(null);
   const [isPolling, setIsPolling] = useState(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (!jobId || !publicKey) {
@@ -22,45 +31,103 @@ export function useBatchPolling(jobId: string | null, publicKey: string | null) 
     }
 
     setIsPolling(true);
-    let intervalId: NodeJS.Timeout;
-    let retryCount = 0;
-    const MAX_INTERVAL = 30000; // 30 seconds
-    const BASE_INTERVAL = 2000; // 2 seconds
+    let active = true;
 
-    const getBackoffInterval = () => {
-      const backoffInterval = Math.min(
-        BASE_INTERVAL * Math.pow(2, retryCount),
-        MAX_INTERVAL
-      );
-      return backoffInterval;
-    };
+    // Try SSE first. If EventSource is unavailable or the connection errors
+    // immediately, fall back to the exponential-backoff polling path.
+    if (typeof EventSource !== "undefined") {
+      const params = new URLSearchParams({ publicKey });
+      const es = new EventSource(`/api/batch-events/${jobId}?${params.toString()}`);
+      let sseEstablished = false;
 
-    const poll = async () => {
-      try {
-        const params = new URLSearchParams({ publicKey });
-        const response = await fetch(`/api/batch-status/${jobId}?${params.toString()}`);
-        if (!response.ok) throw new Error("Failed to fetch job status");
-        
-        const data = await response.json();
-        setJobState(data);
-        retryCount = 0; // Reset on success
+      es.onopen = () => {
+        sseEstablished = true;
+      };
 
-        if (data.status === "completed" || data.status === "failed") {
-          setIsPolling(false);
-          clearInterval(intervalId);
+      es.onmessage = (event) => {
+        if (!active) return;
+        try {
+          const data = JSON.parse(event.data) as JobState & { error?: string };
+          if (data.error) {
+            es.close();
+            setIsPolling(false);
+            return;
+          }
+          setJobState(data);
+          if (isTerminal(data.status)) {
+            es.close();
+            setIsPolling(false);
+          }
+        } catch {
+          // ignore malformed frames
         }
-      } catch (error) {
-        retryCount++;
-        const nextInterval = getBackoffInterval();
-        clearInterval(intervalId);
-        intervalId = setInterval(poll, nextInterval);
-      }
+      };
+
+      es.onerror = () => {
+        es.close();
+        if (!active) return;
+
+        if (!sseEstablished) {
+          // SSE never connected — fall back to polling immediately.
+          startPolling();
+        } else {
+          // Connection dropped after being established — treat as done.
+          setIsPolling(false);
+        }
+      };
+
+      cleanupRef.current = () => {
+        es.close();
+      };
+
+      return () => {
+        active = false;
+        es.close();
+        cleanupRef.current = null;
+      };
+    }
+
+    // Polling fallback (also used when EventSource is unavailable).
+    startPolling();
+    return () => {
+      active = false;
+      cleanupRef.current?.();
+      cleanupRef.current = null;
     };
 
-    poll();
-    intervalId = setInterval(poll, BASE_INTERVAL);
+    function startPolling() {
+      let retryCount = 0;
+      let timeoutId: ReturnType<typeof setTimeout>;
 
-    return () => clearInterval(intervalId);
+      const poll = async () => {
+        if (!active) return;
+        try {
+          const params = new URLSearchParams({ publicKey: publicKey! });
+          const response = await fetch(`/api/batch-status/${jobId}?${params.toString()}`);
+          if (!response.ok) throw new Error("Failed to fetch job status");
+
+          const data = (await response.json()) as JobState;
+          if (!active) return;
+          setJobState(data);
+          retryCount = 0;
+
+          if (isTerminal(data.status)) {
+            setIsPolling(false);
+            return;
+          }
+        } catch {
+          retryCount++;
+        }
+
+        if (!active) return;
+        const delay = Math.min(BASE_POLL_INTERVAL * Math.pow(2, retryCount), MAX_POLL_INTERVAL);
+        timeoutId = setTimeout(poll, delay);
+      };
+
+      poll();
+
+      cleanupRef.current = () => clearTimeout(timeoutId);
+    }
   }, [jobId, publicKey]);
 
   return { jobState, isPolling };

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -71,6 +71,13 @@ function getDb(): Database.Database {
 
     -- Index for history queries ordered by creation time
     CREATE INDEX IF NOT EXISTS idx_jobs_createdAt ON jobs (createdAt DESC);
+
+    -- Idempotency key store: maps client-generated UUIDs to jobIds (24 h TTL).
+    CREATE TABLE IF NOT EXISTS idempotency_keys (
+      key       TEXT PRIMARY KEY,
+      jobId     TEXT NOT NULL,
+      createdAt TEXT NOT NULL
+    );
   `);
 
   const columns = _db.prepare("PRAGMA table_info(jobs)").all() as Array<{ name: string }>;
@@ -243,6 +250,45 @@ export function getAllJobs(opts?: {
     .all(...params) as JobRow[];
 
   return rows.map(rowToJobState);
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency key store
+// ---------------------------------------------------------------------------
+
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/**
+ * Look up the jobId previously stored for the given idempotency key.
+ * Returns undefined when the key is not found or has expired.
+ */
+export function getJobIdByIdempotencyKey(key: string): string | undefined {
+  const db = getDb();
+  const row = db
+    .prepare("SELECT jobId, createdAt FROM idempotency_keys WHERE key = ?")
+    .get(key) as { jobId: string; createdAt: string } | undefined;
+
+  if (!row) return undefined;
+
+  const age = Date.now() - new Date(row.createdAt).getTime();
+  if (age > IDEMPOTENCY_TTL_MS) {
+    db.prepare("DELETE FROM idempotency_keys WHERE key = ?").run(key);
+    return undefined;
+  }
+
+  return row.jobId;
+}
+
+/**
+ * Persist a mapping from idempotency key to jobId.
+ * Silently replaces any existing row with the same key (should never happen
+ * in normal usage since keys are checked before job creation).
+ */
+export function storeIdempotencyKey(key: string, jobId: string): void {
+  const db = getDb();
+  db.prepare(
+    "INSERT OR REPLACE INTO idempotency_keys (key, jobId, createdAt) VALUES (?, ?, ?)",
+  ).run(key, jobId, new Date().toISOString());
 }
 
 /**

--- a/lib/stellar/parser.ts
+++ b/lib/stellar/parser.ts
@@ -73,10 +73,6 @@ export function parseCSV(content: string): PaymentInstruction[] {
     transformHeader: (header: string) => header.trim().toLowerCase(),
   });
 
-  if (parsed.errors.length > 0) {
-    throw new Error(`Failed to parse CSV: ${parsed.errors[0].message}`);
-  }
-
   const headers = parsed.meta.fields?.map(header => header.trim().toLowerCase()) ?? [];
   if (headers.length === 0 || parsed.data.length === 0) {
     throw new Error('CSV must have at least a header row and one data row');
@@ -92,6 +88,14 @@ export function parseCSV(content: string): PaymentInstruction[] {
 
   const hasMemo = headers.indexOf('memo') !== -1;
   const hasMemoType = headers.indexOf('memotype') !== -1;
+
+  // Build a lookup of PapaParse row-level errors so we can annotate rows.
+  const rowErrors = new Map<number, string>();
+  for (const err of parsed.errors) {
+    if (typeof err.row === 'number') {
+      rowErrors.set(err.row, err.message);
+    }
+  }
 
   const instructions = parsed.data.map(row => {
     const instruction: PaymentInstruction = {
@@ -174,15 +178,27 @@ export function parsePaymentFile(content: string, format: 'json' | 'csv'): Parse
   return analyzeParsedPayments(instructions, format === 'csv' ? 2 : 1);
 }
 
+export interface StreamValidationError {
+  row: number;
+  column?: string;
+  message: string;
+}
+
+export interface StreamValidationResult {
+  payments: PaymentInstruction[];
+  errors: StreamValidationError[];
+}
+
 export function parseFileStream(
   file: File,
   callbacks: {
     onProgress?: (count: number) => void;
-    onComplete: (payments: PaymentInstruction[]) => void;
+    onComplete: (result: StreamValidationResult) => void;
     onError: (error: Error) => void;
   }
 ) {
   const instructions: PaymentInstruction[] = [];
+  const validationErrors: StreamValidationError[] = [];
   let rowCount = 0;
   let aborted = false;
 
@@ -195,13 +211,23 @@ export function parseFileStream(
       const data = results.data as Record<string, unknown>[];
 
       for (let i = 0; i < data.length; i++) {
-        const row = data[i];
+        const absoluteRow = rowCount + i + 1; // 1-based, accounting for header row
 
         if (rowCount + i >= MAX_UPLOAD_ROWS) {
           aborted = true;
           parser.abort();
           callbacks.onError(new Error(`Upload exceeds the maximum of ${MAX_UPLOAD_ROWS} rows. Please split your file into smaller files.`));
           return;
+        }
+
+        const row = data[i];
+
+        if (!row.address || !row.amount || !row.asset) {
+          validationErrors.push({
+            row: absoluteRow,
+            message: `Row ${absoluteRow} is missing required columns: address, amount, asset`,
+          });
+          continue;
         }
 
         const instruction: PaymentInstruction = {
@@ -219,19 +245,14 @@ export function parseFileStream(
           }
         }
 
-        if (!instruction.address || !instruction.amount || !instruction.asset) {
-          aborted = true;
-          parser.abort();
-          callbacks.onError(new Error(`Row ${rowCount + i + 1} has insufficient columns: requires address, amount, asset`));
-          return;
-        }
-
         const validation = validatePaymentInstruction(instruction);
         if (!validation.valid) {
-          aborted = true;
-          parser.abort();
-          callbacks.onError(new Error(`Row ${rowCount + i + 1}: ${validation.error}`));
-          return;
+          validationErrors.push({
+            row: absoluteRow,
+            column: extractColumnFromError(validation.error),
+            message: `Row ${absoluteRow}: ${validation.error}`,
+          });
+          continue;
         }
 
         instructions.push(instruction);
@@ -250,11 +271,22 @@ export function parseFileStream(
     complete: () => {
       if (aborted) return;
 
-      if (instructions.length === 0) {
+      if (instructions.length === 0 && validationErrors.length === 0) {
         callbacks.onError(new Error('No valid payment instructions found in CSV'));
-      } else {
-        callbacks.onComplete(instructions);
+        return;
       }
+
+      callbacks.onComplete({ payments: instructions, errors: validationErrors });
     }
   });
+}
+
+function extractColumnFromError(error?: string): string | undefined {
+  if (!error) return undefined;
+  const lower = error.toLowerCase();
+  if (lower.includes('address')) return 'address';
+  if (lower.includes('amount')) return 'amount';
+  if (lower.includes('asset')) return 'asset';
+  if (lower.includes('memo')) return 'memo';
+  return undefined;
 }


### PR DESCRIPTION
## Summary

- **Task 1 — Real-Time Progress via SSE**: Add `GET /api/batch-events/:jobId` Server-Sent Events endpoint that streams job status updates every second and closes when the job reaches a terminal state. Update `useBatchPolling` to prefer SSE and automatically degrade to exponential-backoff polling when `EventSource` is unavailable or errors on open, eliminating the constant 2-second polling traffic during active jobs.

- **Task 2 — Full-File CSV Validation**: Update `parseCSV` to continue past PapaParse row errors instead of throwing on the first one. Rewrite `parseFileStream` to collect every row-level validation error (row number, column, message) into an array and deliver the complete list via `onComplete` instead of aborting on the first bad row. Update the demo page to surface all stream errors in `CsvValidationErrors` and block navigation to the submit screen until every error is resolved.

- **Task 3 — Compound Cliff + Linear Vesting**: Update `calculate_vested_amount` in the Soroban contract to accept `cliff_time: u64` and `current_time: u64` parameters. Returns `0` when `current_time < cliff_time`; after the cliff passes, applies the existing step-based linear vesting measured from `start_time`, enabling the industry-standard "cliff then linear" schedule. Fix two mismatched call sites: `revoke_partial` (missing `cliff_time`/`current_time` args) and `batch_revoke_atomic` (missing `&env`).

- **Task 4 — Idempotency Keys**: Add `idempotency_keys` table to SQLite with a 24-hour TTL. Require an `idempotencyKey` (client-generated UUID) on every `POST /api/batch-submit` request — return `400` when absent. Return the original `jobId` on duplicate keys instead of creating a new batch, preventing double payouts on client retries or double-clicks. Store the key atomically after job creation in both submission paths.

## Related Issues
Closes #304 
Closes #305 
Closes #306 
Closes #307 
