### PR TITLE
fix: resolve horizon URL overrides, rate limiting, atomic decrement, and Retry-After header semantics

### DIFF
--- a/app/api/dashboard-metrics/route.ts
+++ b/app/api/dashboard-metrics/route.ts
@@ -12,6 +12,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { Horizon } from "stellar-sdk";
+import { horizonUrl } from "@/lib/stellar/network-config";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 type TimeRange = "7d" | "30d" | "90d";
 
@@ -28,6 +30,9 @@ function rangeToDays(range: TimeRange | null): number | null {
 }
 
 export async function GET(request: NextRequest) {
+  const rateLimit = applyRateLimit(request, "dashboard-metrics");
+  if (rateLimit.blocked) return rateLimit.response!;
+
   const { searchParams } = request.nextUrl;
   const publicKey = searchParams.get("publicKey");
   const network = searchParams.get("network");
@@ -54,11 +59,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const serverUrl =
-    network === "testnet"
-      ? "https://horizon-testnet.stellar.org"
-      : "https://horizon.stellar.org";
-  const server = new Horizon.Server(serverUrl);
+  const server = new Horizon.Server(horizonUrl(network));
 
   try {
     // Get account operations (limit to recent 200 for performance)
@@ -177,20 +178,23 @@ export async function GET(request: NextRequest) {
       }));
     }
 
