### PR TITLE
fix(vesting): pass caller address to revoke contract call (#392)

### DIFF
--- a/lib/stellar/vesting.ts
+++ b/lib/stellar/vesting.ts
@@ -214,6 +214,10 @@ export async function buildRevokeTransaction(
   const contract = new Contract(contractId);
   const operation = contract.call(
     "revoke",
+    // The contract signature is `revoke(env, caller, recipient, index)` and the
+    // sender authorization is checked against `caller`. Omitting it produces an
+    // XDR that does not match the contract interface (#392).
+    new Address(publicKey).toScVal(),
     new Address(recipient).toScVal(),
     nativeToScVal(BigInt(index), { type: "u32" }),
   );

--- a/tests/vesting.test.ts
+++ b/tests/vesting.test.ts
@@ -165,6 +165,38 @@ describe('buildDepositTransaction (#364)', () => {
   });
 });
 
+describe('buildRevokeTransaction (#392)', () => {
+  test('revoke passes caller, recipient and index in order', async () => {
+    const callSpy = vi.spyOn(Contract.prototype, 'call');
+    const { buildRevokeTransaction } = await import('../lib/stellar/vesting');
+
+    const recipient = Keypair.random().publicKey();
+    const caller = Keypair.random().publicKey();
+
+    // We only assert the ScVals handed to `contract.call(...)`; those are
+    // assembled before the network-bound Soroban submission, so swallow any
+    // downstream RPC error and let the ABI assertion stand on its own. A
+    // structurally valid contract ID is required by the current stellar-sdk.
+    await buildRevokeTransaction(
+      'CAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQMCJ',
+      recipient,
+      3,
+      'testnet',
+      caller,
+    ).catch(() => undefined);
+
+    expect(callSpy).toHaveBeenCalledTimes(1);
+    const [fn, ...args] = callSpy.mock.calls[0];
+    expect(fn).toBe('revoke');
+    // Contract is revoke(env, caller, recipient, index) — three ScVals after fn.
+    expect(args).toHaveLength(3);
+    expect(scValToNative(args[0] as xdr.ScVal)).toBe(caller);
+    expect(scValToNative(args[1] as xdr.ScVal)).toBe(recipient);
+    expect(Number(scValToNative(args[2] as xdr.ScVal))).toBe(3);
+    callSpy.mockRestore();
+  });
+});
+
 describe('buildTransferVestingRightsTransaction', () => {
   test('transfer_vesting_rights passes three contract arguments', async () => {
     const callSpy = vi.spyOn(Contract.prototype, 'call');


### PR DESCRIPTION
## Summary

Closes #392.

The Soroban contract defines `revoke(env, caller, recipient, index)` and checks sender authorization against `caller` (`contracts/batch-vesting/src/lib.rs:862`). `buildRevokeTransaction` in `lib/stellar/vesting.ts` only passed `(recipient, index)`, so the generated XDR did not match the contract interface — simulation against deployed WASM fails and the vesting revoke lifecycle is unusable from the dashboard.

## Changes

- Insert `new Address(publicKey).toScVal()` as the first contract argument (`caller`), matching the contract signature.
- Add a regression test (`tests/vesting.test.ts`) asserting `contract.call('revoke', ...)` receives the three ScVals — `caller`, `recipient`, `index` — in order.

`claim(env, recipient, index, amount)` has no `caller` parameter, so `buildClaimTransaction` is already correct and is left unchanged.

## Testing

`bunx vitest run tests/vesting.test.ts -t "392"` → passing.

> Note: other pre-existing tests in `tests/vesting.test.ts` fail on `main` independently of this change — the legacy placeholder contract ID and the RPC mock are incompatible with the upgraded stellar-sdk/vitest. The new test is scoped to the `contract.call` ABI so it stands on its own. Worth a separate cleanup.