### PR TITLE
fix(dashboard): fix #465 server-signing flag exposure and #470 wallet gate and #469 hero CTA links

### DIFF
--- a/app/dashboard/history/[jobId]/page.tsx
+++ b/app/dashboard/history/[jobId]/page.tsx
@@ -72,7 +72,6 @@ export default function BatchDetailPage({
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [retrying, setRetrying] = useState(false);
-  const allowServerSigning = process.env.NEXT_PUBLIC_ALLOW_SERVER_SIGNING === "true";
 
   useEffect(() => {
     let cancelled = false;
@@ -220,7 +219,7 @@ export default function BatchDetailPage({
                 <Download className="h-4 w-4 mr-1.5" />
                 Export CSV
               </Button>
-              {allowServerSigning && data.summary?.failed ? (
+              {data.summary?.failed ? (
                 <Button
                   variant="destructive"
                   size="sm"

--- a/app/dashboard/new-batch/page.tsx
+++ b/app/dashboard/new-batch/page.tsx
@@ -184,9 +184,7 @@ export default function NewBatchPaymentPage() {
   const [convertedIndices, setConvertedIndices] = useState<number[]>([]);
   const [batchMeta, setBatchMeta] = useState<BatchMetaEntry[] | undefined>();
   const [batchMetaLoading, setBatchMetaLoading] = useState(false);
-  const { publicKey, signTx } = useWallet();
-  const allowServerSigning =
-    process.env.NEXT_PUBLIC_ALLOW_SERVER_SIGNING === "true";
+  const { publicKey } = useWallet();
 
   const loadBatchMeta = useCallback(
     async (payments: PaymentInstruction[]) => {

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { AppSidebar } from "./app-sidebar"
 import { AppHeader } from "./app-header"
+import { WalletGate } from "@/components/dashboard/WalletGate"
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
 
 export function DashboardLayout({ children }: { children: React.ReactNode }) {
@@ -14,7 +15,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           <AppHeader />
           <main className="flex-1 px-4 md:px-8 py-8">
             <div className="mx-auto w-full max-w-[1200px]">
-              {children}
+              <WalletGate>{children}</WalletGate>
             </div>
           </main>
         </SidebarInset>

--- a/components/dashboard/WalletGate.tsx
+++ b/components/dashboard/WalletGate.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
+import { useWallet } from "@/contexts/WalletContext";
+
+const PUBLIC_DASHBOARD_PATHS = new Set(["/dashboard/docs"]);
+
+export function WalletGate({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const { publicKey } = useWallet();
+
+  if (!publicKey && !PUBLIC_DASHBOARD_PATHS.has(pathname)) {
+    return <DashboardWalletEmpty />;
+  }
+
+  return <>{children}</>;
+}

--- a/components/landing/Hero.tsx
+++ b/components/landing/Hero.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Link from 'next/link';
 import { MotionSafe } from "@/components/motion-safe";
 import { Button } from '@/components/ui/button';
 import { Rocket, FileText, Shield, Clock, Users } from 'lucide-react';
@@ -48,13 +49,17 @@ export const Hero = () => {
                         transition={{ duration: 0.6, delay: 0.4 }}
                         className="flex flex-wrap gap-5 pt-4"
                     >
-                        <Button className="bg-[#00D4AA] hover:bg-[#00B894] text-[#020B0D] font-bold px-8 py-7 rounded-2xl text-lg flex items-center gap-3 shadow-[0_10px_30px_rgba(0,212,170,0.2)] transition-all hover:scale-105 active:scale-95 group">
-                            <Rocket className="w-5 h-5  fill-black" />
-                            Start Batch Payment
+                        <Button asChild className="bg-[#00D4AA] hover:bg-[#00B894] text-[#020B0D] font-bold px-8 py-7 rounded-2xl text-lg flex items-center gap-3 shadow-[0_10px_30px_rgba(0,212,170,0.2)] transition-all hover:scale-105 active:scale-95 group">
+                            <Link href="/dashboard/new-batch">
+                                <Rocket className="w-5 h-5  fill-black" />
+                                Start Batch Payment
+                            </Link>
                         </Button>
-                        <Button variant="outline" className="border-[#4B5563] bg-[#00000000]/50 hover:bg-white/5 hover:text-[#00D4AA] text-white font-bold px-8 py-7 rounded-2xl text-lg flex items-center gap-3 backdrop-blur-sm transition-all hover:border-white/20 hover:scale-105 active:scale-95 group">
-                            <FileText className="w-5 h-5 " />
-                            View Documentation
+                        <Button asChild variant="outline" className="border-[#4B5563] bg-[#00000000]/50 hover:bg-white/5 hover:text-[#00D4AA] text-white font-bold px-8 py-7 rounded-2xl text-lg flex items-center gap-3 backdrop-blur-sm transition-all hover:border-white/20 hover:scale-105 active:scale-95 group">
+                            <Link href="/docs">
+                                <FileText className="w-5 h-5 " />
+                                View Documentation
+                            </Link>
                         </Button>
                     </MotionSafe>
 


### PR DESCRIPTION
Closes #465 
Closes #469 
Closes #470 

# PR Description

Fixes #465, #470, and #469 by tightening dashboard access around connected Stellar wallets, removing public exposure of the server-signing capability flag from client dashboard code, and making the landing hero CTAs navigate as expected.

For #465, the dashboard no longer reads the public `NEXT_PUBLIC_ALLOW_SERVER_SIGNING` flag from client components. Server-side signing capability remains enforced only inside server API routes through the non-public `ALLOW_SERVER_SIGNING` environment variable. This matters because public `NEXT_PUBLIC_` values are bundled into browser JavaScript, so keeping this capability check server-only avoids advertising deployment signing behavior to visitors.

For #470, dashboard route content is now wrapped in a shared wallet gate. When a user reaches wallet-scoped dashboard pages without a connected wallet, the layout shows the existing wallet empty state and connect action instead of letting the user click through workflows that later fail at submit time. The dashboard docs route remains readable without a wallet because it is documentation-only.

For #469, the landing hero primary CTA buttons now use Next.js `Link` through the existing `Button asChild` pattern. Keyboard and pointer activation now navigate to the correct product and documentation routes instead of rendering non-functional interactive controls.

# Changed

- #465 Removed client-side reads of the public server-signing environment flag from `app/dashboard/new-batch/page.tsx` and `app/dashboard/history/[jobId]/page.tsx`.
- #465 Left server-signing authorization behind server-only API checks that use `ALLOW_SERVER_SIGNING`.
- #470 Added `components/dashboard/WalletGate.tsx` and wrapped dashboard page content in `components/dashboard-layout.tsx`.
- #470 Kept `/dashboard/docs` outside the wallet gate because it is read-only documentation.
- #469 Updated `components/landing/Hero.tsx` so `Start Batch Payment` links to `/dashboard/new-batch`.
- #469 Updated `components/landing/Hero.tsx` so `View Documentation` links to `/docs`.