### PR TITLE
Fix history search/date filters and route View Details to dashboard page

### DIFF
--- a/app/api/batch-history/route.ts
+++ b/app/api/batch-history/route.ts
@@ -4,10 +4,13 @@
  * Returns paginated batch job history from the durable SQLite store.
  *
  * Query params:
- *   page    – 1-based page number (default 1)
- *   limit   – rows per page (default 20, max 100)
- *   status  – filter by job status (queued | processing | completed | failed)
- *   network – filter by network (testnet | mainnet)
+ *   page      – 1-based page number (default 1)
+ *   limit     – rows per page (default 20, max 100)
+ *   status    – filter by job status (queued | processing | completed | failed)
+ *   network   – filter by network (testnet | mainnet)
+ *   search    – substring match on jobId, payments JSON, or result JSON
+ *   from      – ISO timestamp; include jobs with createdAt >= from
+ *   to        – ISO timestamp; include jobs with createdAt <= to
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -15,6 +18,13 @@ import { StrKey } from "stellar-sdk";
 import { getAllJobs, countJobs } from "@/lib/job-store";
 import { safeJsonResponse } from "@/lib/safe-json";
 import type { JobStatus } from "@/lib/stellar/types";
+
+function parseIsoTimestamp(value: string | null): string | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed.toISOString();
+}
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -25,7 +35,10 @@ export async function GET(request: NextRequest) {
 
   const rawStatus  = searchParams.get("status");
   const rawNetwork = searchParams.get("network");
-  const publicKey = searchParams.get("publicKey");
+  const publicKey  = searchParams.get("publicKey");
+  const search     = searchParams.get("search")?.trim() || undefined;
+  const from       = parseIsoTimestamp(searchParams.get("from"));
+  const to         = parseIsoTimestamp(searchParams.get("to"));
 
   if (!publicKey || !StrKey.isValidEd25519PublicKey(publicKey)) {
     return NextResponse.json(
@@ -39,9 +52,11 @@ export async function GET(request: NextRequest) {
   const network = rawNetwork === "testnet" || rawNetwork === "mainnet" ? rawNetwork : undefined;
 
   try {
+    const filters = { status, network, publicKey, search, from, to };
+
     const [jobs, total] = [
-      getAllJobs({ limit, offset, status, network, publicKey }),
-      countJobs({ status, network, publicKey }),
+      getAllJobs({ limit, offset, ...filters }),
+      countJobs(filters),
     ];
 
     // Strip the full payments array from the list response to keep payloads small.

--- a/app/dashboard/history/[jobId]/page.tsx
+++ b/app/dashboard/history/[jobId]/page.tsx
@@ -29,33 +29,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
+import { useWallet } from "@/contexts/WalletContext";
 import {
   buildBatchExportRows,
   toBatchExportCsv,
   toBatchExportHtml,
 } from "@/lib/dashboard/batch-export";
-
-interface JobStatusResponse {
-  jobId: string;
-  status: "queued" | "processing" | "completed" | "failed";
-  network: "testnet" | "mainnet";
-  createdAt?: string;
-  completedAt?: string;
-  totalBatches?: number;
-  completedBatches?: number;
-  summary?: {
-    successful: number;
-    failed: number;
-  };
-  recipients?: Array<{
-    address: string;
-    amount: string;
-    asset: string;
-    status: "pending" | "success" | "failed";
-    transactionHash?: string;
-    error?: string;
-  }>;
-}
+import {
+  mapBatchStatusToDetailView,
+  type BatchDetailView,
+} from "@/lib/dashboard/batch-detail";
 
 function explorerUrl(hash: string, network: "testnet" | "mainnet"): string {
   const base =
@@ -82,7 +65,8 @@ export default function BatchDetailPage({
 }) {
   const { jobId } = use(params);
   const router = useRouter();
-  const [data, setData] = useState<JobStatusResponse | null>(null);
+  const { publicKey } = useWallet();
+  const [data, setData] = useState<BatchDetailView | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [retrying, setRetrying] = useState(false);
@@ -90,26 +74,37 @@ export default function BatchDetailPage({
 
   useEffect(() => {
     let cancelled = false;
+
+    if (!publicKey) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
     async function load() {
       setLoading(true);
+      setError(null);
       try {
-        const res = await fetch(`/api/batch-status/${jobId}`);
+        const params = new URLSearchParams({ publicKey });
+        const res = await fetch(`/api/batch-status/${jobId}?${params.toString()}`);
         if (!res.ok) {
           throw new Error(`Failed to load batch (HTTP ${res.status})`);
         }
-        const body = (await res.json()) as JobStatusResponse;
-        if (!cancelled) setData(body);
+        const body = await res.json();
+        if (!cancelled) setData(mapBatchStatusToDetailView(body));
       } catch (e) {
         if (!cancelled) setError((e as Error).message);
       } finally {
         if (!cancelled) setLoading(false);
       }
     }
+
     load();
     return () => {
       cancelled = true;
     };
-  }, [jobId]);
+  }, [jobId, publicKey]);
 
   const handleRetry = async () => {
     if (!data?.summary?.failed) {
@@ -188,10 +183,13 @@ export default function BatchDetailPage({
               <Loader2 className="h-4 w-4 animate-spin" /> Loading job…
             </div>
           )}
+          {!loading && !publicKey && (
+            <p className="text-gray-400">Connect your wallet to view batch details.</p>
+          )}
           {error && <p className="text-red-300">{error}</p>}
           {data && (
             <div className="grid sm:grid-cols-3 gap-4 text-sm">
-              <Metric label="Recipients" value={data.recipients?.length ?? 0} />
+              <Metric label="Recipients" value={data.recipients.length} />
               <Metric
                 label="Successful"
                 value={data.summary?.successful ?? 0}
@@ -265,7 +263,7 @@ export default function BatchDetailPage({
                 </tr>
               </thead>
               <tbody>
-                {(data.recipients ?? []).map((r, i) => (
+                {data.recipients.map((r, i) => (
                   <tr key={`${r.address}-${i}`} className="border-b border-[#1F2937]/50">
                     <td className="py-3 pr-4 font-mono text-xs text-gray-300 break-all">
                       {r.address}

--- a/app/dashboard/history/page.tsx
+++ b/app/dashboard/history/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { MotionSafe } from "@/components/motion-safe";
 import {
   HistoryFilterBar,
@@ -12,6 +12,7 @@ import { Pagination } from "@/components/dashboard/Pagination";
 import { MetricsGrid } from "@/components/dashboard/MetricsGrid";
 import { HistoryExportCenter } from "@/components/dashboard/HistoryExportCenter";
 import { Card, CardContent } from "@/components/ui/card";
+import { dateRangeToFrom } from "@/lib/history-filters";
 
 // #360: filter + pagination state is owned by the page so the
 // HistoryTable query and Pagination controls actually react to user
@@ -24,12 +25,17 @@ const DEFAULT_LIMIT = 10;
 export default function HistoryPage() {
   const [filters, setFilters] = useState<HistoryFilterValues>(DEFAULT_HISTORY_FILTERS);
   const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
   // Reset to page 1 whenever the filters change so a 5-page result
   // doesn't trap the user on page 3 of an empty filtered view.
   const handleFiltersChange = (next: HistoryFilterValues) => {
     setFilters(next);
     setPage(1);
   };
+
+  const handlePaginationLoad = useCallback(({ totalPages: nextTotalPages }: { totalPages: number; total: number }) => {
+    setTotalPages(Math.max(1, nextTotalPages));
+  }, []);
 
   return (
     <MotionSafe
@@ -60,19 +66,14 @@ export default function HistoryPage() {
             limit={DEFAULT_LIMIT}
             statusFilter={filters.status === "all" ? undefined : filters.status}
             networkFilter={filters.network === "all" ? undefined : filters.network}
+            searchFilter={filters.search}
+            fromFilter={dateRangeToFrom(filters.dateRange)}
+            onPaginationLoad={handlePaginationLoad}
           />
           <div className="px-4 pb-4 sm:px-0 sm:pb-0">
-            {/*
-              HistoryTable owns its own paged fetch, so the page count
-              is what the API reports through `useBatchHistory`. For
-              the MVP we assume a 10-page upper bound; once the API
-              starts returning a real total this number can come from
-              the table via a callback. The buttons themselves are
-              fully wired regardless.
-            */}
             <Pagination
               currentPage={page}
-              totalPages={10}
+              totalPages={totalPages}
               onPageChange={setPage}
             />
           </div>

--- a/components/dashboard/HistoryTable.tsx
+++ b/components/dashboard/HistoryTable.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { ExternalLink, ChevronDown, Loader2 } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useWallet } from "@/contexts/WalletContext"
@@ -27,6 +28,9 @@ interface HistoryTableProps {
   limit?: number
   statusFilter?: string
   networkFilter?: string
+  searchFilter?: string
+  fromFilter?: string
+  onPaginationLoad?: (pagination: { totalPages: number; total: number }) => void
 }
 
 function formatDate(iso: string): string {
@@ -55,11 +59,32 @@ function deriveDisplayStatus(batch: HistoricalBatch): "Success" | "Partial" | "F
   return "Success"
 }
 
-export function HistoryTable({ data, className, page = 1, limit = 20, statusFilter, networkFilter }: HistoryTableProps) {
+export function HistoryTable({
+  data,
+  className,
+  page = 1,
+  limit = 20,
+  statusFilter,
+  networkFilter,
+  searchFilter,
+  fromFilter,
+  onPaginationLoad,
+}: HistoryTableProps) {
+  const router = useRouter()
   const { publicKey } = useWallet()
   const [rows, setRows]       = useState<HistoricalBatch[]>(data ?? [])
   const [loading, setLoading] = useState(!data)
   const [error, setError]     = useState<string | null>(null)
+  const [debouncedSearch, setDebouncedSearch] = useState(searchFilter ?? "")
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchFilter ?? ""), 300)
+    return () => clearTimeout(timer)
+  }, [searchFilter])
+
+  const openBatchDetail = (jobId: string) => {
+    router.push(`/dashboard/history/${jobId}`)
+  }
 
   useEffect(() => {
     if (data) {
@@ -84,16 +109,24 @@ export function HistoryTable({ data, className, page = 1, limit = 20, statusFilt
     })
     if (statusFilter)  params.set("status",  statusFilter)
     if (networkFilter) params.set("network", networkFilter)
+    if (debouncedSearch.trim()) params.set("search", debouncedSearch.trim())
+    if (fromFilter) params.set("from", fromFilter)
 
     fetch(`/api/batch-history?${params.toString()}`)
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`)
-        return r.json() as Promise<{ items: HistoricalBatch[] }>
+        return r.json() as Promise<{
+          items: HistoricalBatch[]
+          pagination: { totalPages: number; total: number }
+        }>
       })
-      .then((body) => setRows(body.items))
+      .then((body) => {
+        setRows(body.items)
+        onPaginationLoad?.(body.pagination)
+      })
       .catch((e: unknown) => setError(e instanceof Error ? e.message : "Failed to load history"))
       .finally(() => setLoading(false))
-  }, [data, page, limit, statusFilter, networkFilter, publicKey])
+  }, [data, page, limit, statusFilter, networkFilter, debouncedSearch, fromFilter, publicKey, onPaginationLoad])
 
   if (loading) {
     return (
@@ -187,7 +220,7 @@ export function HistoryTable({ data, className, page = 1, limit = 20, statusFilt
                     <Button
                       variant="link"
                       className="text-[#00D98B] hover:text-[#00D98B]/80 p-0 h-auto font-medium"
-                      onClick={() => window.open(`/api/batch-status/${batch.jobId}?publicKey=${encodeURIComponent(publicKey ?? "")}`, "_blank")}
+                      onClick={() => openBatchDetail(batch.jobId)}
                     >
                       View Details
                     </Button>
@@ -253,9 +286,9 @@ export function HistoryTable({ data, className, page = 1, limit = 20, statusFilt
                 <Button
                   variant="link"
                   className="text-[#00D98B] hover:text-[#00D98B]/80 p-0 h-auto text-xs font-semibold"
-                  onClick={() => window.open(`/api/batch-status/${batch.jobId}?publicKey=${encodeURIComponent(publicKey ?? "")}`, "_blank")}
+                  onClick={() => openBatchDetail(batch.jobId)}
                 >
-                  View Details <ExternalLink className="ml-1 h-3 w-3" />
+                  View Details <ChevronRight className="ml-1 h-3 w-3" />
                 </Button>
               </div>
             </div>

--- a/lib/dashboard/batch-detail.ts
+++ b/lib/dashboard/batch-detail.ts
@@ -1,0 +1,62 @@
+import type { BatchResult, PaymentResult } from "@/lib/stellar/types";
+
+export interface BatchDetailRecipient {
+  address: string;
+  amount: string;
+  asset: string;
+  status: "pending" | "success" | "failed";
+  transactionHash?: string;
+  error?: string;
+}
+
+export interface BatchDetailView {
+  jobId: string;
+  status: "queued" | "processing" | "completed" | "failed";
+  network: "testnet" | "mainnet";
+  createdAt?: string;
+  completedAt?: string;
+  totalBatches?: number;
+  completedBatches?: number;
+  summary?: {
+    successful: number;
+    failed: number;
+  };
+  recipients: BatchDetailRecipient[];
+}
+
+interface BatchStatusApiResponse {
+  jobId: string;
+  status: "queued" | "processing" | "completed" | "failed";
+  network: "testnet" | "mainnet";
+  createdAt?: string;
+  updatedAt?: string;
+  totalBatches?: number;
+  completedBatches?: number;
+  result?: BatchResult;
+}
+
+function mapPaymentResult(result: PaymentResult): BatchDetailRecipient {
+  return {
+    address: result.recipient,
+    amount: result.amount,
+    asset: result.asset,
+    status: result.status,
+    transactionHash: result.transactionHash,
+    error: result.error,
+  };
+}
+
+/** Normalise GET /api/batch-status/:jobId into the dashboard detail view shape. */
+export function mapBatchStatusToDetailView(body: BatchStatusApiResponse): BatchDetailView {
+  return {
+    jobId: body.jobId,
+    status: body.status,
+    network: body.network,
+    createdAt: body.createdAt,
+    completedAt: body.updatedAt,
+    totalBatches: body.totalBatches,
+    completedBatches: body.completedBatches,
+    summary: body.result?.summary,
+    recipients: (body.result?.results ?? []).map(mapPaymentResult),
+  };
+}

--- a/lib/history-filters.ts
+++ b/lib/history-filters.ts
@@ -1,0 +1,20 @@
+import type { DateRangeValue } from "@/components/dashboard/HistoryFilterBar";
+
+const DATE_RANGE_DAYS: Record<DateRangeValue, number> = {
+  "7days": 7,
+  "30days": 30,
+  "90days": 90,
+  year: 365,
+};
+
+/** Convert a preset date-range filter into an ISO `from` timestamp for createdAt. */
+export function dateRangeToFrom(dateRange: DateRangeValue): string {
+  const from = new Date();
+  from.setUTCDate(from.getUTCDate() - DATE_RANGE_DAYS[dateRange]);
+  return from.toISOString();
+}
+
+/** Escape `%` and `_` so user input is treated literally in SQL LIKE patterns. */
+export function escapeLikePattern(input: string): string {
+  return input.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
+}

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -30,6 +30,7 @@ import type {
   PaymentInstruction,
   BatchResult,
 } from "./stellar/types";
+import { escapeLikePattern } from "./history-filters";
 
 // ---------------------------------------------------------------------------
 // DB initialisation
@@ -201,19 +202,22 @@ export function updateJob(
   );
 }
 
-/**
- * Return all jobs ordered by creation time descending (newest first).
- * Accepts optional filters for the batch history endpoint.
- */
-export function getAllJobs(opts?: {
-  limit?: number;
-  offset?: number;
+export interface JobQueryFilters {
   status?: JobStatus;
   network?: "testnet" | "mainnet";
   publicKey?: string;
-}): JobState[] {
-  const db = getDb();
+  /** Case-insensitive substring match on jobId, payments JSON, or result JSON. */
+  search?: string;
+  /** ISO timestamp — include jobs with createdAt >= from. */
+  from?: string;
+  /** ISO timestamp — include jobs with createdAt <= to. */
+  to?: string;
+}
 
+function buildJobQueryFilters(opts?: JobQueryFilters): {
+  where: string;
+  params: (string | number)[];
+} {
   const conditions: string[] = [];
   const params: (string | number)[] = [];
 
@@ -229,18 +233,44 @@ export function getAllJobs(opts?: {
     conditions.push("publicKey = ?");
     params.push(opts.publicKey);
   }
+  if (opts?.from) {
+    conditions.push("createdAt >= ?");
+    params.push(opts.from);
+  }
+  if (opts?.to) {
+    conditions.push("createdAt <= ?");
+    params.push(opts.to);
+  }
+  if (opts?.search?.trim()) {
+    const term = `%${escapeLikePattern(opts.search.trim())}%`;
+    conditions.push(
+      "(jobId LIKE ? ESCAPE '\\' OR COALESCE(result, '') LIKE ? ESCAPE '\\' OR payments LIKE ? ESCAPE '\\')",
+    );
+    params.push(term, term, term);
+  }
 
   const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  return { where, params };
+}
+
+/**
+ * Return all jobs ordered by creation time descending (newest first).
+ * Accepts optional filters for the batch history endpoint.
+ */
+export function getAllJobs(opts?: JobQueryFilters & {
+  limit?: number;
+  offset?: number;
+}): JobState[] {
+  const db = getDb();
+  const { where, params } = buildJobQueryFilters(opts);
   const limit = opts?.limit ?? 50;
   const offset = opts?.offset ?? 0;
-
-  params.push(limit, offset);
 
   const rows = db
     .prepare(
       `SELECT * FROM jobs ${where} ORDER BY createdAt DESC LIMIT ? OFFSET ?`,
     )
-    .all(...params) as JobRow[];
+    .all(...params, limit, offset) as JobRow[];
 
   return rows.map(rowToJobState);
 }
@@ -248,30 +278,9 @@ export function getAllJobs(opts?: {
 /**
  * Return the total count of jobs (optionally filtered).
  */
-export function countJobs(opts?: {
-  status?: JobStatus;
-  network?: "testnet" | "mainnet";
-  publicKey?: string;
-}): number {
+export function countJobs(opts?: JobQueryFilters): number {
   const db = getDb();
-
-  const conditions: string[] = [];
-  const params: (string | number)[] = [];
-
-  if (opts?.status) {
-    conditions.push("status = ?");
-    params.push(opts.status);
-  }
-  if (opts?.network) {
-    conditions.push("network = ?");
-    params.push(opts.network);
-  }
-  if (opts?.publicKey) {
-    conditions.push("publicKey = ?");
-    params.push(opts.publicKey);
-  }
-
-  const where = conditions.length ? `WHERE ${conditions.join(" AND ")}` : "";
+  const { where, params } = buildJobQueryFilters(opts);
   const row = db
     .prepare(`SELECT COUNT(*) as cnt FROM jobs ${where}`)
     .get(...params) as { cnt: number };

--- a/tests/batch-detail.test.ts
+++ b/tests/batch-detail.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { mapBatchStatusToDetailView } from "../lib/dashboard/batch-detail";
+
+describe("mapBatchStatusToDetailView", () => {
+  test("maps batch-status API payload into dashboard detail recipients", () => {
+    const view = mapBatchStatusToDetailView({
+      jobId: "job-123",
+      status: "completed",
+      network: "testnet",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:05:00.000Z",
+      totalBatches: 2,
+      completedBatches: 2,
+      result: {
+        batchId: "job-123",
+        totalRecipients: 1,
+        totalAmount: "10",
+        totalTransactions: 1,
+        network: "testnet",
+        timestamp: "2026-05-01T00:05:00.000Z",
+        results: [
+          {
+            recipient: "GAAA",
+            amount: "10",
+            asset: "XLM",
+            status: "success",
+            transactionHash: "abc123",
+          },
+        ],
+        summary: { successful: 1, failed: 0 },
+      },
+    });
+
+    expect(view.recipients).toEqual([
+      {
+        address: "GAAA",
+        amount: "10",
+        asset: "XLM",
+        status: "success",
+        transactionHash: "abc123",
+        error: undefined,
+      },
+    ]);
+    expect(view.summary).toEqual({ successful: 1, failed: 0 });
+    expect(view.completedAt).toBe("2026-05-01T00:05:00.000Z");
+  });
+});

--- a/tests/history-filters.test.ts
+++ b/tests/history-filters.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+import { dateRangeToFrom } from "../lib/history-filters";
+
+describe("dateRangeToFrom", () => {
+  test("returns an ISO timestamp in the past", () => {
+    const now = Date.now();
+    const from = dateRangeToFrom("7days");
+    const parsed = Date.parse(from);
+    expect(parsed).toBeLessThan(now);
+    expect(now - parsed).toBeGreaterThanOrEqual(6 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -214,4 +214,24 @@ describe("Job Store — getAllJobs / countJobs", () => {
     const page = getAllJobs({ limit: 3, offset: 0 });
     expect(page.length).toBeLessThanOrEqual(3);
   });
+
+  test("search filter matches jobId substring", () => {
+    const jobId = createJob(samplePayments, "testnet", OWNER_PUBLIC_KEY);
+    const matches = getAllJobs({ search: jobId.slice(0, 8), publicKey: OWNER_PUBLIC_KEY });
+    expect(matches.some((job) => job.jobId === jobId)).toBe(true);
+  });
+
+  test("search filter matches recipient address in payments JSON", () => {
+    const address = samplePayments[0]?.address ?? "GSEARCHMATCH";
+    const jobId = createJob(samplePayments, "testnet", OWNER_PUBLIC_KEY);
+    const matches = getAllJobs({ search: address, publicKey: OWNER_PUBLIC_KEY });
+    expect(matches.some((job) => job.jobId === jobId)).toBe(true);
+  });
+
+  test("from date filter excludes older jobs", () => {
+    const jobId = createJob(samplePayments, "testnet", OWNER_PUBLIC_KEY);
+    const futureFrom = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    const matches = getAllJobs({ from: futureFrom, publicKey: OWNER_PUBLIC_KEY });
+    expect(matches.some((job) => job.jobId === jobId)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #409 and #410 by making history filters functional end-to-end and routing "View Details" to the formatted dashboard page instead of raw JSON.

- **#410 — Search & date filters:** Extend `GET /api/batch-history` with `search`, `from`, and `to` query params backed by SQLite filtering on `jobId`, `payments`, `result`, and `createdAt`. Wire the History page filter bar through `HistoryTable` (with debounced search) and drive pagination from the API's real `totalPages`.
- **#409 — View Details routing:** Replace `window.open('/api/batch-status/...')` with in-app navigation to `/dashboard/history/[jobId]`. Update the detail page to fetch with the connected wallet's `publicKey` and map the batch-status API response into the dashboard detail view shape.

## Changes

| Area | File(s) | What changed |
|------|---------|--------------|
| API | `app/api/batch-history/route.ts` | Accept `search`, `from`, `to` params |
| Store | `lib/job-store.ts` | Shared filter builder for search/date |
| Filters | `lib/history-filters.ts` | Date-range → ISO `from` helper |
| Detail mapping | `lib/dashboard/batch-detail.ts` | Map API payload → dashboard view |
| History page | `app/dashboard/history/page.tsx` | Pass search/date filters; real pagination |
| History table | `components/dashboard/HistoryTable.tsx` | Query new params; `router.push` for details |
| Detail page | `app/dashboard/history/[jobId]/page.tsx` | Wallet-scoped fetch + response mapping |
| Tests | `tests/job-store.test.ts`, `tests/batch-detail.test.ts`, `tests/history-filters.test.ts` | Coverage for new behavior |

## Test plan

- [ ] Connect wallet and open `/dashboard/history`
- [ ] Type a batch ID prefix or recipient address in **Search Batch** — table updates after debounce
- [ ] Change **Date Range** (7/30/90 days, year) — results narrow to recent batches
- [ ] Confirm **Network** and **Status** filters still work alongside search/date
- [ ] Paginate through results — page count reflects API `totalPages`, not a fixed 10
- [ ] Click **View Details** on a batch — navigates to `/dashboard/history/[jobId]` (not raw JSON tab)
- [ ] On detail page, verify recipient table, explorer links, and export buttons render
- [ ] Disconnect wallet on detail page — shows "Connect your wallet" prompt
- [ ] Run unit tests: `npx vitest run tests/job-store.test.ts tests/batch-detail.test.ts tests/history-filters.test.ts`

Closes #409
Closes #410