### PR TITLE
fix(batch-retry): require owning wallet key so retries are pollable (#388)

### DIFF
--- a/app/api/batch-retry/route.ts
+++ b/app/api/batch-retry/route.ts
@@ -8,6 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { StrKey } from "stellar-sdk";
 import { createJob, getJob } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
 import { safeJsonResponse } from "@/lib/safe-json";
@@ -16,13 +17,29 @@ import { logger } from "@/lib/logger";
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get("x-request-id");
     try {
-        const body = (await request.json()) as { jobId?: string };
+        const body = (await request.json()) as { jobId?: string; publicKey?: string };
         const jobId = body.jobId;
+        const publicKey = body.publicKey;
 
         if (!jobId || typeof jobId !== "string") {
             logger.warn({ requestId }, "Missing jobId in retry request");
             return NextResponse.json(
                 { error: "jobId is required" },
+                { status: 400 },
+            );
+        }
+
+        // The retry job is created under, and only pollable by, a wallet key
+        // (see GET /api/batch-status). Require a valid key up front so retries
+        // are never orphaned from the submitting account (#388).
+        if (
+            !publicKey ||
+            typeof publicKey !== "string" ||
+            !StrKey.isValidEd25519PublicKey(publicKey)
+        ) {
+            logger.warn({ requestId, jobId }, "Missing or invalid publicKey in retry request");
+            return NextResponse.json(
+                { error: "A valid publicKey is required" },
                 { status: 400 },
             );
         }
@@ -58,6 +75,15 @@ export async function POST(request: NextRequest) {
             return NextResponse.json(
                 { error: "Batch job not found or not completed yet" },
                 { status: 404 },
+            );
+        }
+
+        // Only the wallet that submitted the original batch may retry it.
+        if (!job.publicKey || job.publicKey !== publicKey) {
+            logger.warn({ requestId, jobId }, "Retry requested by a non-owning wallet");
+            return NextResponse.json(
+                { error: "This batch job does not belong to the provided wallet" },
+                { status: 403 },
             );
         }
 
@@ -128,7 +154,7 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        const retryJobId = createJob(failedPayments, job.network, job.publicKey || "");
+        const retryJobId = createJob(failedPayments, job.network, job.publicKey);
         void processJobInBackground(retryJobId, failedPayments, job.network, secretKey, undefined, requestId || undefined);
 
         logger.info({ requestId, jobId, retryJobId }, "Retry job successfully created and triggered");

--- a/app/dashboard/history/[jobId]/page.tsx
+++ b/app/dashboard/history/[jobId]/page.tsx
@@ -99,7 +99,9 @@ export default function BatchDetailPage({
 
       const poll = async () => {
         try {
-          const r = await fetch(`/api/batch-status/${newJobId}`);
+          const r = await fetch(
+            `/api/batch-status/${newJobId}?publicKey=${encodeURIComponent(publicKey!)}`,
+          );
           if (!r.ok) throw new Error(`Status fetch failed (${r.status})`);
           const jb = (await r.json()) as JobStatusResponse;
           if (cancelled) return;

--- a/tests/batch-retry.test.ts
+++ b/tests/batch-retry.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Integration tests for POST /api/batch-retry (#388).
+ *
+ * Verifies that retry requires the owning wallet's publicKey, rejects
+ * mismatches, and creates a retry job that is pollable by that same key
+ * (i.e. not orphaned from the submitting account).
+ */
+
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+
+process.env.JOB_STORE_PATH = ":memory:";
+process.env.ALLOW_SERVER_SIGNING = "true";
+process.env.STELLAR_SECRET_KEY =
+    "SAEZSI6DY7AXJFIYA4PM6SIBONESDAFDIE2WBJ7B6Y4AZG3RB5HEYZJK";
+
+// The worker would otherwise submit to the network; stub it out.
+vi.mock("@/lib/stellar/batch-worker", () => ({
+    processJobInBackground: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createJob, updateJob, getJob } from "@/lib/job-store";
+import { POST } from "@/app/api/batch-retry/route";
+import type { BatchResult, PaymentInstruction } from "@/lib/stellar/types";
+
+const OWNER = "GBI5V7T3FEBDBV3DX23WHGHHXI6QYFWNUS7FGJU2WSQKFDGARW2HVAYA";
+const OTHER = "GBXR2LJHZWSW56XUIH35VPQMAP7BYKIUGWZJBP6HKSBSCRZSGD6XTY4N";
+const RECIPIENT_OK = "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H";
+const RECIPIENT_BAD = "GDX2CY6AP6MOZ5SBWOK2H43UCEWZJTQXXBI43RR5VMSY3O7HZHCTZAZL";
+
+const payments: PaymentInstruction[] = [
+    { address: RECIPIENT_OK, amount: "10.0000000", asset: "XLM", rowIndex: 0 },
+    { address: RECIPIENT_BAD, amount: "5.0000000", asset: "XLM", rowIndex: 1 },
+];
+
+const completedResult: BatchResult = {
+    batchId: "test-batch",
+    totalRecipients: 2,
+    totalAmount: "15.0000000",
+    totalTransactions: 1,
+    network: "testnet",
+    timestamp: new Date().toISOString(),
+    results: [
+        { recipient: RECIPIENT_OK, amount: "10.0000000", asset: "XLM", status: "success", transactionHash: "abc", rowIndex: 0 },
+        { recipient: RECIPIENT_BAD, amount: "5.0000000", asset: "XLM", status: "failed", transactionHash: undefined, error: "op_no_destination", rowIndex: 1 },
+    ],
+    summary: { successful: 1, failed: 1 },
+};
+
+function makeRequest(body: Record<string, unknown>) {
+    return new Request("http://localhost/api/batch-retry", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+    });
+}
+
+describe("POST /api/batch-retry (#388)", () => {
+    let jobId: string;
+
+    beforeEach(() => {
+        jobId = createJob(payments, "testnet", OWNER);
+        updateJob(jobId, { status: "completed", result: completedResult });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test("returns 400 when publicKey is missing", async () => {
+        const res = await POST(makeRequest({ jobId }) as never);
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toMatch(/publicKey/i);
+    });
+
+    test("returns 400 when publicKey is malformed", async () => {
+        const res = await POST(makeRequest({ jobId, publicKey: "not-a-key" }) as never);
+        expect(res.status).toBe(400);
+    });
+
+    test("returns 403 when publicKey does not match the job owner", async () => {
+        const res = await POST(makeRequest({ jobId, publicKey: OTHER }) as never);
+        expect(res.status).toBe(403);
+    });
+
+    test("creates a retry job owned by — and pollable with — the same key", async () => {
+        const res = await POST(makeRequest({ jobId, publicKey: OWNER }) as never);
+        expect(res.status).toBe(202);
+
+        const body = await res.json();
+        expect(body.jobId).toBeDefined();
+        expect(body.failedPayments).toBe(1);
+
+        // The retry job must be scoped to the owning wallet so the UI can poll
+        // GET /api/batch-status with the same publicKey (the bug left it orphaned).
+        const retryJob = getJob(body.jobId, OWNER);
+        expect(retryJob).toBeDefined();
+        expect(retryJob?.publicKey).toBe(OWNER);
+        expect(retryJob?.payments).toHaveLength(1);
+        expect(retryJob?.payments[0].address).toBe(RECIPIENT_BAD);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #388.

`POST /api/batch-retry` created the retry job with `createJob(failedPayments, job.network, job.publicKey || "")`. When the original job has no stored owner that produces a retry job with an empty `publicKey`, which `GET /api/batch-status/:jobId` can never poll — it mandates a valid `publicKey` query param — so the UI hangs forever on unknown status. The route also fetched the job without verifying the requesting wallet.

## Changes

- Require a valid `publicKey` in the POST body (`400` when missing/malformed, validated with `StrKey`).
- Reject retries from a wallet that does not own the job with `403`.
- Create the retry job under the verified owner key (never `""`), so it is owned by — and pollable with — the submitting account.
- Pass `publicKey` when the history page polls the retry job's status (the poll previously omitted it and would have hit the same `400`).

The dashboard caller already sends `{ jobId, publicKey }`, so this is backward compatible.

## Testing

`bunx vitest run tests/batch-retry.test.ts` → 4 passing:
- `400` when `publicKey` is missing / malformed;
- `403` on owner mismatch;
- successful retry → `202`, and the new job is retrievable via `getJob(retryJobId, ownerKey)` with the failed row preserved.