### PR TITLE
Fix theming, Ledger transport, loading states, and address migration

### DIFF
--- a/app/dashboard/history/loading.tsx
+++ b/app/dashboard/history/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function HistoryLoading() {
+  return (
+    <div className="container max-w-7xl mx-auto py-8 space-y-6" aria-label="Loading batch history">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-9 w-52" />
+          <Skeleton className="h-5 w-96 max-w-full" />
+        </div>
+        <Skeleton className="h-10 w-36" />
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-6">
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Skeleton className="h-10 w-full sm:w-80" />
+          <Skeleton className="h-10 w-full sm:w-40" />
+        </div>
+
+        <div className="space-y-3">
+          <div className="grid grid-cols-5 gap-4 border-b border-border pb-3">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <Skeleton key={index} className="h-4 w-full" />
+            ))}
+          </div>
+          {Array.from({ length: 8 }).map((_, rowIndex) => (
+            <div key={rowIndex} className="grid grid-cols-5 gap-4 py-3">
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-8 w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function DashboardLoading() {
+  return (
+    <div className="container max-w-7xl mx-auto py-8 space-y-6" aria-label="Loading dashboard">
+      <div className="space-y-2">
+        <Skeleton className="h-9 w-56" />
+        <Skeleton className="h-5 w-80 max-w-full" />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="rounded-xl border border-border bg-card p-6 space-y-4">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-8 w-32" />
+            <Skeleton className="h-4 w-40" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 rounded-xl border border-border bg-card p-6 space-y-4">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-72 w-full" />
+        </div>
+        <div className="rounded-xl border border-border bg-card p-6 space-y-4">
+          <Skeleton className="h-6 w-36" />
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-3">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/dashboard/new-batch/page.tsx
+++ b/app/dashboard/new-batch/page.tsx
@@ -313,15 +313,15 @@ export default function NewBatchPaymentPage() {
               style={{ width: `${((step - 1) / (steps.length - 1)) * 100}%` }}
             />
             {steps.map((s) => (
-              <div key={s.id} className="flex flex-col items-center gap-2 bg-[#0B0F1A] px-2 md:px-4">
+              <div key={s.id} className="flex flex-col items-center gap-2 bg-background px-2 md:px-4">
                 <button
                   disabled={step < s.id && (s.id > 1 && (!validationResult || !summary))}
                   onClick={() => setStep(s.id)}
                   className={`w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm transition-colors border-2 outline-hidden disabled:cursor-not-allowed ${step > s.id
                       ? "bg-emerald-500 border-emerald-500 text-white cursor-pointer hover:bg-emerald-600"
                       : step === s.id
-                        ? "bg-[#0B0F1A] border-emerald-500 text-emerald-500"
-                        : "bg-[#0B0F1A] border-slate-700 text-slate-500"
+                        ? "bg-background border-emerald-500 text-emerald-500"
+                        : "bg-background border-border text-muted-foreground"
                     }`}
                 >
                   {step > s.id ? <Check className="w-4 h-4" /> : s.id}

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Card,
   CardContent,
@@ -18,22 +18,29 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useWallet } from "@/contexts/WalletContext";
-import { Copy, Wallet, Layers } from "lucide-react";
+import { Copy, Wallet, Layers, Monitor, Moon, Sun } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { AccountProfileCard } from "@/components/dashboard/settings/AccountProfileCard";
 import { NotificationsCard } from "@/components/dashboard/settings/NotificationsCard";
 import { DangerZoneCard } from "@/components/dashboard/settings/DangerZoneCard";
 import { SecuritySettingsCard } from "@/components/dashboard/settings/SecuritySettingsCard";
 import { ApiDeveloperCard } from "@/components/dashboard/settings/ApiDeveloperCard";
+import { useTheme } from "next-themes";
 
 export default function SettingsPage() {
   const { publicKey, connect, disconnect, isConnecting } = useWallet();
+  const { theme, setTheme } = useTheme();
   const { toast } = useToast();
 
   const [defaultNetwork, setDefaultNetwork] = useState<string>("testnet");
   const [defaultAsset, setDefaultAsset] = useState<string>("xlm");
   const [batchValidation, setBatchValidation] = useState(true);
   const [completionNotifications, setCompletionNotifications] = useState(true);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const handleCopyAddress = () => {
     if (publicKey) {
@@ -57,8 +64,8 @@ export default function SettingsPage() {
   return (
     <div className="container max-w-7xl mx-auto py-8 space-y-6">
       <div>
-        <h1 className="text-3xl font-bold text-white mb-2">Settings</h1>
-        <p className="text-slate-400">
+        <h1 className="text-3xl font-bold text-foreground mb-2">Settings</h1>
+        <p className="text-muted-foreground">
           Manage your account settings and preferences
         </p>
       </div>
@@ -74,6 +81,50 @@ export default function SettingsPage() {
         </div>
       </div>
 
+      {/* Theme Preferences Section */}
+      <Card className="border-border bg-card text-card-foreground">
+        <CardHeader>
+          <div className="flex items-start gap-4">
+            <div className="p-3 bg-emerald-500/10 rounded-lg">
+              <Sun className="w-6 h-6 text-emerald-500" />
+            </div>
+            <div className="flex-1">
+              <CardTitle className="text-2xl text-card-foreground">
+                Appearance
+              </CardTitle>
+              <CardDescription className="text-muted-foreground">
+                Choose how Stellar BatchPay adapts to your display preferences
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            {[
+              { value: "light", label: "Light", icon: Sun },
+              { value: "dark", label: "Dark", icon: Moon },
+              { value: "system", label: "System", icon: Monitor },
+            ].map((option) => {
+              const Icon = option.icon;
+              const selected = mounted && theme === option.value;
+
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={selected ? "default" : "outline"}
+                  className="justify-start gap-3"
+                  aria-pressed={selected}
+                  onClick={() => setTheme(option.value)}
+                >
+                  <Icon className="h-4 w-4" />
+                  {option.label}
+                </Button>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Wallet Connection Section */}
       <Card className="bg-slate-900/50 border-slate-800">

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -22,10 +22,10 @@ export default function Error({
   }, [error]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-[#0B0F1A] p-4">
+    <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <Card className="max-w-md w-full bg-card border-border">
         <CardHeader>
-          <CardTitle className="text-2xl font-bold text-center text-white">
+          <CardTitle className="text-2xl font-bold text-center text-card-foreground">
             Something went wrong!
           </CardTitle>
         </CardHeader>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`font-sans antialiased bg-[#0B0F1A] text-white`}>
+      <body className="font-sans antialiased bg-background text-foreground">
         <ThemeProvider
           attribute="class"
           defaultTheme="dark"

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -8,7 +8,7 @@ import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
 export function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
     <SidebarProvider defaultOpen={true}>
-      <div className="flex min-h-screen w-full bg-[#0B0F1A]">
+      <div className="flex min-h-screen w-full bg-background text-foreground">
         <AppSidebar />
         <SidebarInset className="flex flex-col bg-transparent">
           <AppHeader />

--- a/contexts/AddressBookContext.tsx
+++ b/contexts/AddressBookContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState, useCallback } from "react";
+import { useToast } from "@/hooks/use-toast";
 
 export interface AddressBookEntry {
     address: string;
@@ -18,76 +19,135 @@ interface AddressBookContextType {
 
 const AddressBookContext = createContext<AddressBookContextType | undefined>(undefined);
 
-const STORAGE_KEY = "batchpay_address_book";
+const STORAGE_KEY = "stellar-batch-pay-address-book";
+const LEGACY_STORAGE_KEYS = ["batchpay_address_book"];
+
+type StoredAddressBookEntry = {
+    id?: string;
+    address?: unknown;
+    name?: unknown;
+    addedAt?: unknown;
+};
+
+function normalizeStoredEntries(raw: string | null): AddressBookEntry[] {
+    if (!raw) return [];
+
+    try {
+        const parsed = JSON.parse(raw) as StoredAddressBookEntry[];
+        if (!Array.isArray(parsed)) return [];
+
+        return parsed.flatMap((entry) => {
+            if (typeof entry.address !== "string" || typeof entry.name !== "string") {
+                return [];
+            }
+
+            return [{
+                address: entry.address,
+                name: entry.name,
+                addedAt: typeof entry.addedAt === "number" ? entry.addedAt : 0,
+            }];
+        });
+    } catch (err) {
+        console.error("Failed to parse address book:", err);
+        return [];
+    }
+}
+
+function mergeAddressBookEntries(entryGroups: AddressBookEntry[][]) {
+    const merged = new Map<string, AddressBookEntry>();
+    let importedCount = 0;
+
+    entryGroups.forEach((entries, groupIndex) => {
+        entries.forEach((entry) => {
+            const existing = merged.get(entry.address);
+            const shouldUseEntry = !existing || entry.addedAt >= existing.addedAt;
+
+            if (shouldUseEntry) {
+                merged.set(entry.address, entry);
+            }
+
+            if (groupIndex > 0 && shouldUseEntry) {
+                importedCount += 1;
+            }
+        });
+    });
+
+    return {
+        entries: Array.from(merged.values()).sort((a, b) => b.addedAt - a.addedAt),
+        importedCount,
+    };
+}
 
 export function AddressBookProvider({ children }: { children: React.ReactNode }) {
-    const [entries, setEntries] = useState<Record<string, string>>({});
+    const { toast } = useToast();
+    const [entries, setEntries] = useState<AddressBookEntry[]>([]);
     const [initialized, setInitialized] = useState(false);
 
-    // Load from localStorage on mount
+    // Load and migrate from localStorage on mount
     useEffect(() => {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-            try {
-                const parsed = JSON.parse(stored) as any[];
-                const mapping: Record<string, string> = {};
-                parsed.forEach(entry => {
-                    if (entry.address && entry.name) {
-                        mapping[entry.address] = String(entry.name);
-                    }
-                });
-                setEntries(mapping);
-            } catch (err) {
-                console.error("Failed to parse address book:", err);
-            }
+        const canonicalEntries = normalizeStoredEntries(localStorage.getItem(STORAGE_KEY));
+        const legacyEntries = LEGACY_STORAGE_KEYS.map((key) => normalizeStoredEntries(localStorage.getItem(key)));
+        const { entries: mergedEntries, importedCount } = mergeAddressBookEntries([
+            canonicalEntries,
+            ...legacyEntries,
+        ]);
+
+        setEntries(mergedEntries);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(mergedEntries));
+        LEGACY_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
+
+        if (importedCount > 0) {
+            toast({
+                title: `Imported ${importedCount} contacts`,
+                description: "Contacts from previous storage were merged into your address book.",
+            });
+            console.info(`Imported ${importedCount} contacts from legacy address book storage.`);
         }
+
         setInitialized(true);
-    }, []);
+    }, [toast]);
 
     // Persist to localStorage when entries change
     useEffect(() => {
         if (!initialized) return;
 
-        const entryList: AddressBookEntry[] = Object.entries(entries).map(([address, name]) => ({
-            address,
-            name,
-            addedAt: Date.now(),
-        }));
-
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(entryList));
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
     }, [entries, initialized]);
 
     const getName = useCallback((address: string) => {
-        return entries[address] || null;
+        return entries.find((entry) => entry.address === address)?.name || null;
     }, [entries]);
 
     const saveName = useCallback((address: string, name: string) => {
-        setEntries(prev => ({
-            ...prev,
-            [address]: name
-        }));
-    }, []);
-
-    const removeEntry = useCallback((address: string) => {
         setEntries(prev => {
-            const next = { ...prev };
-            delete next[address];
-            return next;
+            const now = Date.now();
+            const exists = prev.some((entry) => entry.address === address);
+
+            if (!exists) {
+                return [...prev, { address, name, addedAt: now }];
+            }
+
+            return prev.map((entry) => (
+                entry.address === address ? { ...entry, name, addedAt: now } : entry
+            ));
         });
     }, []);
 
-    const allEntries: AddressBookEntry[] = Object.entries(entries).map(([address, name]) => ({
-        address,
-        name,
-        addedAt: 0,
-    }));
+    const removeEntry = useCallback((address: string) => {
+        setEntries(prev => prev.filter((entry) => entry.address !== address));
+    }, []);
+
+    const entryMap = entries.reduce<Record<string, string>>((mapping, entry) => {
+        mapping[entry.address] = entry.name;
+        return mapping;
+    }, {});
 
     const value: AddressBookContextType = {
-        entries,
+        entries: entryMap,
         getName,
         saveName,
         removeEntry,
-        allEntries,
+        allEntries: entries,
     };
 
     return (

--- a/hooks/use-address-book.ts
+++ b/hooks/use-address-book.ts
@@ -4,29 +4,76 @@ export interface Contact {
   id: string;
   name: string;
   address: string;
+  addedAt?: number;
 }
 
 const STORAGE_KEY = 'stellar-batch-pay-address-book';
+const LEGACY_STORAGE_KEY = 'batchpay_address_book';
+
+const parseContacts = (raw: string | null): Contact[] => {
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.flatMap((contact) => {
+      if (typeof contact.name !== 'string' || typeof contact.address !== 'string') {
+        return [];
+      }
+
+      return [{
+        id: typeof contact.id === 'string' ? contact.id : crypto.randomUUID(),
+        name: contact.name,
+        address: contact.address,
+        addedAt: typeof contact.addedAt === 'number' ? contact.addedAt : 0,
+      }];
+    });
+  } catch (e) {
+    console.error('Failed to parse address book:', e);
+    return [];
+  }
+};
+
+const mergeContactsByNewestAddress = (contacts: Contact[]) => {
+  const merged = new Map<string, Contact>();
+
+  contacts.forEach((contact) => {
+    const existing = merged.get(contact.address);
+    if (!existing || (contact.addedAt ?? 0) >= (existing.addedAt ?? 0)) {
+      merged.set(contact.address, contact);
+    }
+  });
+
+  return Array.from(merged.values()).sort((a, b) => (b.addedAt ?? 0) - (a.addedAt ?? 0));
+};
 
 export function useAddressBook() {
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      try {
-        setContacts(JSON.parse(saved));
-      } catch (e) {
-        console.error('Failed to parse address book:', e);
-      }
-    }
+    const canonicalContacts = parseContacts(localStorage.getItem(STORAGE_KEY));
+    const legacyContacts = parseContacts(localStorage.getItem(LEGACY_STORAGE_KEY));
+    const mergedContacts = mergeContactsByNewestAddress([
+      ...canonicalContacts,
+      ...legacyContacts,
+    ]);
+
+    setContacts(mergedContacts);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mergedContacts));
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
     setIsLoading(false);
   }, []);
 
   const saveContacts = (newContacts: Contact[]) => {
-    setContacts(newContacts);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(newContacts));
+    const normalizedContacts = newContacts.map((contact) => ({
+      ...contact,
+      addedAt: contact.addedAt ?? Date.now(),
+    }));
+
+    setContacts(normalizedContacts);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(normalizedContacts));
   };
 
   const addContact = (name: string, address: string) => {
@@ -34,13 +81,14 @@ export function useAddressBook() {
       id: crypto.randomUUID(),
       name,
       address,
+      addedAt: Date.now(),
     };
     saveContacts([...contacts, newContact]);
   };
 
   const updateContact = (id: string, name: string, address: string) => {
     saveContacts(
-      contacts.map((c) => (c.id === id ? { ...c, name, address } : c))
+      contacts.map((c) => (c.id === id ? { ...c, name, address, addedAt: Date.now() } : c))
     );
   };
 
@@ -75,6 +123,7 @@ export function useAddressBook() {
                 id: newContact.id || crypto.randomUUID(),
                 name: newContact.name,
                 address: newContact.address,
+                addedAt: newContact.addedAt || Date.now(),
               });
             }
           });

--- a/hooks/use-ledger.ts
+++ b/hooks/use-ledger.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useToast } from "./use-toast";
+
+type LedgerTransport = {
+  close: () => Promise<void> | void;
+};
 
 export interface LedgerState {
   isConnected: boolean;
@@ -13,6 +17,8 @@ export interface LedgerState {
 
 export function useLedger() {
   const { toast } = useToast();
+  const transportRef = useRef<LedgerTransport | null>(null);
+  const signQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [state, setState] = useState<LedgerState>({
     isConnected: false,
     isConnecting: false,
@@ -21,20 +27,33 @@ export function useLedger() {
     deviceInfo: null,
   });
 
+  const closeTransport = useCallback(async () => {
+    const transport = transportRef.current;
+    transportRef.current = null;
+
+    if (transport) {
+      await transport.close();
+    }
+  }, []);
+
+  const getTransport = useCallback(async () => {
+    if (transportRef.current) {
+      return transportRef.current;
+    }
+
+    const { default: TransportWebUSB } = await import("@ledgerhq/hw-transport-webusb");
+    const transport = await TransportWebUSB.create();
+    transportRef.current = transport;
+    return transport;
+  }, []);
+
   const connect = useCallback(async () => {
     setState((prev) => ({ ...prev, isConnecting: true, error: null }));
 
+    const { default: StellarApp } = await import("@ledgerhq/hw-app-str");
+
     try {
-      // Dynamically import Ledger libraries to avoid SSR issues
-      const { default: TransportWebUSB } = await import("@ledgerhq/hw-transport-webusb").catch(() => {
-        throw new Error("WebUSB transport not available");
-      });
-
-      const { default: StellarApp } = await import("@ledgerhq/hw-app-str").catch(() => {
-        throw new Error("Stellar Ledger app not available");
-      });
-
-      const transport = await TransportWebUSB.create();
+      const transport = await getTransport();
       const stellar = new StellarApp(transport);
 
       // Get app info to verify Stellar app is open
@@ -61,6 +80,10 @@ export function useLedger() {
 
       return result.publicKey;
     } catch (error) {
+      await closeTransport().catch((closeError) => {
+        console.warn("Failed to close Ledger transport after connection error:", closeError);
+      });
+
       let errorMessage = "Failed to connect to Ledger";
 
       if (error instanceof Error) {
@@ -92,48 +115,69 @@ export function useLedger() {
 
       return null;
     }
-  }, [toast]);
+  }, [closeTransport, getTransport, toast]);
+
+  const runQueuedSign = useCallback(<T,>(task: () => Promise<T>): Promise<T> => {
+    const run = signQueueRef.current.then(task, task);
+    signQueueRef.current = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }, []);
 
   const signTransaction = useCallback(async (xdr: string): Promise<string> => {
     if (!state.isConnected) {
       throw new Error("Ledger not connected");
     }
 
-    try {
-      const { default: TransportWebUSB } = await import("@ledgerhq/hw-transport-webusb");
+    return runQueuedSign(async () => {
       const { default: StellarApp } = await import("@ledgerhq/hw-app-str");
 
-      const transport = await TransportWebUSB.create();
-      const stellar = new StellarApp(transport);
+      try {
+        const transport = await getTransport();
+        const stellar = new StellarApp(transport);
 
-      // Sign the transaction using Ledger
-      const result = await stellar.signTransaction("44'/148'/0'", xdr);
+        // Sign the transaction using Ledger. Chrome, Edge, and Opera are the
+        // supported WebUSB browsers for Ledger signing.
+        const result = await stellar.signTransaction("44'/148'/0'", xdr);
 
-      return result.signedTxXdr;
-    } catch (error) {
-      let errorMessage = "Failed to sign transaction with Ledger";
+        await closeTransport();
 
-      if (error instanceof Error) {
-        if (error.message.includes("Transaction approval request")) {
-          errorMessage = "Transaction was rejected on Ledger device";
-        } else if (error.message.includes("locked")) {
-          errorMessage = "Device locked. Please unlock your Ledger and try again.";
-        } else {
-          errorMessage = error.message;
+        return result.signedTxXdr;
+      } catch (error) {
+        await closeTransport().catch((closeError) => {
+          console.warn("Failed to close Ledger transport after signing error:", closeError);
+        });
+
+        let errorMessage = "Failed to sign transaction with Ledger";
+
+        if (error instanceof Error) {
+          if (error.message.includes("Transaction approval request")) {
+            errorMessage = "Transaction was rejected on Ledger device";
+          } else if (error.message.includes("locked")) {
+            errorMessage = "Device locked. Please unlock your Ledger and try again.";
+          } else {
+            errorMessage = error.message;
+          }
         }
+
+        toast({
+          title: "Ledger Signing Failed",
+          description: errorMessage,
+          variant: "destructive",
+        });
+
+        throw new Error(errorMessage);
       }
+    });
+  }, [closeTransport, getTransport, runQueuedSign, state.isConnected, toast]);
 
-      toast({
-        title: "Ledger Signing Failed",
-        description: errorMessage,
-        variant: "destructive",
-      });
+  const disconnect = useCallback(async () => {
+    await closeTransport().catch((error) => {
+      console.warn("Failed to close Ledger transport on disconnect:", error);
+    });
 
-      throw new Error(errorMessage);
-    }
-  }, [state.isConnected, toast]);
-
-  const disconnect = useCallback(() => {
     setState({
       isConnected: false,
       isConnecting: false,
@@ -141,9 +185,17 @@ export function useLedger() {
       error: null,
       deviceInfo: null,
     });
-  }, []);
+  }, [closeTransport]);
 
-  // Check if WebUSB is available
+  useEffect(() => {
+    return () => {
+      void closeTransport().catch((error) => {
+        console.warn("Failed to close Ledger transport on unmount:", error);
+      });
+    };
+  }, [closeTransport]);
+
+  // Check if WebUSB is available. Ledger WebUSB signing is supported in Chromium browsers.
   const isWebUSBSupported = typeof navigator !== "undefined" && "usb" in navigator;
 
   return {


### PR DESCRIPTION
## Summary
- Replaced hardcoded dark shell/background classes with theme tokens and added a Settings appearance selector powered by next-themes.
- Reworked Ledger WebUSB handling to retain/reuse a transport during the session, serialize signing requests, and close transports after sign, disconnect, errors, and unmount.
- Added route-level loading skeletons for dashboard and history navigation.
- Added one-time address book migration from legacy localStorage into the canonical key, with newest-contact merge behavior, cleanup, toast notification, and console logging.

## Testing
- `git diff --check`
- `rg -n 'bg-\[#0B0F1A\]' app components hooks contexts -S || true`
- `bun install` (blocked by registry 403 for eslint-config-next and @playwright/test in this environment)
- `npm test -- --runInBand` (blocked because dependencies/vitest are not installed)
- `npx tsc --noEmit --ignoreDeprecations 6.0` (blocked because dependencies/types are not installed in this environment)

Closes #416
Closes #417
Closes #424
Closes #430