### PR TITLE
test(demo): guard React hook imports on the demo page (#391)

### DIFF
--- a/tests/demo-page-hooks.test.ts
+++ b/tests/demo-page-hooks.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression guard for #391.
+ *
+ * `app/demo/page.tsx` called `useEffect(...)` (session restore) while only
+ * importing `{ useState }` from "react". With `ignoreBuildErrors` on, the
+ * missing import slipped through and threw `ReferenceError: useEffect is not
+ * defined` at runtime on repeat visits with saved session state.
+ *
+ * Mounting the client component would need jsdom + testing-library; instead we
+ * statically assert that every React built-in hook the file *calls* is also
+ * *imported* from "react". This pins the exact failure mode without new deps.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const DEMO_PAGE = path.join(process.cwd(), "app", "demo", "page.tsx");
+const SOURCE = readFileSync(DEMO_PAGE, "utf8");
+
+// React 19 built-in hooks. Hooks not in this set (useToast, useBatchHistory,
+// useFreighter, useRouter, …) come from other modules and are out of scope.
+const REACT_HOOKS = new Set([
+  "use",
+  "useState",
+  "useEffect",
+  "useLayoutEffect",
+  "useRef",
+  "useMemo",
+  "useCallback",
+  "useReducer",
+  "useContext",
+  "useTransition",
+  "useDeferredValue",
+  "useId",
+  "useImperativeHandle",
+  "useSyncExternalStore",
+  "useDebugValue",
+  "useInsertionEffect",
+  "useOptimistic",
+  "useActionState",
+  "useFormStatus",
+]);
+
+/** Names brought in via `import { a, b as c } from "react"`. */
+function reactNamedImports(src: string): Set<string> {
+  const names = new Set<string>();
+  const re = /import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*["']react["']/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(src)) !== null) {
+    for (const part of match[1].split(",")) {
+      const original = part.trim().split(/\s+as\s+/)[0].trim();
+      if (original) names.add(original);
+    }
+  }
+  return names;
+}
+
+/** Distinct `useX(` call sites in the file. */
+function calledHooks(src: string): Set<string> {
+  const hooks = new Set<string>();
+  const re = /\b(use[A-Z][A-Za-z0-9]*)\s*\(/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(src)) !== null) hooks.add(match[1]);
+  return hooks;
+}
+
+describe("app/demo/page.tsx React hook imports (#391)", () => {
+  test("useEffect is imported from react", () => {
+    expect(reactNamedImports(SOURCE).has("useEffect")).toBe(true);
+  });
+
+  test("every React built-in hook it calls is imported from react", () => {
+    const imported = reactNamedImports(SOURCE);
+    const namespaceImport = /import\s+\*\s+as\s+\w+\s+from\s+["']react["']/.test(SOURCE);
+
+    const missing = [...calledHooks(SOURCE)].filter(
+      (hook) => REACT_HOOKS.has(hook) && !imported.has(hook) && !namespaceImport,
+    );
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #391.

#391 reported that `app/demo/page.tsx` called `useEffect(...)` while only importing `{ useState }` from "react", throwing `ReferenceError: useEffect is not defined` at runtime on repeat visits with saved session state (the crash was masked by `ignoreBuildErrors`).

The missing import itself was already corrected on `main` by commit `d71ce62` — line 3 now imports `{ useState, useEffect }`. This PR adds the **regression guard** the issue asked for so the failure mode can't silently return.

## What I did

- Added `tests/demo-page-hooks.test.ts`, which:
  - parses `app/demo/page.tsx` and collects the names imported from `"react"` and every `useX(` call site;
  - asserts `useEffect` is imported;
  - asserts that **every React built-in hook the file calls is also imported from `react`** (library hooks like `useToast`, `useBatchHistory`, `useFreighter` are out of scope).
- No production code change — the bug is already fixed; this pins it.

I chose a static source-level check over mounting the component because the demo page is a client component that would otherwise require adding jsdom + testing-library; this guard targets the exact `#391` failure mode (hook used but not imported) with no new dependencies.

## Testing

`bunx vitest run tests/demo-page-hooks.test.ts` → 2 passing. Verified the guard fails when the `useEffect` import is removed.