### PR TITLE
ci: require stellar contract build, prod e2e, bun playwright config

### DIFF
--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -35,10 +35,20 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin/stellar
             contracts/target
-          key: ${{ runner.os }}-cargo-contracts-${{ hashFiles('contracts/Cargo.lock', 'contracts/Cargo.toml', 'contracts/batch-vesting/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-contracts-stellar-21.7.0-${{ hashFiles('contracts/Cargo.lock', 'contracts/Cargo.toml', 'contracts/batch-vesting/Cargo.toml') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-contracts-stellar-21.7.0-
             ${{ runner.os }}-cargo-contracts-
+
+      - name: Install Stellar CLI
+        run: |
+          if ! stellar --version 2>/dev/null | grep -q '21.7.0'; then
+            cargo install --locked stellar-cli --version 21.7.0 --features opt
+          else
+            echo "Stellar CLI 21.7.0 already cached."
+          fi
 
       - name: Run batch-vesting tests
         working-directory: contracts
@@ -48,13 +58,13 @@ jobs:
         working-directory: contracts
         run: cargo build --manifest-path batch-vesting/Cargo.toml --target wasm32-unknown-unknown --release
 
-      - name: Build with Stellar CLI if available
+      - name: Build with Stellar CLI
         working-directory: contracts/batch-vesting
-        shell: bash
-        continue-on-error: true
-        run: |
-          if command -v stellar >/dev/null 2>&1; then
-            stellar contract build --manifest-path Cargo.toml
-          else
-            echo "stellar CLI not available; skipping optional contract build."
-          fi
+        run: stellar contract build --manifest-path Cargo.toml
+
+      - name: Upload batch-vesting WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: batch-vesting-wasm
+          path: contracts/target/wasm32-unknown-unknown/release/batch_vesting.wasm
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,13 +26,35 @@ jobs:
       - name: Install deps
         run: bun install --frozen-lockfile
 
+      - name: Build production bundle
+        run: bun run build
+
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
+
+      - name: Start production server
+        run: bun run start &
+
+      - name: Wait for server to be ready
+        run: |
+          echo "Waiting for server on http://localhost:3000..."
+          timeout=60
+          elapsed=0
+          until curl -sf http://localhost:3000 >/dev/null 2>&1; do
+            if [ "$elapsed" -ge "$timeout" ]; then
+              echo "Server did not start within ${timeout}s" >&2
+              exit 1
+            fi
+            sleep 1
+            elapsed=$((elapsed + 1))
+          done
+          echo "Server is ready."
 
       - name: Run Playwright tests
         run: bunx playwright test
         env:
           CI: 'true'
+          E2E_BASE_URL: http://localhost:3000
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,11 +26,11 @@ export default defineConfig({
     },
   ],
   // Don't auto-start a server when E2E_BASE_URL is provided — the CI
-  // job points the suite at a pre-built preview.
+  // job points the suite at a pre-built production server.
   webServer: process.env.E2E_BASE_URL
     ? undefined
     : {
-        command: "npm run dev",
+        command: "bun run dev",
         url: "http://localhost:3000",
         reuseExistingServer: !process.env.CI,
         timeout: 120 * 1000,

--- a/scripts/keeper.ts
+++ b/scripts/keeper.ts
@@ -13,7 +13,6 @@ import { createSecretsProvider } from "../lib/secrets/index";
 import {
   decodeTopicValue,
   parseVestingEventRecipient,
-  parseVestingTransferred,
 } from "../lib/stellar/vesting-events";
 
 /**
@@ -245,35 +244,24 @@ async function fetchActiveRecipients(): Promise<string[]> {
       }
 
       for (const event of events.events) {
-        if (event.type === "contract" && Array.isArray(event.contractId)) {
-          const topics = event.contractId;
-          const eventNameTopic = topics[0];
+        if (event.type !== "contract") continue;
+        const topics: unknown[] = Array.isArray((event as any).topic)
+          ? (event as any).topic
+          : Array.isArray(event.contractId)
+            ? event.contractId
+            : [];
 
-          // Match vesting-related event names
-          if (eventNameTopic && typeof eventNameTopic === "object") {
-            const eventName =
-              (eventNameTopic as any).sym || String(eventNameTopic);
-            if (
-              eventName.includes("vested") ||
-              eventName.includes("created") ||
-              eventName.includes("revoked")
-            ) {
-              // Extract recipient address from event data
-              const eventData = (event as any).data;
-              if (Array.isArray(eventData) && eventData.length > 0) {
-                const recipientData = eventData[0];
-                if (recipientData && typeof recipientData === "object") {
-                  const recipientAddr =
-                    (recipientData as any).address ||
-                    (recipientData as any).recipientAddress ||
-                    String(recipientData);
-                  if (recipientAddr && recipientAddr.startsWith("G")) {
-                    recipients.add(recipientAddr);
-                  }
-                }
-              }
-            }
-          }
+        const eventName = decodeTopicValue(topics[0]);
+        if (!eventName) {
+          console.log(`Skipping event with undecodable name`);
+          continue;
+        }
+
+        const recipient = parseVestingEventRecipient(eventName, topics);
+        if (recipient) {
+          recipients.add(recipient);
+        } else {
+          console.log(`Skipping unknown event type: ${eventName}`);
         }
       }
 

--- a/tests/keeper-recipient-discovery.test.ts
+++ b/tests/keeper-recipient-discovery.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for the keeper's recipient discovery logic (#585).
+ *
+ * Validates that fetchActiveRecipients-style parsing uses
+ * decodeTopicValue + parseVestingEventRecipient rather than brittle
+ * string-includes heuristics.
+ */
+import {
+  decodeTopicValue,
+  parseVestingEventRecipient,
+} from "../lib/stellar/vesting-events";
+
+const RECIPIENT = "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ012345678901234";
+
+function makeTopics(eventName: string, ...rest: unknown[]): unknown[] {
+  return [{ sym: eventName }, ...rest];
+}
+
+function discoverRecipientFromEvent(event: {
+  type: string;
+  topic?: unknown[];
+  contractId?: unknown[];
+}): string | undefined {
+  if (event.type !== "contract") return undefined;
+  const topics: unknown[] = Array.isArray(event.topic)
+    ? event.topic
+    : Array.isArray(event.contractId)
+      ? event.contractId
+      : [];
+
+  const eventName = decodeTopicValue(topics[0]);
+  if (!eventName) return undefined;
+
+  return parseVestingEventRecipient(eventName, topics);
+}
+
+describe("keeper recipient discovery", () => {
+  describe("VestingDeposited", () => {
+    it("extracts recipient from topic index 2", () => {
+      const topics = makeTopics("VestingDeposited", "token_addr", RECIPIENT);
+      const result = parseVestingEventRecipient("VestingDeposited", topics);
+      expect(result).toBe(RECIPIENT);
+    });
+
+    it("returns undefined when recipient topic is missing", () => {
+      const topics = makeTopics("VestingDeposited", "token_addr");
+      const result = parseVestingEventRecipient("VestingDeposited", topics);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("VestingClaimed", () => {
+    it("extracts recipient from topic index 1", () => {
+      const topics = makeTopics("VestingClaimed", RECIPIENT);
+      const result = parseVestingEventRecipient("VestingClaimed", topics);
+      expect(result).toBe(RECIPIENT);
+    });
+  });
+
+  describe("VestingRevoked", () => {
+    it("extracts recipient from topic index 1", () => {
+      const topics = makeTopics("VestingRevoked", RECIPIENT);
+      const result = parseVestingEventRecipient("VestingRevoked", topics);
+      expect(result).toBe(RECIPIENT);
+    });
+  });
+
+  describe("VestingTransferred", () => {
+    it("extracts recipient from topic index 1", () => {
+      const topics = makeTopics("VestingTransferred", RECIPIENT);
+      const result = parseVestingEventRecipient("VestingTransferred", topics);
+      expect(result).toBe(RECIPIENT);
+    });
+  });
+
+  describe("VestingPartiallyRevoked", () => {
+    it("extracts recipient from topic index 1", () => {
+      const topics = makeTopics("VestingPartiallyRevoked", RECIPIENT);
+      const result = parseVestingEventRecipient(
+        "VestingPartiallyRevoked",
+        topics,
+      );
+      expect(result).toBe(RECIPIENT);
+    });
+  });
+
+  describe("unknown event types", () => {
+    it("returns undefined for unknown event name", () => {
+      const topics = makeTopics("SomeOtherEvent", RECIPIENT);
+      const result = parseVestingEventRecipient("SomeOtherEvent", topics);
+      expect(result).toBeUndefined();
+    });
+
+    it("does NOT match on substring heuristics like includes('vested')", () => {
+      // Old brittle code would match "VestingDeposited" via includes("vested")
+      // but also match "harvested" — the new code does exact matching
+      const result = parseVestingEventRecipient("harvested", [
+        { sym: "harvested" },
+        RECIPIENT,
+      ]);
+      expect(result).toBeUndefined();
+    });
+
+    it("does NOT match on includes('created') heuristic", () => {
+      const result = parseVestingEventRecipient("created", [
+        { sym: "created" },
+        RECIPIENT,
+      ]);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("decoverRecipientFromEvent integration", () => {
+    it("handles event with topic array field", () => {
+      const event = {
+        type: "contract",
+        topic: makeTopics("VestingClaimed", RECIPIENT),
+      };
+      expect(discoverRecipientFromEvent(event)).toBe(RECIPIENT);
+    });
+
+    it("handles event with contractId array as fallback", () => {
+      const event = {
+        type: "contract",
+        contractId: makeTopics("VestingRevoked", RECIPIENT) as any,
+      };
+      expect(discoverRecipientFromEvent(event)).toBe(RECIPIENT);
+    });
+
+    it("skips non-contract events", () => {
+      const event = {
+        type: "diagnostic",
+        topic: makeTopics("VestingClaimed", RECIPIENT),
+      };
+      expect(discoverRecipientFromEvent(event)).toBeUndefined();
+    });
+
+    it("skips events with empty topics", () => {
+      const event = { type: "contract", topic: [] };
+      expect(discoverRecipientFromEvent(event)).toBeUndefined();
+    });
+
+    it("deduplication: same recipient from multiple events collected once", () => {
+      const events = [
+        { type: "contract", topic: makeTopics("VestingDeposited", "tok", RECIPIENT) },
+        { type: "contract", topic: makeTopics("VestingClaimed", RECIPIENT) },
+        { type: "contract", topic: makeTopics("VestingRevoked", RECIPIENT) },
+      ];
+      const recipients = new Set<string>();
+      for (const ev of events) {
+        const r = discoverRecipientFromEvent(ev);
+        if (r) recipients.add(r);
+      }
+      expect(recipients.size).toBe(1);
+      expect(recipients.has(RECIPIENT)).toBe(true);
+    });
+  });
+
+  describe("decodeTopicValue", () => {
+    it("decodes sym object to string", () => {
+      expect(decodeTopicValue({ sym: "VestingDeposited" })).toBe(
+        "VestingDeposited",
+      );
+    });
+
+    it("passes through plain string", () => {
+      expect(decodeTopicValue("VestingClaimed")).toBe("VestingClaimed");
+    });
+
+    it("returns undefined for null", () => {
+      expect(decodeTopicValue(null)).toBeUndefined();
+    });
+
+    it("returns undefined for numeric topic", () => {
+      expect(decodeTopicValue(42)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **#584** — Switch Playwright `webServer.command` from `npm run dev` to `bun run dev` so local dev server is always started via bun
- **#583** — Run Playwright e2e tests against a production build in CI: add `bun run build`, start `bun run start` in background, health-check until port 3000 responds, then pass `E2E_BASE_URL=http://localhost:3000` to skip the webServer block in playwright.config.ts
- **#581** — Make the Stellar CLI contract build step required: install `stellar-cli@21.7.0` (cached), remove `continue-on-error` and the `command -v stellar` guard, call `stellar contract build` unconditionally, and upload the compiled WASM as a 7-day artifact
- **#585** — Refactor `fetchActiveRecipients` in `scripts/keeper.ts` to use `decodeTopicValue` + `parseVestingEventRecipient` parsers; remove brittle `includes("vested")` string heuristics; add 18 integration tests

## Test plan

- [ ] Contract CI: verify `Install Stellar CLI` step runs and is cached on repeat runs
- [ ] Contract CI: verify `Build with Stellar CLI` step fails the job on error (no silent skip)
- [ ] Contract CI: verify `batch-vesting-wasm` artifact is uploaded and downloadable
- [ ] E2E CI: verify `Build production bundle` completes before tests run
- [ ] E2E CI: verify health-check loop exits once server is up and tests run against port 3000
- [ ] Local: verify `bun run dev` is used when `E2E_BASE_URL` is unset
- [ ] Keeper: all 18 `keeper-recipient-discovery` tests pass

closes #581
closes #583
closes #584
closes #585