### PR TITLE
Unify dashboard UX: motion tokens, persistence health, analytics gate…

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -143,6 +143,41 @@ Update your frontend `.env` file with the newly deployed Contract ID:
 NEXT_PUBLIC_CONTRACT_ID="C..."
 ```
 
+## SQLite persistence (batch jobs and rate limits)
+
+The API stores batch jobs in SQLite via `better-sqlite3`. By default:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `JOB_STORE_PATH` | `./data/jobs.db` | Durable batch job state |
+| `RATE_LIMIT_DB_PATH` | `./data/rate-limit.db` | Per-key API rate limiting |
+
+Vercel serverless functions use a read-only filesystem except `/tmp`. Without
+explicit paths, job persistence can fail silently or reset on every cold start.
+
+**Recommended hosting:**
+
+1. **Serverful Node** — long-running `next start`, PM2, or Docker with a writable `data/` directory.
+2. **Persistent volume** — mount a volume at `data/` (Kubernetes PVC, ECS EFS, etc.).
+3. **Managed SQL** — replace SQLite with Turso, Postgres, or another shared store (requires application changes).
+
+**Ephemeral demo on serverless** (data is lost between invocations):
+
+```bash
+export JOB_STORE_PATH=/tmp/jobs.db
+export RATE_LIMIT_DB_PATH=/tmp/rate-limit.db
+```
+
+**Health check** — verify directories are writable before routing traffic:
+
+```bash
+curl -s http://localhost:3000/api/health
+# Returns 200 when job_store and rate_limit paths are writable, 503 otherwise
+```
+
+Set `JOB_STORE_PATH` and `RATE_LIMIT_DB_PATH` in the same environment as your
+API routes (Vercel project settings, Docker env, or systemd unit).
+
 ## Hosting Options
 
 ### Option 1: Vercel (Recommended for Next.js)
@@ -623,7 +658,7 @@ pm2 stop stellar-bulk-pay
 git checkout main && npm run build && pm2 start stellar-bulk-pay
 
 # 5. Verify
-curl http://localhost:3000/health
+curl http://localhost:3000/api/health
 ```
 
 ## Support

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,24 @@ The project follows a clean layered architecture with clear separation of concer
 - Manages sequence numbers and error handling
 - Returns structured results
 
+## Motion vocabulary
+
+Dashboard and marketing UI share `MotionSafe` (`components/motion-safe.tsx`),
+which disables Framer Motion when `prefers-reduced-motion` is set.
+
+Presets live in `lib/motion-tokens.ts`:
+
+| Preset | Use |
+|--------|-----|
+| `pageEnter` | Dashboard page shells (history, batch detail) |
+| `stepEnter` | New-batch wizard steps |
+| `fadeInUpMedium` | Metric cards and staggered grids |
+| `motionCssDuration` | Tailwind `transition-all` durations aligned with tokens |
+
+Prefer spreading a preset onto `MotionSafe` instead of ad hoc `animate-in`
+utilities or raw `motion.div` on data-heavy routes. Utilitarian tables can
+omit entrance animation entirely.
+
 ## Key Design Decisions
 
 ### 1. No ORM or Additional Abstraction

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { checkPersistenceHealth } from "@/lib/persistence-health";
+
+export async function GET() {
+  const health = checkPersistenceHealth();
+  return NextResponse.json(health, { status: health.ok ? 200 : 503 });
+}

--- a/app/dashboard/analytics/page.tsx
+++ b/app/dashboard/analytics/page.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import Link from "next/link";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
 import { OverviewMetrics } from "@/components/dashboard/overview-metrics";
 import {
   PaymentVolumeChart,
   type PaymentVolumePoint,
 } from "@/components/dashboard/PaymentVolumeChart";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { useWallet } from "@/contexts/WalletContext";
 import { useDashboardMetrics } from "@/hooks/use-dashboard-metrics";
 
