### PR TITLE
fix(server): never mark validation failures as successful payments (#389)

### DIFF
--- a/lib/stellar/server.ts
+++ b/lib/stellar/server.ts
@@ -80,6 +80,11 @@ export class StellarService {
       let totalAmountBig = new Big(0);
 
       for (const batch of batches) {
+        // Indices into `results` of placeholders for operations actually added
+        // to this transaction. Validation/asset-parse failures are pushed to
+        // `results` too but are NOT added to the builder, so they must be
+        // excluded from the success/error updates below (#389).
+        const addedResultIndices: number[] = [];
         try {
           // Use user-provided memo from the first payment that has one,
           // otherwise fall back to the system-generated tracking memo.
@@ -156,6 +161,13 @@ export class StellarService {
               transactionHash: undefined,
               rowIndex: payment.rowIndex,
             });
+            addedResultIndices.push(results.length - 1);
+          }
+
+          // Every payment in this batch was invalid — nothing to submit.
+          // (TransactionBuilder.build() throws with zero operations.)
+          if (addedResultIndices.length === 0) {
+            continue;
           }
 
           // Build, sign, and submit transaction
@@ -166,16 +178,12 @@ export class StellarService {
 
           txCount++;
 
-          // Update successful results
-          for (
-            let i = results.length - batch.payments.length;
-            i < results.length;
-            i++
-          ) {
-            if (results[i].status === "failed") {
-              results[i].status = "success";
-              results[i].transactionHash = result.hash;
-            }
+          // Mark only the operations that were actually included in this
+          // transaction as successful. Validation failures keep their own
+          // status/error and must never be flipped to success (#389).
+          for (const i of addedResultIndices) {
+            results[i].status = "success";
+            results[i].transactionHash = result.hash;
           }
         } catch (error) {
           // Mark batch results as failed if transaction fails
@@ -183,11 +191,12 @@ export class StellarService {
             sourceAccount = await this.server.loadAccount(this.keypair.publicKey());
           }
 
-          for (const result of results) {
-            if (result.status === "failed") {
-              result.error =
-                error instanceof Error ? error.message : "Unknown error";
-            }
+          // Only annotate the operations that belonged to this failed
+          // transaction; rows that failed validation already carry their
+          // own error message.
+          for (const i of addedResultIndices) {
+            results[i].error =
+              error instanceof Error ? error.message : "Unknown error";
           }
         }
       }

--- a/tests/server-submit-batch.test.ts
+++ b/tests/server-submit-batch.test.ts
@@ -187,3 +187,70 @@ describe('StellarService.submitBatch — asset parsing (#319)', () => {
     expect(incrementSpy).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('StellarService.submitBatch — validation failures are not marked success (#389)', () => {
+  beforeEach(() => {
+    mockLoadAccount.mockClear();
+    mockSubmitTransaction.mockClear();
+    mockFetchBaseFee.mockClear();
+    mockLoadAccount.mockResolvedValue(new Account(SOURCE_KEYPAIR.publicKey(), '1'));
+    mockSubmitTransaction.mockResolvedValue({ hash: 'mock-tx-hash-389' });
+  });
+
+  test('an invalid row sharing a batch with a valid row stays failed after the tx lands', async () => {
+    const { StellarService } = await import('../lib/stellar/server');
+
+    const service = new StellarService({
+      secretKey: SOURCE_KEYPAIR.secret(),
+      network: 'testnet',
+      maxOperationsPerTransaction: 100,
+    });
+
+    const result = await service.submitBatch([
+      { address: RECIPIENT_1, amount: '10.0000000', asset: 'XLM' }, // valid
+      { address: 'not-a-valid-stellar-address', amount: '5.0000000', asset: 'XLM' }, // invalid
+    ]);
+
+    expect(mockSubmitTransaction).toHaveBeenCalledTimes(1);
+
+    // Only the valid payment should have been included in the envelope.
+    const submittedTx = mockSubmitTransaction.mock.calls[0][0];
+    expect(submittedTx.operations).toHaveLength(1);
+
+    expect(result.summary.successful).toBe(1);
+    expect(result.summary.failed).toBe(1);
+
+    const valid = result.results.find((r) => r.recipient === RECIPIENT_1);
+    const invalid = result.results.find(
+      (r) => r.recipient === 'not-a-valid-stellar-address',
+    );
+
+    expect(valid?.status).toBe('success');
+    expect(valid?.transactionHash).toBe('mock-tx-hash-389');
+
+    // The row that never made it into the envelope must NOT be flipped to success.
+    expect(invalid?.status).toBe('failed');
+    expect(invalid?.transactionHash).toBeUndefined();
+    expect(invalid?.error).toBeTruthy();
+  });
+
+  test('a batch where every row is invalid is never submitted', async () => {
+    const { StellarService } = await import('../lib/stellar/server');
+
+    const service = new StellarService({
+      secretKey: SOURCE_KEYPAIR.secret(),
+      network: 'testnet',
+      maxOperationsPerTransaction: 100,
+    });
+
+    const result = await service.submitBatch([
+      { address: 'bad-address-1', amount: '1.0000000', asset: 'XLM' },
+      { address: 'bad-address-2', amount: '2.0000000', asset: 'XLM' },
+    ]);
+
+    expect(mockSubmitTransaction).not.toHaveBeenCalled();
+    expect(result.summary.successful).toBe(0);
+    expect(result.summary.failed).toBe(2);
+    expect(result.results.every((r) => r.status === 'failed')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #389.

In `lib/stellar/server.ts` `submitBatch`, after `submitTransaction` succeeds the code looped over the last `batch.payments.length` entries of `results` and flipped any `status === "failed"` to `"success"`. Rows that failed validation or asset parsing are pushed into `results` in that same window but were **never added to the transaction envelope** — so they got flipped to `success` too. Operators (and accounting/export/retry-skip logic) would then see successful payouts that never happened on-chain.

## Changes

- Track `addedResultIndices` — the `results` indices of operations actually added to the builder — and only upgrade those to `success` (or annotate them on failure).
- The catch block likewise now only annotates this transaction's operations instead of every `failed` row accumulated across batches, so a validation row keeps its own error message.
- Skip submission entirely for a batch with no valid operations (`TransactionBuilder.build()` throws on zero operations).

## Testing

`bunx vitest run tests/server-submit-batch.test.ts` → 6 passing, including two new cases:
- one invalid + one valid row in the same batch → valid succeeds, invalid stays `failed` with no tx hash;
- an all-invalid batch is never submitted.