### PR TITLE
fix(#319, #320): shared parseAsset for issued assets + batch-recover SQLite integration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,10 +89,12 @@ Secret keys come from environment variables, never from configuration files. Thi
 
 If you need special handling for a specific asset:
 
-1. Update `batcher.ts` parseAsset() function
+1. Update `parseAsset()` in `lib/stellar/utils.ts` — this is the **single shared parser** used by both `batcher.ts` and `server.ts`
 2. Add validation in `validator.ts`
 3. Update type definitions in `types.ts`
 4. Add tests in `tests/`
+
+> **Important — server-side signing:** `StellarService` in `server.ts` (used by `/api/batch-submit` with `STELLAR_SECRET_KEY`) builds payment operations by calling `parseAsset` from `lib/stellar/utils.ts`. This shared parser handles `"XLM"`, `"native"`, and `"CODE:ISSUER"` strings. Do **not** introduce a local `parseAsset` in `server.ts`; doing so will break issued-asset batches (USDC, etc.) on the server-submit path.
 
 ### Adding Rate Limiting
 

--- a/app/api/batch-recover/route.ts
+++ b/app/api/batch-recover/route.ts
@@ -24,7 +24,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const job = getJob(jobId);
+    const publicKey = searchParams.get("publicKey") ?? undefined;
+    const job = getJob(jobId, publicKey);
 
     if (!job || !job.result) {
       return safeJsonResponse(

--- a/lib/stellar/batcher.ts
+++ b/lib/stellar/batcher.ts
@@ -4,7 +4,6 @@
 
 import {
   Account,
-  Asset as StellarAsset,
   Memo,
   Networks,
   Operation,
@@ -14,8 +13,9 @@ import {
 } from 'stellar-sdk';
 import Big from 'big.js';
 
-import { PaymentInstruction, Asset } from './types';
+import { PaymentInstruction } from './types';
 import { getRecommendedFee } from './fee-service';
+import { parseAsset } from './utils';
 
 export interface Batch {
   transactionIndex: number;
@@ -63,11 +63,7 @@ export async function simulateBatchTransactionSize(
     }).addMemo(Memo.text('batch-size-check'));
 
     for (const payment of payments) {
-      const asset = parseAsset(payment.asset);
-      const stellarAsset =
-        asset.issuer === null
-          ? StellarAsset.native()
-          : new StellarAsset(asset.code, asset.issuer);
+      const stellarAsset = parseAsset(payment.asset);
 
       builder = builder.addOperation(
         Operation.payment({
@@ -118,11 +114,7 @@ export function estimateBatchTransactionSize(
   }).addMemo(Memo.text('batch-size-check'));
 
   for (const payment of payments) {
-    const asset = parseAsset(payment.asset);
-    const stellarAsset =
-      asset.issuer === null
-        ? StellarAsset.native()
-        : new StellarAsset(asset.code, asset.issuer);
+    const stellarAsset = parseAsset(payment.asset);
 
     builder = builder.addOperation(
       Operation.payment({
@@ -217,23 +209,6 @@ export async function createBatches(
   return batches;
 }
 
-/**
- * Parse asset string to code and issuer
- */
-export function parseAsset(assetString: string): Asset {
-  if (assetString === 'XLM') {
-    return {
-      code: 'XLM',
-      issuer: null,
-    };
-  }
-
-  const [code, issuer] = assetString.split(':');
-  return {
-    code,
-    issuer,
-  };
-}
 
 import { validatePaymentInstruction } from './validator';
 

--- a/lib/stellar/server.ts
+++ b/lib/stellar/server.ts
@@ -27,22 +27,8 @@ import {
 } from "./validator";
 import { getRecommendedFee } from "./fee-service";
 import Big from "big.js";
-import { parseStellarAmount, formatStellarAmount } from "./utils";
-
-/**
- * Utility to parse asset input into a StellarAsset instance
- */
-export function parseAsset(asset: any): StellarAsset {
-  if (asset === "XLM" || asset === "native") {
-    return StellarAsset.native();
-  }
-
-  if (!asset.code || !asset.issuer) {
-    throw new Error("Invalid asset: must provide code and issuer");
-  }
-
-  return new StellarAsset(asset.code, asset.issuer);
-}
+import { parseStellarAmount, formatStellarAmount, parseAsset } from "./utils";
+export { parseAsset };
 
 export class StellarService {
   private keypair: Keypair;

--- a/lib/stellar/utils.ts
+++ b/lib/stellar/utils.ts
@@ -1,4 +1,5 @@
 import Big from 'big.js'
+import { Asset as StellarAsset } from 'stellar-sdk'
 
 /**
  * Formats a Stellar amount string or number to show up to 7 decimal places
@@ -113,4 +114,43 @@ export function sumStellarAmounts(amounts: string[]): Big {
     (acc, amount) => acc.plus(parseStellarAmount(amount)),
     new Big(0)
   )
+}
+
+/**
+ * Parses an asset string into a stellar-sdk Asset instance.
+ * Accepts "XLM" / "native" for the native asset, or "CODE:ISSUER" for issued assets.
+ *
+ * @param asset - Asset string or object with { code, issuer }
+ * @returns A stellar-sdk Asset instance
+ * @throws {Error} If the input cannot be resolved to a valid asset
+ *
+ * @example
+ * parseAsset("XLM")                          // → Asset.native()
+ * parseAsset("USDC:GBUQWP3B...")             // → new Asset("USDC", "GBUQWP3B...")
+ * parseAsset({ code: "USDC", issuer: "G…" }) // → new Asset("USDC", "G…")
+ */
+export function parseAsset(asset: string | { code: string; issuer: string | null }): StellarAsset {
+  if (typeof asset === 'string') {
+    if (asset === 'XLM' || asset === 'native') {
+      return StellarAsset.native()
+    }
+    const colonIndex = asset.indexOf(':')
+    if (colonIndex === -1) {
+      throw new Error(`Invalid asset string "${asset}": expected "CODE:ISSUER" or "XLM"`)
+    }
+    const code = asset.slice(0, colonIndex)
+    const issuer = asset.slice(colonIndex + 1)
+    if (!code || !issuer) {
+      throw new Error(`Invalid asset string "${asset}": code and issuer must be non-empty`)
+    }
+    return new StellarAsset(code, issuer)
+  }
+
+  if (!asset.code || asset.issuer === undefined) {
+    throw new Error('Invalid asset object: must provide code and issuer')
+  }
+  if (asset.issuer === null || asset.code === 'XLM') {
+    return StellarAsset.native()
+  }
+  return new StellarAsset(asset.code, asset.issuer)
 }

--- a/tests/batch-recover.test.ts
+++ b/tests/batch-recover.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Integration tests for GET /api/batch-recover (#320).
+ *
+ * Verifies that the route reads from SQLite (job-store) — not IndexedDB —
+ * and returns the correct HTTP status codes.
+ */
+
+import { beforeEach, describe, expect, test } from "vitest";
+
+process.env.JOB_STORE_PATH = ":memory:";
+
+import { createJob, updateJob } from "@/lib/job-store";
+import { GET } from "@/app/api/batch-recover/route";
+import type { BatchResult } from "@/lib/stellar/types";
+
+const PUBLIC_KEY = "GDQERHRWJYV7JHRP5V7DWJVI6Y5ABZP3YRH7DKYJRBEGJQKE6IQEOSY2";
+
+const completedResult: BatchResult = {
+  batchId: "test-batch",
+  totalRecipients: 2,
+  totalAmount: "30.0000000",
+  totalTransactions: 1,
+  network: "testnet",
+  timestamp: new Date().toISOString(),
+  results: [
+    { recipient: "GAAA", amount: "10.0000000", asset: "XLM", status: "success", transactionHash: "abc" },
+    { recipient: "GBBB", amount: "20.0000000", asset: "XLM", status: "failed",  transactionHash: undefined, error: "op_no_destination" },
+  ],
+  summary: { successful: 1, failed: 1 },
+};
+
+function makeRequest(params: Record<string, string>) {
+  const url = new URL("http://localhost/api/batch-recover");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new Request(url.toString());
+}
+
+describe("GET /api/batch-recover", () => {
+  let jobId: string;
+
+  beforeEach(() => {
+    jobId = createJob([], "testnet", PUBLIC_KEY);
+    updateJob(jobId, { status: "completed", result: completedResult });
+  });
+
+  test("returns 200 with recovery data for a completed SQLite job", async () => {
+    const res = await GET(makeRequest({ jobId }) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.batch.jobId).toBe(jobId);
+    expect(body.progress.total).toBe(2);
+    expect(body.progress.successful).toBe(1);
+    expect(body.progress.failed).toBe(1);
+    expect(body.failedTransactions).toHaveLength(1);
+    expect(body.successfulTransactions).toHaveLength(1);
+    expect(body.ready).toBe(true);
+  });
+
+  test("returns 404 for an unknown jobId", async () => {
+    const res = await GET(makeRequest({ jobId: "does-not-exist" }) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBeDefined();
+  });
+
+  test("returns 400 when jobId is missing", async () => {
+    const res = await GET(makeRequest({}) as never);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/jobId/i);
+  });
+
+  test("returns 404 when publicKey does not match the job owner", async () => {
+    const res = await GET(makeRequest({ jobId, publicKey: "GCCC" }) as never);
+
+    expect(res.status).toBe(404);
+  });
+
+  test("returns 200 when publicKey matches the job owner", async () => {
+    const res = await GET(makeRequest({ jobId, publicKey: PUBLIC_KEY }) as never);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/batcher.test.ts
+++ b/tests/batcher.test.ts
@@ -8,8 +8,8 @@ import {
   createBatches,
   estimateBatchTransactionSize,
   getBatchSummary,
-  parseAsset,
 } from '../lib/stellar/batcher';
+import { parseAsset } from '../lib/stellar/utils';
 
 const firstAddress = Keypair.random().publicKey();
 const secondAddress = Keypair.random().publicKey();
@@ -100,20 +100,19 @@ describe('Batch Creation', () => {
 describe('Asset Parsing', () => {
   test('parses native XLM', () => {
     const asset = parseAsset('XLM');
-    expect(asset.code).toBe('XLM');
-    expect(asset.issuer).toBeNull();
+    expect(asset.isNative()).toBe(true);
   });
 
   test('parses issued asset', () => {
     const asset = parseAsset(`USDC:${issuerAddress}`);
-    expect(asset.code).toBe('USDC');
-    expect(asset.issuer).toBe(issuerAddress);
+    expect(asset.getCode()).toBe('USDC');
+    expect(asset.getIssuer()).toBe(issuerAddress);
   });
 
   test('parses asset with long code', () => {
     const asset = parseAsset(`LONGCODE123:${issuerAddress}`);
-    expect(asset.code).toBe('LONGCODE123');
-    expect(asset.issuer).toBe(issuerAddress);
+    expect(asset.getCode()).toBe('LONGCODE123');
+    expect(asset.getIssuer()).toBe(issuerAddress);
   });
 });
 

--- a/tests/server-submit-batch.test.ts
+++ b/tests/server-submit-batch.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Integration test for StellarService.submitBatch — verifies that both XLM
+ * and issued assets (e.g. USDC) are correctly parsed and submitted (#319).
+ */
+
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { Asset as StellarAsset, Keypair } from 'stellar-sdk';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockSubmitTransaction = vi.fn();
+const mockLoadAccount = vi.fn();
+const mockFetchBaseFee = vi.fn().mockResolvedValue(100);
+
+vi.mock('stellar-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('stellar-sdk')>();
+
+  class MockServer {
+    loadAccount = mockLoadAccount;
+    submitTransaction = mockSubmitTransaction;
+    fetchBaseFee = mockFetchBaseFee;
+    feeStats = vi.fn().mockResolvedValue({
+      fee_charged: { p90: '100' },
+    });
+  }
+
+  return {
+    ...actual,
+    Horizon: {
+      ...actual.Horizon,
+      Server: MockServer,
+    },
+  };
+});
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SOURCE_KEYPAIR = Keypair.random();
+const RECIPIENT_1 = Keypair.random().publicKey();
+const RECIPIENT_2 = Keypair.random().publicKey();
+const RECIPIENT_3 = Keypair.random().publicKey();
+const USDC_ISSUER = Keypair.random().publicKey();
+
+const payments = [
+  { address: RECIPIENT_1, amount: '10.0000000', asset: 'XLM' },
+  { address: RECIPIENT_2, amount: '20.0000000', asset: 'XLM' },
+  { address: RECIPIENT_3, amount: '50.0000000', asset: `USDC:${USDC_ISSUER}` },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('StellarService.submitBatch — asset parsing (#319)', () => {
+  beforeEach(() => {
+    mockLoadAccount.mockResolvedValue({
+      id: SOURCE_KEYPAIR.publicKey(),
+      sequenceNumber: () => '1',
+      incrementSequenceNumber: vi.fn(),
+      accountId: () => SOURCE_KEYPAIR.publicKey(),
+      sequence: '1',
+      balances: [],
+      signers: [],
+      flags: {},
+      thresholds: { low_threshold: 0, med_threshold: 0, high_threshold: 0 },
+      data_attr: {},
+    });
+
+    mockSubmitTransaction.mockResolvedValue({ hash: 'mock-tx-hash-abc123' });
+  });
+
+  test('submits XLM and USDC payments without throwing', async () => {
+    const { StellarService } = await import('../lib/stellar/server');
+
+    const service = new StellarService({
+      secretKey: SOURCE_KEYPAIR.secret(),
+      network: 'testnet',
+      maxOperationsPerTransaction: 100,
+    });
+
+    const result = await service.submitBatch(payments);
+
+    expect(result.totalRecipients).toBe(3);
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test('builds correct Asset instances for XLM and USDC operations', async () => {
+    const { StellarService } = await import('../lib/stellar/server');
+
+    const service = new StellarService({
+      secretKey: SOURCE_KEYPAIR.secret(),
+      network: 'testnet',
+      maxOperationsPerTransaction: 100,
+    });
+
+    await service.submitBatch(payments);
+
+    const submittedTx = mockSubmitTransaction.mock.calls[0][0];
+    const ops = submittedTx.operations;
+
+    expect(ops).toHaveLength(3);
+
+    // First two ops: XLM (native)
+    expect(ops[0].asset.isNative()).toBe(true);
+    expect(ops[1].asset.isNative()).toBe(true);
+
+    // Third op: USDC issued asset
+    expect(ops[2].asset.isNative()).toBe(false);
+    expect(ops[2].asset.getCode()).toBe('USDC');
+    expect(ops[2].asset.getIssuer()).toBe(USDC_ISSUER);
+  });
+
+  test('all results are successful', async () => {
+    const { StellarService } = await import('../lib/stellar/server');
+
+    const service = new StellarService({
+      secretKey: SOURCE_KEYPAIR.secret(),
+      network: 'testnet',
+      maxOperationsPerTransaction: 100,
+    });
+
+    const result = await service.submitBatch(payments);
+
+    expect(result.summary.successful).toBe(3);
+    expect(result.summary.failed).toBe(0);
+    for (const r of result.results) {
+      expect(r.status).toBe('success');
+      expect(r.transactionHash).toBe('mock-tx-hash-abc123');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two bugs affecting the server-side batch submission and recovery paths.

---

### fix(#319) — `parseAsset` in `server.ts` rejects issued assets (USDC, etc.)

**Root cause:** `server.ts` had its own `parseAsset` that only handled `"XLM"`/`"native"` or an object `{code, issuer}`. It had no `"CODE:ISSUER"` string parsing, so any USDC/issued-asset batch submitted via the server-signing path (`/api/batch-submit` + `STELLAR_SECRET_KEY`) threw `Invalid asset: must provide code and issuer`.

**Changes:**
- Added shared `parseAsset()` to `lib/stellar/utils.ts` — handles `"XLM"`, `"native"`, `"CODE:ISSUER"` strings, and `{code, issuer}` objects; returns a `StellarAsset` instance
- Removed local `parseAsset` from `lib/stellar/server.ts`; now imports + re-exports from `utils.ts`
- Removed local `parseAsset` from `lib/stellar/batcher.ts`; now imports from `utils.ts`; call sites updated to use the returned `StellarAsset` directly
- Added `tests/server-submit-batch.test.ts`: 3 Vitest integration tests — 2× XLM + 1× USDC through `StellarService.submitBatch` with mocked Horizon, asserting correct `Asset` instances are built and all results succeed
- Fixed `tests/batcher.test.ts`: import `parseAsset` from `utils`; updated assertions to use `StellarAsset` API (`isNative()`, `getCode()`, `getIssuer()`)
- Updated `DEVELOPMENT.md`: documents `utils.ts` as the single shared parser and warns against re-introducing a local one in `server.ts`

Closes #319

---

### fix(#320) — `/api/batch-recover` calls browser IndexedDB on the server

**Root cause (as filed):** The route was calling `loadBatch()` from `lib/batch-persistence.ts` which opens browser `IndexedDB` — unavailable in Node.js/Edge. The route had already been corrected to use `job-store` (SQLite), but had no test coverage and was missing the optional `publicKey` ownership filter described in the issue.

**Changes:**
- Added optional `publicKey` query param to `GET /api/batch-recover?jobId=...&publicKey=...` — passed to `getJob(jobId, publicKey)` so callers can scope recovery to jobs they own
- Added `tests/batch-recover.test.ts`: 5 integration tests running in Node against an in-memory SQLite store — 200 for a completed job, 404 for unknown `jobId`, 400 for missing `jobId`, 404 for wrong `publicKey`, 200 for correct `publicKey`

Closes #320