@@ -60,24 +58,7 @@ export default function AnalyticsPage() {
       </div>
 
       {!publicKey ? (
-        <Card className="border-[#1F2937] bg-[#121827]">
-          <CardContent className="flex flex-col items-center gap-4 p-12 text-center">
-            <h2 className="text-xl font-semibold text-white">
-              Connect a wallet to see analytics
-            </h2>
-            <p className="max-w-md text-sm text-gray-400">
-              Analytics are derived from Horizon operations for the connected
-              account. Connect a wallet in Settings to populate volume,
-              success rate, and the daily chart.
-            </p>
-            <Button
-              asChild
-              className="bg-[#00D98B] hover:bg-[#00D98B]/90 text-white"
-            >
-              <Link href="/dashboard/settings">Go to Settings</Link>
-            </Button>
-          </CardContent>
-        </Card>
+        <DashboardWalletEmpty />
       ) : (
         <>
           <OverviewMetrics metrics={metrics} loading={loading} />

--- a/app/dashboard/history/[jobId]/page.tsx
+++ b/app/dashboard/history/[jobId]/page.tsx
@@ -24,6 +24,8 @@ import { use, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { MotionSafe } from "@/components/motion-safe";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
+import { pageEnter } from "@/lib/motion-tokens";
 import { ArrowLeft, Copy, ExternalLink, Download, FileText, Loader2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -136,12 +138,7 @@ export default function BatchDetailPage({
   const exportRows = data ? buildBatchExportRows(data) : [];
 
   return (
-    <MotionSafe
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.25 }}
-      className="space-y-6"
-    >
+    <MotionSafe {...pageEnter} className="space-y-6">
       <Link
         href="/dashboard/history"
         className="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-white"
@@ -183,9 +180,7 @@ export default function BatchDetailPage({
               <Loader2 className="h-4 w-4 animate-spin" /> Loading job…
             </div>
           )}
-          {!loading && !publicKey && (
-            <p className="text-gray-400">Connect your wallet to view batch details.</p>
-          )}
+          {!loading && !publicKey && <DashboardWalletEmpty className="border-none bg-transparent" />}
           {error && <p className="text-red-300">{error}</p>}
           {data && (
             <div className="grid sm:grid-cols-3 gap-4 text-sm">

--- a/app/dashboard/history/page.tsx
+++ b/app/dashboard/history/page.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useCallback } from "react";
 import { MotionSafe } from "@/components/motion-safe";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
+import { pageEnter } from "@/lib/motion-tokens";
+import { useWallet } from "@/contexts/WalletContext";
 import {
   HistoryFilterBar,
   DEFAULT_HISTORY_FILTERS,
@@ -44,6 +47,7 @@ function computeMetrics(batches: HistoricalBatch[]) {
 }
 
 export default function HistoryPage() {
+  const { publicKey } = useWallet();
   const [filters, setFilters] = useState<HistoryFilterValues>(DEFAULT_HISTORY_FILTERS);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -68,12 +72,7 @@ export default function HistoryPage() {
   const metricsData = computeMetrics(loadedBatches);
 
   return (
-    <MotionSafe
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.25 }}
-      className="space-y-8"
-    >
+    <MotionSafe {...pageEnter} className="space-y-8">
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-bold tracking-tight text-white">Batch Payment History</h1>
         <p className="text-gray-400">
@@ -81,6 +80,10 @@ export default function HistoryPage() {
         </p>
       </div>
 
+      {!publicKey ? (
+        <DashboardWalletEmpty />
+      ) : (
+        <>
       <MetricsGrid data={metricsData} />
 
       <Card className="border-[#1F2937] bg-[#121827] shadow-lg">
@@ -112,6 +115,8 @@ export default function HistoryPage() {
       </Card>
 
       <HistoryExportCenter />
+        </>
+      )}
     </MotionSafe>
   );
 }

--- a/app/dashboard/new-batch/page.tsx
+++ b/app/dashboard/new-batch/page.tsx
@@ -4,7 +4,9 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { FileUpload } from "@/components/file-upload";
-import { ConnectWalletButton } from "@/components/connect-wallet-button";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
+import { MotionSafe } from "@/components/motion-safe";
+import { motionCssDuration, stepEnter } from "@/lib/motion-tokens";
 import { BatchDryRun } from "@/components/dashboard/BatchDryRun";
 import { CsvValidationErrors } from "@/components/csv-validation-errors";
 import { JobProgress } from "@/components/job-progress";
@@ -362,16 +364,9 @@ export default function NewBatchPaymentPage() {
         </p>
       </div>
 
-      {/* Wallet Connection */}
-      <div className="bg-slate-900/50 border border-slate-800 rounded-lg p-4 flex items-center justify-between">
-        <div className="text-sm text-slate-400">
-          {publicKey
-            ? "Wallet connected"
-            : "Connect your wallet to get started"}
-        </div>
-        <ConnectWalletButton />
-      </div>
-
+      {!publicKey ? (
+        <DashboardWalletEmpty />
+      ) : (
       <BatchErrorBoundary
         storageKey="new_batch_state"
         onRestore={handleRestore}
@@ -381,7 +376,7 @@ export default function NewBatchPaymentPage() {
           <div className="flex items-center justify-between relative max-w-2xl mx-auto">
             <div className="absolute left-0 top-1/2 -translate-y-1/2 w-full h-0.5 bg-slate-800 -z-10" />
             <div
-              className="absolute left-0 top-1/2 -translate-y-1/2 h-0.5 bg-emerald-500 -z-10 transition-all duration-300"
+              className={`absolute left-0 top-1/2 -translate-y-1/2 h-0.5 bg-emerald-500 -z-10 transition-all ${motionCssDuration.fast}`}
               style={{ width: `${((step - 1) / (steps.length - 1)) * 100}%` }}
             />
             {steps.map((s) => (
@@ -418,7 +413,7 @@ export default function NewBatchPaymentPage() {
 
         {/* Step 1: Entry */}
         {step === 1 && (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <MotionSafe {...stepEnter} className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div className="lg:col-span-2 space-y-6">
               <Tabs
                 value={entryMode}
@@ -543,12 +538,12 @@ export default function NewBatchPaymentPage() {
                 </CardContent>
               </Card>
             </div>
-          </div>
+          </MotionSafe>
         )}
 
         {/* Step 2: Validate */}
         {step === 2 && summary && validationResult && (
-          <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <MotionSafe {...stepEnter} className="space-y-6">
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
               <div className="lg:col-span-2">
                 <Card className="bg-slate-900/50 border-slate-800">
@@ -647,12 +642,12 @@ export default function NewBatchPaymentPage() {
             )}
 
             <BatchDryRun result={validationResult} />
-          </div>
+          </MotionSafe>
         )}
 
         {/* Step 3: Review */}
         {step === 3 && summary && validationResult && (
-          <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <MotionSafe {...stepEnter} className="space-y-6">
             <BatchReview
               payments={validationResult.validPayments}
               network={selectedNetwork}
@@ -702,12 +697,12 @@ export default function NewBatchPaymentPage() {
                 }
               }}
             />
-          </div>
+          </MotionSafe>
         )}
 
         {/* Processing progress — shown while batch job is running */}
         {isSubmitting && jobId && (
-          <div className="space-y-4 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <MotionSafe {...stepEnter} className="space-y-4">
             <Card className="bg-slate-900/50 border-slate-800">
               <CardHeader>
                 <CardTitle className="text-lg text-white">
@@ -723,12 +718,12 @@ export default function NewBatchPaymentPage() {
                 />
               </CardContent>
             </Card>
-          </div>
+          </MotionSafe>
         )}
 
         {/* Step 4: Submit Confirmation */}
         {step === 4 && result && (
-          <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <MotionSafe {...stepEnter} className="space-y-6">
             <Card className="bg-slate-900/50 border-slate-800">
               <CardHeader>
                 <CardTitle className="text-lg text-white">
@@ -761,9 +756,10 @@ export default function NewBatchPaymentPage() {
                 </div>
               </CardContent>
             </Card>
-          </div>
+          </MotionSafe>
         )}
       </BatchErrorBoundary>
+      )}
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { OverviewMetrics } from "@/components/dashboard/overview-metrics";
 import { PaymentVolumeChart } from "@/components/dashboard/PaymentVolumeChart";
 import { QuickActions } from "@/components/dashboard/QuickActions";
 import { DeveloperResources } from "@/components/dashboard/developer-resources";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
 import { useWallet } from "@/contexts/WalletContext";
 import { useDashboardMetrics } from "@/hooks/use-dashboard-metrics";
 import { Badge } from "@/components/ui/badge";
@@ -27,36 +28,36 @@ export default function DashboardPage() {
         </p>
       </div>
 
-      {hasNoData ? (
-        <div className="flex flex-wrap items-center gap-3 rounded-xl border border-[#1F2937] bg-[#121827] px-4 py-3 text-sm text-gray-300">
-          <Badge className="bg-[#00D98B]/10 text-[#00D98B] hover:bg-[#00D98B]/10">
-            Connected
-          </Badge>
-          <span className="font-mono">{publicKey}</span>
-          <span className="uppercase tracking-wide text-gray-500">{dashboardNetwork}</span>
-          <span className="text-gray-400">No batches yet. Real activity will appear after your first batch payment.</span>
-        </div>
-      ) : null}
+      {!publicKey ? (
+        <DashboardWalletEmpty />
+      ) : (
+        <>
+          {hasNoData ? (
+            <div className="flex flex-wrap items-center gap-3 rounded-xl border border-[#1F2937] bg-[#121827] px-4 py-3 text-sm text-gray-300">
+              <Badge className="bg-[#00D98B]/10 text-[#00D98B] hover:bg-[#00D98B]/10">
+                Connected
+              </Badge>
+              <span className="font-mono">{publicKey}</span>
+              <span className="uppercase tracking-wide text-gray-500">{dashboardNetwork}</span>
+              <span className="text-gray-400">No batches yet. Real activity will appear after your first batch payment.</span>
+            </div>
+          ) : null}
 
-      {/* Overview Metrics */}
-      <OverviewMetrics metrics={metrics} loading={loading} />
+          <OverviewMetrics metrics={metrics} loading={loading} />
 
-      <div className="grid gap-8 lg:grid-cols-3">
-        {/* Quick Actions Column */}
-        <div className="lg:col-span-1">
-          <QuickActions />
-        </div>
+          <div className="grid gap-8 lg:grid-cols-3">
+            <div className="lg:col-span-1">
+              <QuickActions />
+            </div>
+            <div className="lg:col-span-2">
+              <PaymentVolumeChart />
+            </div>
+          </div>
 
-        {/* Payment Volume Chart */}
-        <div className="lg:col-span-2">
-          <PaymentVolumeChart />
-        </div>
-      </div>
+          <RecentBatchesTable publicKey={publicKey} network={dashboardNetwork} limit={5} />
+        </>
+      )}
 
-      {/* Recent Batches Table Section */}
-      <RecentBatchesTable publicKey={publicKey} network={dashboardNetwork} limit={5} />
-
-      {/* Developer Resources Section */}
       <DeveloperResources />
     </div>
   );

--- a/app/dashboard/vesting/page.tsx
+++ b/app/dashboard/vesting/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Upload, Calendar, Clock, AlertCircle, CheckCircle } from "lucide-react";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
 import { useWallet } from "@/contexts/WalletContext";
 import { toast } from "sonner";
 import type { PaymentInstruction } from "@/lib/stellar/types";
@@ -256,7 +257,10 @@ export default function VestingPage() {
         </p>
       </div>
 
-      {/* Tabs */}
+      {!publicKey ? (
+        <DashboardWalletEmpty />
+      ) : (
+        <>
       <div className="flex gap-2 border-b border-[#1F2937]">
         <button
           onClick={() => setActiveTab("deposit")}
@@ -523,6 +527,8 @@ export default function VestingPage() {
             </CardContent>
           </Card>
         </div>
+      )}
+        </>
       )}
     </div>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { Analytics } from "@vercel/analytics/next";
+import { ConditionalAnalytics } from "@/components/conditional-analytics";
 import StellarFooter from "@/components/landing/StellarFooter";
 import { Toaster } from "@/components/ui/toaster";
 import { WalletProvider } from "@/contexts/WalletContext";
@@ -57,7 +57,7 @@ export default function RootLayout({
             </AddressBookProvider>
           </WalletProvider>
           <Toaster />
-          <Analytics />
+          <ConditionalAnalytics />
         </ThemeProvider>
       </body>
     </html>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import StellarFooter from "@/components/landing/StellarFooter";
+
+export const metadata: Metadata = {
+  title: "Privacy | Stellar BatchPay",
+  description: "Privacy practices for Stellar BatchPay",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-[#0B0E14] text-gray-300">
+      <main className="mx-auto max-w-3xl px-6 py-24 space-y-8">
+        <div>
+          <Link href="/" className="text-sm text-[#00D98B] hover:underline">
+            Home
+          </Link>
+          <h1 className="mt-4 text-3xl font-bold text-white">Privacy</h1>
+        </div>
+
+        <section className="space-y-3 text-sm leading-relaxed">
+          <h2 className="text-lg font-semibold text-white">Analytics</h2>
+          <p>
+            Usage analytics are disabled by default in self-hosted deployments.
+            They load only when{" "}
+            <code className="rounded bg-slate-800 px-1.5 py-0.5 text-xs">
+              NEXT_PUBLIC_ENABLE_ANALYTICS=true
+            </code>{" "}
+            and you opt in by setting{" "}
+            <code className="rounded bg-slate-800 px-1.5 py-0.5 text-xs">
+              localStorage.analytics_consent
+            </code>{" "}
+            to <code className="rounded bg-slate-800 px-1.5 py-0.5 text-xs">true</code>{" "}
+            in your browser. Vercel-hosted previews may enable analytics separately
+            through project environment variables.
+          </p>
+          <p>
+            Batch payment data is read from the Stellar network for connected wallets.
+            Server-side job history is stored in SQLite paths configured with{" "}
+            <code className="rounded bg-slate-800 px-1.5 py-0.5 text-xs">
+              JOB_STORE_PATH
+            </code>
+            ; see DEPLOYMENT.md for hosting requirements.
+          </p>
+        </section>
+      </main>
+      <StellarFooter />
+    </div>
+  );
+}

--- a/components/conditional-analytics.tsx
+++ b/components/conditional-analytics.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Analytics } from "@vercel/analytics/next";
+
+const CONSENT_KEY = "analytics_consent";
+
+function analyticsEnabledByEnv(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_ANALYTICS === "true";
+}
+
+export function ConditionalAnalytics() {
+  const [consented, setConsented] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setConsented(localStorage.getItem(CONSENT_KEY) === "true");
+    setReady(true);
+  }, []);
+
+  if (!analyticsEnabledByEnv() || !ready || !consented) {
+    return null;
+  }
+
+  return <Analytics />;
+}
+
+export function setAnalyticsConsent(allowed: boolean): void {
+  if (typeof window === "undefined") return;
+  if (allowed) {
+    localStorage.setItem(CONSENT_KEY, "true");
+  } else {
+    localStorage.removeItem(CONSENT_KEY);
+  }
+}

--- a/components/dashboard/dashboard-wallet-empty.tsx
+++ b/components/dashboard/dashboard-wallet-empty.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Wallet } from "lucide-react";
+import { ConnectWalletButton } from "@/components/connect-wallet-button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { cn } from "@/lib/utils";
+
+export const DASHBOARD_WALLET_EMPTY_TITLE =
+  "Connect your wallet to view data";
+
+export const DASHBOARD_WALLET_EMPTY_DESCRIPTION =
+  "Link a Stellar wallet to load batch history, metrics, and vesting schedules for your account.";
+
+export function DashboardWalletEmpty({ className }: { className?: string }) {
+  return (
+    <Empty
+      className={cn(
+        "rounded-xl border border-dashed border-[#1F2937] bg-[#121827]",
+        className,
+      )}
+    >
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <Wallet className="size-6" aria-hidden />
+        </EmptyMedia>
+        <EmptyTitle className="text-white">{DASHBOARD_WALLET_EMPTY_TITLE}</EmptyTitle>
+        <EmptyDescription>{DASHBOARD_WALLET_EMPTY_DESCRIPTION}</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>
+        <ConnectWalletButton />
+      </EmptyContent>
+    </Empty>
+  );
+}

--- a/components/dashboard/metric-card.tsx
+++ b/components/dashboard/metric-card.tsx
@@ -4,6 +4,7 @@ import Image from "next/image"
 import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 import { MotionSafe } from "@/components/motion-safe"
+import { fadeInUpMedium, staggerTransition } from "@/lib/motion-tokens"
 
 export interface MetricCardProps {
   title: string
@@ -26,9 +27,8 @@ export function MetricCard({
 
   return (
     <MotionSafe
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: index * 0.1 }}
+      {...fadeInUpMedium}
+      transition={staggerTransition(index)}
     >
       <Card className="border border-slate-700/50 bg-slate-900/50 shadow-lg hover:shadow-xl hover:border-slate-600/70 transition-all duration-300">
         <CardContent className="p-6">

--- a/lib/motion-tokens.ts
+++ b/lib/motion-tokens.ts
@@ -1,0 +1,50 @@
+import type { Transition } from "framer-motion";
+
+export const motionEase = [0.25, 0.1, 0.25, 1] as const;
+
+export const motionDuration = {
+  fast: 0.25,
+  normal: 0.5,
+  slow: 0.6,
+} as const;
+
+export const motionCssDuration = {
+  fast: "duration-300",
+  normal: "duration-500",
+} as const;
+
+const baseTransition = (duration: number, delay = 0): Transition => ({
+  duration,
+  ease: motionEase,
+  delay,
+});
+
+export const fadeIn = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  transition: baseTransition(motionDuration.fast),
+} as const;
+
+export const fadeInUp = {
+  initial: { opacity: 0, y: 12 },
+  animate: { opacity: 1, y: 0 },
+  transition: baseTransition(motionDuration.fast),
+} as const;
+
+export const fadeInUpMedium = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: baseTransition(motionDuration.normal),
+} as const;
+
+export const pageEnter = fadeInUp;
+
+export const stepEnter = {
+  initial: { opacity: 0, y: 16 },
+  animate: { opacity: 1, y: 0 },
+  transition: baseTransition(motionDuration.normal),
+} as const;
+
+export function staggerTransition(index: number, step = 0.1): Transition {
+  return baseTransition(motionDuration.fast, index * step);
+}

--- a/lib/persistence-health.ts
+++ b/lib/persistence-health.ts
@@ -1,0 +1,65 @@
+import { accessSync, constants, mkdirSync, writeFileSync, unlinkSync } from "fs";
+import path from "path";
+
+export interface PersistenceHealthResult {
+  ok: boolean;
+  jobStorePath: string;
+  rateLimitDbPath: string;
+  checks: Array<{ name: string; path: string; ok: boolean; error?: string }>;
+}
+
+function resolveJobStorePath(): string {
+  return process.env.JOB_STORE_PATH ?? path.join(process.cwd(), "data", "jobs.db");
+}
+
+function resolveRateLimitDbPath(): string {
+  return (
+    process.env.RATE_LIMIT_DB_PATH ??
+    path.join(process.cwd(), "data", "rate-limit.db")
+  );
+}
+
+function checkDirectoryWritable(dbPath: string): { ok: boolean; error?: string } {
+  const dir = path.dirname(dbPath);
+  try {
+    mkdirSync(dir, { recursive: true });
+    accessSync(dir, constants.W_OK);
+    const probe = path.join(dir, `.write-probe-${process.pid}`);
+    writeFileSync(probe, "");
+    unlinkSync(probe);
+    return { ok: true };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: message };
+  }
+}
+
+export function checkPersistenceHealth(): PersistenceHealthResult {
+  const jobStorePath = resolveJobStorePath();
+  const rateLimitDbPath = resolveRateLimitDbPath();
+
+  const jobDir = checkDirectoryWritable(jobStorePath);
+  const rateDir = checkDirectoryWritable(rateLimitDbPath);
+
+  const checks = [
+    {
+      name: "job_store",
+      path: jobStorePath,
+      ok: jobDir.ok,
+      error: jobDir.error,
+    },
+    {
+      name: "rate_limit",
+      path: rateLimitDbPath,
+      ok: rateDir.ok,
+      error: rateDir.error,
+    },
+  ];
+
+  return {
+    ok: checks.every((c) => c.ok),
+    jobStorePath,
+    rateLimitDbPath,
+    checks,
+  };
+}

--- a/tests/persistence-health.test.ts
+++ b/tests/persistence-health.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+describe("checkPersistenceHealth", () => {
+  let tempDir: string;
+  const previousJobPath = process.env.JOB_STORE_PATH;
+  const previousRatePath = process.env.RATE_LIMIT_DB_PATH;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "batchpay-health-"));
+    process.env.JOB_STORE_PATH = path.join(tempDir, "jobs.db");
+    process.env.RATE_LIMIT_DB_PATH = path.join(tempDir, "rate-limit.db");
+  });
+
+  afterEach(() => {
+    if (previousJobPath === undefined) {
+      delete process.env.JOB_STORE_PATH;
+    } else {
+      process.env.JOB_STORE_PATH = previousJobPath;
+    }
+    if (previousRatePath === undefined) {
+      delete process.env.RATE_LIMIT_DB_PATH;
+    } else {
+      process.env.RATE_LIMIT_DB_PATH = previousRatePath;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("reports ok when database directories are writable", async () => {
+    const { checkPersistenceHealth } = await import("../lib/persistence-health");
+    const result = checkPersistenceHealth();
+    expect(result.ok).toBe(true);
+    expect(result.checks.every((check) => check.ok)).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #480 
closes #478 
closes #479 
closes #475 
## Summary

- Standardize dashboard motion via `lib/motion-tokens.ts` and `MotionSafe` instead of mixed `animate-in` / raw Framer settings
- Document SQLite hosting requirements for `JOB_STORE_PATH` and `RATE_LIMIT_DB_PATH`, with `/api/health` writable-DB check
- Gate Vercel Analytics behind `NEXT_PUBLIC_ENABLE_ANALYTICS` (default off) and `localStorage.analytics_consent`; document on `/privacy`
- Add `DashboardWalletEmpty` for a consistent connect-wallet empty state across dashboard routes



## Test plan

- [ ] With wallet disconnected: overview, history, analytics, vesting, and new-batch show `DashboardWalletEmpty`
- [ ] Connect wallet: metrics, history table, and charts load as expected
- [ ] `curl http://localhost:3000/api/health` returns `200` when `data/` (or configured paths) is writable
- [ ] Without `NEXT_PUBLIC_ENABLE_ANALYTICS=true`, no Vercel Analytics script loads
- [ ] With env enabled + `localStorage.setItem('analytics_consent', 'true')`, analytics loads after reload
- [ ] New-batch wizard steps animate via `MotionSafe` / `stepEnter`; respects `prefers-reduced-motion`
- [ ] `npx vitest run tests/persistence-health.test.ts` passes
