### PR TITLE
feat: Node 22, Docker app service, gitignore deploy artifacts, webhook delivery log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ next-env.d.ts
 # pnpm
 pnpm-lock.yaml
 contracts/target/
+
+# Stellar contract deploy artifacts
+contract_id_*.txt
+contract_id*.txt
+
+# SQLite data directory
+/data/
+data/*.db

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -210,7 +210,7 @@ vercel --prod
 For flexibility and multi-platform deployment:
 
 ```dockerfile
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -160,11 +160,19 @@ To work on the Soroban smart contracts, you need:
 
 We use the [Stellar Quickstart](https://github.com/stellar/docker-stellar-quickstart) Docker image to run a local network with Soroban RPC enabled.
 
-1. **Start the local node**:
+1. **Start the full stack** (Stellar node + Next.js app):
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
-   This starts a standalone network with Horizon on port `8000` and Soroban RPC on port `8001`.
+   This starts both the Stellar quickstart node and the Next.js app:
+   - Horizon on port `8000`
+   - Soroban RPC on port `8001`
+   - Next.js app on port `3000`
+
+   To run only the Stellar node (e.g. during active development with `npm run dev`):
+   ```bash
+   docker compose up -d stellar
+   ```
 
 2. **Configure Stellar CLI for Local**:
    ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/app/api/webhooks/deliveries/route.ts
+++ b/app/api/webhooks/deliveries/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getWebhookDeliveries } from "@/lib/job-store";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const jobId = searchParams.get("jobId") ?? undefined;
+  const webhookId = searchParams.get("webhookId") ?? undefined;
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam ? Math.min(parseInt(limitParam, 10), 500) : 100;
+
+  if (isNaN(limit) || limit < 1) {
+    return NextResponse.json({ error: "Invalid limit parameter" }, { status: 400 });
+  }
+
+  const deliveries = getWebhookDeliveries({ jobId, webhookId, limit });
+  return NextResponse.json({ deliveries });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,22 @@ services:
     networks:
       - stellar-network
 
+  app:
+    build: .
+    container_name: stellar-batch-pay-app
+    ports:
+      - "3000:3000"
+    environment:
+      - SOROBAN_RPC_URL=http://stellar:8001
+      - NEXT_PUBLIC_HORIZON_URL=http://stellar:8000
+      - NODE_ENV=production
+    depends_on:
+      - stellar
+    volumes:
+      - ./data:/app/data
+    networks:
+      - stellar-network
+
 volumes:
   stellar-data:
 

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -115,6 +115,21 @@ function getDb(): Database.Database {
     );
 
     CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expiresAt ON idempotency_keys (expiresAt);
+
+    CREATE TABLE IF NOT EXISTS webhook_deliveries (
+      id           TEXT PRIMARY KEY,
+      webhookId    TEXT NOT NULL,
+      jobId        TEXT,
+      event        TEXT NOT NULL,
+      status       TEXT NOT NULL,
+      responseCode INTEGER,
+      retryCount   INTEGER NOT NULL DEFAULT 0,
+      error        TEXT,
+      deliveredAt  TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_webhookId ON webhook_deliveries (webhookId);
+    CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_jobId ON webhook_deliveries (jobId);
   `);
 
   const columns = _db.prepare("PRAGMA table_info(jobs)").all() as Array<{ name: string }>;
@@ -473,4 +488,81 @@ export function countJobs(opts?: JobQueryFilters): number {
     .prepare(`SELECT COUNT(*) as cnt FROM jobs ${where}`)
     .get(...params) as { cnt: number };
   return row.cnt;
+}
+
+// ---------------------------------------------------------------------------
+// Webhook delivery log
+// ---------------------------------------------------------------------------
+
+export interface WebhookDeliveryLog {
+  webhookId: string;
+  jobId?: string;
+  event: string;
+  status: "success" | "failed";
+  responseCode?: number;
+  retryCount: number;
+  error?: string;
+}
+
+export interface WebhookDelivery extends WebhookDeliveryLog {
+  id: string;
+  deliveredAt: string;
+}
+
+/**
+ * Record the outcome of a single webhook delivery attempt.
+ * Called synchronously from triggerWebhooksWithRetry — uses better-sqlite3's
+ * sync API so no await is required at the call site.
+ */
+export function logWebhookDelivery(entry: WebhookDeliveryLog): void {
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO webhook_deliveries (id, webhookId, jobId, event, status, responseCode, retryCount, error, deliveredAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    crypto.randomUUID(),
+    entry.webhookId,
+    entry.jobId ?? null,
+    entry.event,
+    entry.status,
+    entry.responseCode ?? null,
+    entry.retryCount,
+    entry.error ?? null,
+    new Date().toISOString(),
+  );
+}
+
+/**
+ * Retrieve webhook delivery records, optionally filtered by jobId or webhookId.
+ * Returns newest-first, capped at `limit` rows (default 100).
+ */
+export function getWebhookDeliveries(opts?: {
+  jobId?: string;
+  webhookId?: string;
+  limit?: number;
+}): WebhookDelivery[] {
+  const db = getDb();
+  const limit = opts?.limit ?? 100;
+
+  if (opts?.jobId) {
+    return db
+      .prepare(
+        "SELECT * FROM webhook_deliveries WHERE jobId = ? ORDER BY deliveredAt DESC LIMIT ?",
+      )
+      .all(opts.jobId, limit) as WebhookDelivery[];
+  }
+
+  if (opts?.webhookId) {
+    return db
+      .prepare(
+        "SELECT * FROM webhook_deliveries WHERE webhookId = ? ORDER BY deliveredAt DESC LIMIT ?",
+      )
+      .all(opts.webhookId, limit) as WebhookDelivery[];
+  }
+
+  return db
+    .prepare(
+      "SELECT * FROM webhook_deliveries ORDER BY deliveredAt DESC LIMIT ?",
+    )
+    .all(limit) as WebhookDelivery[];
 }