-    return NextResponse.json({
-      totalPayments,
-      totalAmountSent: totalAmountDisplay,
-      successRate: successRate.toFixed(1) + "%",
-      activeBatches,
-      totalPaymentsTrend: formatTrend(currentWindowPayments, previousWindowPayments),
-      totalAmountSentTrend: formatTrend(currentWindowAmount, previousWindowAmount),
-      successRateTrend: formatTrend(
-        rate(currentWindowSuccessful, currentWindowPayments),
-        rate(previousWindowSuccessful, previousWindowPayments),
-        "pp",
-      ),
-      activeBatchesTrend: recentPayments > 0 ? "Last 24h" : "No active batches",
-    });
+    return setRateLimitHeaders(
+      NextResponse.json({
+        totalPayments,
+        totalAmountSent: totalAmountDisplay,
+        successRate: successRate.toFixed(1) + "%",
+        activeBatches,
+        totalPaymentsTrend: formatTrend(currentWindowPayments, previousWindowPayments),
+        totalAmountSentTrend: formatTrend(currentWindowAmount, previousWindowAmount),
+        successRateTrend: formatTrend(
+          rate(currentWindowSuccessful, currentWindowPayments),
+          rate(previousWindowSuccessful, previousWindowPayments),
+          "pp",
+        ),
+        activeBatchesTrend: recentPayments > 0 ? "Last 24h" : "No active batches",
+      }),
+      rateLimit,
+    );
   } catch (error) {
     console.error("Error fetching dashboard metrics:", error);
     return NextResponse.json(

--- a/app/api/tx-status/route.ts
+++ b/app/api/tx-status/route.ts
@@ -10,8 +10,13 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { Horizon } from "stellar-sdk";
+import { horizonUrl } from "@/lib/stellar/network-config";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 export async function GET(request: NextRequest) {
+  const rate = applyRateLimit(request, "tx-status");
+  if (rate.blocked) return rate.response!;
+
   const { searchParams } = request.nextUrl;
   const hash = searchParams.get("hash");
   const network = searchParams.get("network");
@@ -30,24 +35,23 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const serverUrl =
-    network === "testnet"
-      ? "https://horizon-testnet.stellar.org"
-      : "https://horizon.stellar.org";
-  const server = new Horizon.Server(serverUrl);
+  const server = new Horizon.Server(horizonUrl(network));
 
   try {
     const tx = await server.transactions().transaction(hash).call();
 
-    return NextResponse.json({
-      found: true,
-      hash: tx.hash,
-      successful: tx.successful,
-      ledger: tx.ledger_attr,
-      createdAt: tx.created_at,
-      operationCount: tx.operation_count,
-      sourceAccount: tx.source_account,
-    });
+    return setRateLimitHeaders(
+      NextResponse.json({
+        found: true,
+        hash: tx.hash,
+        successful: tx.successful,
+        ledger: tx.ledger_attr,
+        createdAt: tx.created_at,
+        operationCount: tx.operation_count,
+        sourceAccount: tx.source_account,
+      }),
+      rate,
+    );
   } catch (error: unknown) {
     // Horizon returns 404 when the transaction doesn't exist
     const isNotFound =
@@ -57,12 +61,15 @@ export async function GET(request: NextRequest) {
       (error as { response?: { status?: number } }).response?.status === 404;
 
     if (isNotFound) {
-      return NextResponse.json({
-        found: false,
-        hash,
-        message:
-          "Transaction not found on the network. It may have expired or was never submitted successfully.",
-      });
+      return setRateLimitHeaders(
+        NextResponse.json({
+          found: false,
+          hash,
+          message:
+            "Transaction not found on the network. It may have expired or was never submitted successfully.",
+        }),
+        rate,
+      );
     }
 
     return NextResponse.json(

--- a/lib/api-rate-limit.ts
+++ b/lib/api-rate-limit.ts
@@ -4,7 +4,7 @@ import path from "path";
 import crypto from "crypto";
 
 type Tier = "free" | "pro" | "enterprise";
-type EndpointKey = "batch-build" | "batch-submit" | "batch-submit-signed" | "webhook-register";
+type EndpointKey = "batch-build" | "batch-submit" | "batch-submit-signed" | "webhook-register" | "tx-status" | "dashboard-metrics";
 
 type EndpointLimit = {
   free: number;
@@ -80,6 +80,8 @@ const DEFAULT_LIMITS: Record<EndpointKey, EndpointLimit> = {
   "batch-submit": { free: 5, pro: 15, enterprise: 45, windowMs: 60_000 },
   "batch-submit-signed": { free: 5, pro: 15, enterprise: 45, windowMs: 60_000 },
   "webhook-register": { free: 3, pro: 10, enterprise: 30, windowMs: 60_000 },
+  "tx-status": { free: 30, pro: 100, enterprise: 300, windowMs: 60_000 },
+  "dashboard-metrics": { free: 20, pro: 60, enterprise: 180, windowMs: 60_000 },
 };
 
 const endpointLimits: Record<EndpointKey, EndpointLimit> = {
@@ -93,6 +95,8 @@ const endpointLimits: Record<EndpointKey, EndpointLimit> = {
     "webhook-register",
     DEFAULT_LIMITS["webhook-register"],
   ),
+  "tx-status": tunedLimit("tx-status", DEFAULT_LIMITS["tx-status"]),
+  "dashboard-metrics": tunedLimit("dashboard-metrics", DEFAULT_LIMITS["dashboard-metrics"]),
 };
 
 const apiKeyTierMap: Record<string, Tier> = (() => {
@@ -172,6 +176,7 @@ export function applyRateLimit(request: NextRequest, endpoint: EndpointKey): {
   blocked: boolean;
   remaining: number;
   retryAfterSec: number;
+  resetAt: number;
   limit: number;
   response?: NextResponse;
 } {
@@ -185,24 +190,26 @@ export function applyRateLimit(request: NextRequest, endpoint: EndpointKey): {
   const row = db.prepare("SELECT * FROM rate_buckets WHERE key = ?").get(key) as RateBucketRow | undefined;
 
   if (!row || now >= row.resetAt) {
-    const resetAt = now + policy.windowMs;
+    const resetAtMs = now + policy.windowMs;
     const remaining = limit - 1;
     db.prepare(`
       INSERT OR REPLACE INTO rate_buckets
       (key, tier, endpoint, remaining, limit, resetAt, windowMs, updatedAt)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(key, tier, endpoint, remaining, limit, resetAt, policy.windowMs, new Date().toISOString());
+    `).run(key, tier, endpoint, remaining, limit, resetAtMs, policy.windowMs, new Date().toISOString());
 
     return {
       blocked: false,
       remaining: Math.max(0, remaining),
       retryAfterSec: Math.ceil(policy.windowMs / 1000),
+      resetAt: Math.ceil(resetAtMs / 1000),
       limit,
     };
   }
 
   if (row.remaining <= 0) {
     const retryAfterSec = Math.max(1, Math.ceil((row.resetAt - now) / 1000));
+    const resetAtSec = Math.ceil(row.resetAt / 1000);
     const response = NextResponse.json(
       { error: "Too Many Requests", detail: "Rate limit exceeded for this endpoint." },
       { status: 429 },
@@ -210,31 +217,55 @@ export function applyRateLimit(request: NextRequest, endpoint: EndpointKey): {
     response.headers.set("Retry-After", String(retryAfterSec));
     response.headers.set("X-RateLimit-Remaining", "0");
     response.headers.set("X-RateLimit-Limit", String(limit));
-    return { blocked: true, remaining: 0, retryAfterSec, limit, response };
+    response.headers.set("X-RateLimit-Reset", String(resetAtSec));
+    return { blocked: true, remaining: 0, retryAfterSec, resetAt: resetAtSec, limit, response };
+  }
+
+  // Atomic decrement: only decrements when remaining > 0, preventing races under concurrency
+  const updateResult = db.prepare(`
+    UPDATE rate_buckets SET remaining = remaining - 1, updatedAt = ? WHERE key = ? AND remaining > 0
+  `).run(new Date().toISOString(), key);
+
+  if (updateResult.changes === 0) {
+    // Another concurrent request consumed the last token between our SELECT and UPDATE
+    const retryAfterSec = Math.max(1, Math.ceil((row.resetAt - now) / 1000));
+    const resetAtSec = Math.ceil(row.resetAt / 1000);
+    const response = NextResponse.json(
+      { error: "Too Many Requests", detail: "Rate limit exceeded for this endpoint." },
+      { status: 429 },
+    );
+    response.headers.set("Retry-After", String(retryAfterSec));
+    response.headers.set("X-RateLimit-Remaining", "0");
+    response.headers.set("X-RateLimit-Limit", String(limit));
+    response.headers.set("X-RateLimit-Reset", String(resetAtSec));
+    return { blocked: true, remaining: 0, retryAfterSec, resetAt: resetAtSec, limit, response };
   }
 
   const newRemaining = row.remaining - 1;
-  db.prepare(`
-    UPDATE rate_buckets SET remaining = ?, updatedAt = ? WHERE key = ?
-  `).run(newRemaining, new Date().toISOString(), key);
-
   const retryAfterSec = Math.max(1, Math.ceil((row.resetAt - now) / 1000));
+  const resetAtSec = Math.ceil(row.resetAt / 1000);
   return {
     blocked: false,
     remaining: newRemaining,
     retryAfterSec,
+    resetAt: resetAtSec,
     limit,
   };
 }
 
 export function setRateLimitHeaders(response: NextResponse, state: {
+  blocked: boolean;
   remaining: number;
   retryAfterSec: number;
+  resetAt: number;
   limit: number;
 }) {
   response.headers.set("X-RateLimit-Remaining", String(Math.max(0, state.remaining)));
   response.headers.set("X-RateLimit-Limit", String(state.limit));
-  response.headers.set("Retry-After", String(state.retryAfterSec));
+  response.headers.set("X-RateLimit-Reset", String(state.resetAt));
+  if (state.blocked) {
+    response.headers.set("Retry-After", String(state.retryAfterSec));
+  }
   return response;
 }
 

--- a/lib/stellar/batch-worker.ts
+++ b/lib/stellar/batch-worker.ts
@@ -13,6 +13,7 @@ import { createBatches } from "./batcher";
 import type { PaymentInstruction, BatchResult, PaymentResult } from "./types";
 import { Horizon, TransactionBuilder } from "stellar-sdk";
 import { sumStellarAmounts, formatStellarAmount } from "./utils";
+import { horizonUrl } from "./network-config";
 
 /**
  * Process a batch job in the background. This function must NOT be awaited
@@ -40,10 +41,7 @@ export async function processJobInBackground(
     }
 
     // Create server instance for fee fetching
-    const serverUrl = network === 'testnet'
-      ? 'https://horizon-testnet.stellar.org'
-      : 'https://horizon.stellar.org';
-    const server = new Horizon.Server(serverUrl);
+    const server = new Horizon.Server(horizonUrl(network));
 
     // #300: Handle pre-signed transactions (client-side signing)
     if (xdrs && xdrs.length > 0) {

--- a/lib/stellar/server.ts
+++ b/lib/stellar/server.ts
@@ -26,6 +26,7 @@ import {
   validateBatchConfig,
 } from "./validator";
 import { getRecommendedFee } from "./fee-service";
+import { horizonUrl } from "./network-config";
 import Big from "big.js";
 import { parseStellarAmount, formatStellarAmount, parseAsset } from "./utils";
 export { parseAsset };
@@ -46,12 +47,7 @@ export class StellarService {
     this.network = config.network;
     this.maxOperationsPerTransaction = config.maxOperationsPerTransaction;
 
-    const serverUrl =
-      config.network === "testnet"
-        ? "https://horizon-testnet.stellar.org"
-        : "https://horizon.stellar.org";
-
-    this.server = new Horizon.Server(serverUrl);
+    this.server = new Horizon.Server(horizonUrl(config.network));
   }
 
   /**


### PR DESCRIPTION


closes #400
closes #404
closes #405
closes #406

## Changes

### #400 — Horizon URL env overrides ignored in batch-worker and StellarService

`lib/stellar/batch-worker.ts` and `lib/stellar/server.ts` both hardcoded the public SDF Horizon URLs (`https://horizon-testnet.stellar.org` / `https://horizon.stellar.org`) instead of delegating to the existing `horizonUrl(network)` helper in `lib/stellar/network-config.ts`. The same hardcoding existed in `app/api/tx-status/route.ts` and `app/api/dashboard-metrics/route.ts`.

All four files now import and call `horizonUrl(network)`, making `HORIZON_URL_TESTNET`, `HORIZON_URL_MAINNET`, and their `NEXT_PUBLIC_` counterparts the single source of truth for the Horizon endpoint across builds, submissions, and metrics reads.

### #404 — tx-status and dashboard-metrics lack rate limiting

`app/api/tx-status/route.ts` and `app/api/dashboard-metrics/route.ts` exposed unauthenticated GET handlers that forwarded arbitrary hashes and account IDs to Horizon with no per-IP budget.

Both routes now call `applyRateLimit` with new endpoint keys `tx-status` (30/100/300 req/min by tier) and `dashboard-metrics` (20/60/180 req/min by tier). The corresponding keys and default limits are added to `EndpointKey`, `DEFAULT_LIMITS`, and `endpointLimits` in `lib/api-rate-limit.ts`. Success responses carry `X-RateLimit-*` headers via `setRateLimitHeaders`.

### #405 — setRateLimitHeaders sets Retry-After on successful responses

`setRateLimitHeaders` unconditionally wrote `Retry-After` on every response, including 202 successes, violating RFC 9110 (Retry-After is only meaningful on 429/503).

`setRateLimitHeaders` now only sets `Retry-After` when `state.blocked` is true. All responses (blocked and allowed) now emit `X-RateLimit-Remaining`, `X-RateLimit-Limit`, and `X-RateLimit-Reset` (Unix timestamp in seconds). The `applyRateLimit` return type gains `resetAt: number` so callers have everything they need without a separate lookup.

### #406 — SQLite rate limit decrement is non-atomic under concurrent requests

The previous code did a JavaScript read-modify-write: `SELECT remaining`, subtract 1, then `UPDATE remaining = ?`. Two concurrent requests with `remaining === 1` could both read a positive value and both pass.

The `UPDATE` statement is now `UPDATE rate_buckets SET remaining = remaining - 1 WHERE key = ? AND remaining > 0`. The `changes` count from `better-sqlite3`'s `RunResult` is checked; if it is `0` (another request won the race), the caller receives a 429 response identical to the explicit-block path.