--- a/package.json
+++ b/package.json
@@ -107,5 +107,8 @@
     "tw-animate-css": "1.3.3",
     "typescript": "^5",
     "vitest": "^4.0.18"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
Fixes #590
Fixes #591
Fixes #593
Fixes #605

## What changed

**Issue #590 — Require Node 22**
- Added `"engines": { "node": ">=22" }` to `package.json`
- Updated the sample `Dockerfile` in `DEPLOYMENT.md` from `node:18-alpine` to `node:22-alpine`

**Issue #591 — Docker Compose app service**
- Created `Dockerfile` (Node 22 Alpine) to build and run the Next.js app
- Added `app` service to `docker-compose.yml`: port 3000, `SOROBAN_RPC_URL` and `NEXT_PUBLIC_HORIZON_URL` env vars pointed at the `stellar` service, `depends_on: stellar`, and a `./data:/app/data` volume for SQLite persistence
- Updated `DEVELOPMENT.md` to document `docker compose up` for the full stack and `docker compose up -d stellar` for Stellar-only mode

**Issue #593 — Gitignore deploy artifacts and data directory**
- Added `contract_id_*.txt`, `contract_id*.txt`, `/data/`, and `data/*.db` to `.gitignore`

**Issue #605 — Webhook delivery persistence and query endpoint**
- Added `webhook_deliveries` SQLite table (with indexes on `webhookId` and `jobId`) to the `getDb()` schema in `lib/job-store.ts`
- Implemented `logWebhookDelivery(entry)` — synchronous write using better-sqlite3; called by the existing `triggerWebhooksWithRetry` in `lib/webhooks.ts` (which already had the `import` stub)
- Implemented `getWebhookDeliveries(opts?)` — query by `jobId` or `webhookId`, newest-first, capped at 100 rows by default
- Created `GET /api/webhooks/deliveries` route supporting `?jobId=`, `?webhookId=`, and `?limit=` query params

## Why

- Node 18 is EOL; the CI workflow already pins Node 22 — the `engines` field and Dockerfile should match
- No Dockerfile existed, so local Docker-based development required manual steps
- Contract deploy scripts emit `contract_id_*.txt` files and the SQLite DB lives in `data/` — both were getting tracked accidentally
- `triggerWebhooksWithRetry` already imported `logWebhookDelivery` but the function didn't exist, making any retry-path invocation throw at runtime

## How to test

- **590**: `node --version` must be ≥22; `npm install` with `engine-strict=true` set in `.npmrc` will reject older runtimes
- **591**: `docker compose up -d` → visit `http://localhost:3000`; Stellar RPC reachable at `http://localhost:8001`
- **593**: Create a `contract_id_test.txt` or `data/jobs.db` and confirm `git status` shows them as untracked (ignored)
- **605**: Trigger a webhook via `POST /api/webhooks/register` + a batch job, then `GET /api/webhooks/deliveries?jobId=<id>` — returns delivery records with status, responseCode, retryCount