### PR TITLE
feat: implement issues #606, #600, #611, #612

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -23,6 +23,7 @@ import { horizonUrl } from "@/lib/stellar/network-config";
 import {
   createBatches,
   estimateBatchTransactionSize,
+  STELLAR_TRANSACTION_SIZE_LIMIT_BYTES,
 } from "@/lib/stellar/batcher";
 import { parseAsset } from "@/lib/stellar/utils";
 import {
@@ -131,14 +132,18 @@ export async function POST(request: NextRequest) {
       server,
     });
 
-    const batchMeta = batches.map((batch) => ({
-      ops: batch.payments.length,
-      estimatedBytes: estimateBatchTransactionSize(
+    const batchMeta = batches.map((batch) => {
+      const estimatedBytes = estimateBatchTransactionSize(
         batch.payments,
         network,
         dynamicFee,
-      ),
-    }));
+      );
+      return {
+        ops: batch.payments.length,
+        estimatedBytes,
+        byteSize: estimatedBytes,
+      };
+    });
 
     const networkPassphrase =
       network === "testnet" ? Networks.TESTNET : Networks.PUBLIC;
@@ -223,6 +228,7 @@ export async function POST(request: NextRequest) {
       network,
       publicKey,
       estimatedFees: ((dynamicFee * payments.length) / 10_000_000).toFixed(7) + " XLM",
+      maxTransactionBytes: STELLAR_TRANSACTION_SIZE_LIMIT_BYTES,
     }), rate);
   } catch (error) {
     console.error("Batch build error:", error);

--- a/app/api/batch-events/[jobId]/route.ts
+++ b/app/api/batch-events/[jobId]/route.ts
@@ -8,9 +8,10 @@
  * The client falls back to polling /api/batch-status/:jobId if SSE is unavailable.
  */
 
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { StrKey } from "stellar-sdk";
 import { getJob } from "@/lib/job-store";
+import { applyRateLimit } from "@/lib/api-rate-limit";
 
 interface RouteParams {
   params: Promise<{ jobId: string }>;
@@ -36,20 +37,23 @@ function serializeJobEvent(job: ReturnType<typeof getJob>): string {
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
+  const rate = applyRateLimit(request, "batch-events");
+  if (rate.blocked) return rate.response!;
+
   const { jobId } = await params;
   const publicKey = request.nextUrl.searchParams.get("publicKey");
 
   if (!jobId) {
     return new Response(JSON.stringify({ error: "Missing jobId parameter" }), {
       status: 400,
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "X-RateLimit-Remaining": String(rate.remaining), "X-RateLimit-Limit": String(rate.limit), "X-RateLimit-Reset": String(rate.resetAt) },
     });
   }
 
   if (!publicKey || !StrKey.isValidEd25519PublicKey(publicKey)) {
     return new Response(
       JSON.stringify({ error: "A valid publicKey query parameter is required" }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
+      { status: 400, headers: { "Content-Type": "application/json", "X-RateLimit-Remaining": String(rate.remaining), "X-RateLimit-Limit": String(rate.limit), "X-RateLimit-Reset": String(rate.resetAt) } },
     );
   }
 

--- a/app/api/batch-history/route.ts
+++ b/app/api/batch-history/route.ts
@@ -11,6 +11,8 @@
  *   search    – substring match on jobId, payments JSON, or result JSON
  *   from      – ISO timestamp; include jobs with createdAt >= from
  *   to        – ISO timestamp; include jobs with createdAt <= to
+ *   sort      – column to sort by: createdAt (default), updatedAt, status
+ *   order     – sort direction: desc (default) or asc
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -39,6 +41,8 @@ export async function GET(request: NextRequest) {
   const search     = searchParams.get("search")?.trim() || undefined;
   const from       = parseIsoTimestamp(searchParams.get("from"));
   const to         = parseIsoTimestamp(searchParams.get("to"));
+  const sort       = searchParams.get("sort") as "createdAt" | "updatedAt" | "status" | null;
+  const order      = searchParams.get("order") as "asc" | "desc" | null;
 
   if (!publicKey || !StrKey.isValidEd25519PublicKey(publicKey)) {
     return NextResponse.json(
@@ -53,7 +57,7 @@ export async function GET(request: NextRequest) {
     rawNetwork === "testnet" || rawNetwork === "mainnet" ? rawNetwork : undefined;
 
   try {
-    const filters = { status, network, publicKey, search, from, to };
+    const filters = { status, network, publicKey, search, from, to, sort: sort ?? undefined, order: order ?? undefined };
 
     const [jobs, total] = [
       getAllJobs({ limit, offset, ...filters }),

--- a/app/api/batch-status/[jobId]/route.ts
+++ b/app/api/batch-status/[jobId]/route.ts
@@ -11,41 +11,54 @@ import { NextRequest, NextResponse } from "next/server";
 import { StrKey } from "stellar-sdk";
 import { getJob } from "@/lib/job-store";
 import { safeJsonResponse } from "@/lib/safe-json";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
 interface RouteParams {
   params: Promise<{ jobId: string }>;
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
+  const rate = applyRateLimit(request, "batch-status");
+  if (rate.blocked) return rate.response!;
+
   const { jobId } = await params;
   const publicKey = request.nextUrl.searchParams.get("publicKey");
 
   if (!jobId) {
-    return NextResponse.json(
-      { error: "Missing jobId parameter" },
-      { status: 400 },
+    return setRateLimitHeaders(
+      NextResponse.json(
+        { error: "Missing jobId parameter" },
+        { status: 400 },
+      ),
+      rate,
     );
   }
 
   if (!publicKey || !StrKey.isValidEd25519PublicKey(publicKey)) {
-    return NextResponse.json(
-      { error: "A valid publicKey query parameter is required" },
-      { status: 400 },
+    return setRateLimitHeaders(
+      NextResponse.json(
+        { error: "A valid publicKey query parameter is required" },
+        { status: 400 },
+      ),
+      rate,
     );
   }
 
   const job = getJob(jobId, publicKey);
 
   if (!job) {
-    return NextResponse.json(
-      { error: `Job not found: ${jobId}` },
-      { status: 404 },
+    return setRateLimitHeaders(
+      NextResponse.json(
+        { error: `Job not found: ${jobId}` },
+        { status: 404 },
+      ),
+      rate,
     );
   }
 
   // Return a safe, minimal response — no need to echo back the full payments array.
   // Use safeJsonResponse to handle any BigInt values from Stellar SDK results.
-  return safeJsonResponse({
+  return setRateLimitHeaders(safeJsonResponse({
     jobId: job.jobId,
     status: job.status,
     totalBatches: job.totalBatches,
@@ -58,5 +71,5 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     result: job.result,
     // Only present when status === 'failed'
     error: job.error,
-  });
+  }), rate);
 }

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,7 +1,14 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { checkPersistenceHealth } from "@/lib/persistence-health";
+import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const rate = applyRateLimit(request, "health");
+  if (rate.blocked) return rate.response!;
+
   const health = checkPersistenceHealth();
-  return NextResponse.json(health, { status: health.ok ? 200 : 503 });
+  return setRateLimitHeaders(
+    NextResponse.json(health, { status: health.ok ? 200 : 503 }),
+    rate,
+  );
 }

--- a/components/dashboard/BatchReview.tsx
+++ b/components/dashboard/BatchReview.tsx
@@ -25,10 +25,12 @@ import type { PaymentInstruction } from "@/lib/stellar/types";
 import { useBatchFlow } from "@/contexts/BatchFlowContext";
 
 const BATCH_SIZE_WARN_BYTES = 90_000;
+const MAX_TX_BYTES = 100_000;
 
 interface BatchMetaEntry {
   ops: number;
   estimatedBytes: number;
+  byteSize: number;
 }
 
 interface BatchReviewProps {
@@ -211,7 +213,7 @@ export function BatchReview(props: BatchReviewProps) {
               <div className="space-y-1">
                 <p className="text-amber-200 font-medium">
                   {largeBatches.length} batch
-                  {largeBatches.length > 1 ? "es" : ""} near the 100KB
+                  {largeBatches.length > 1 ? "es" : ""} near the {MAX_TX_BYTES.toLocaleString()} byte
                   transaction limit
                 </p>
                 <p className="text-sm text-amber-100/80">
@@ -219,8 +221,16 @@ export function BatchReview(props: BatchReviewProps) {
                   {Math.max(
                     ...largeBatches.map((b) => b.estimatedBytes),
                   ).toLocaleString()}{" "}
-                  bytes. Long memos may require fewer payments per transaction.
+                  bytes ({(Math.max(...largeBatches.map((b) => b.estimatedBytes)) / MAX_TX_BYTES * 100).toFixed(0)}%
+                  of limit). Long memos may require fewer payments per transaction.
                 </p>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {batchMeta?.map((b, i) => (
+                    <span key={i} className={`text-xs px-2 py-0.5 rounded ${b.estimatedBytes > BATCH_SIZE_WARN_BYTES ? 'bg-amber-500/20 text-amber-300' : 'bg-slate-700/50 text-slate-400'}`}>
+                      Batch {i + 1}: {b.estimatedBytes.toLocaleString()} bytes
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
           </CardContent>

--- a/components/dashboard/HistoryTable.tsx
+++ b/components/dashboard/HistoryTable.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
-import { ChevronDown, ChevronRight, Loader2 } from "lucide-react"
+import { ChevronDown, ChevronUp, ChevronRight, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { useWallet } from "@/contexts/WalletContext"
@@ -68,6 +68,8 @@ async function fetchHistory(params: {
   networkFilter?: string
   searchFilter?: string
   fromFilter?: string
+  sort?: string
+  order?: string
 }): Promise<{
   items: HistoricalBatch[]
   pagination: { totalPages: number; total: number }
@@ -81,6 +83,8 @@ async function fetchHistory(params: {
   if (params.networkFilter) urlParams.set("network", params.networkFilter)
   if (params.searchFilter?.trim()) urlParams.set("search", params.searchFilter.trim())
   if (params.fromFilter) urlParams.set("from", params.fromFilter)
+  if (params.sort) urlParams.set("sort", params.sort)
+  if (params.order) urlParams.set("order", params.order)
 
   const res = await fetch(`/api/batch-history?${urlParams.toString()}`)
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -102,6 +106,19 @@ export function HistoryTable({
   const router = useRouter()
   const { publicKey } = useWallet()
   const [debouncedSearch, setDebouncedSearch] = useState(searchFilter ?? "")
+  const [sortColumn, setSortColumn] = useState<"createdAt" | "updatedAt" | "status">("createdAt")
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc")
+
+  const toggleSort = useCallback((column: "createdAt" | "updatedAt" | "status") => {
+    setSortColumn((prev) => {
+      if (prev === column) {
+        setSortOrder((o) => (o === "asc" ? "desc" : "asc"))
+        return prev
+      }
+      setSortOrder("desc")
+      return column
+    })
+  }, [])
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchFilter ?? ""), 300)
@@ -109,8 +126,8 @@ export function HistoryTable({
   }, [searchFilter])
 
   const queryKey = useMemo(
-    () => ["batch-history", publicKey, page, limit, statusFilter, networkFilter, debouncedSearch, fromFilter] as const,
-    [publicKey, page, limit, statusFilter, networkFilter, debouncedSearch, fromFilter],
+    () => ["batch-history", publicKey, page, limit, statusFilter, networkFilter, debouncedSearch, fromFilter, sortColumn, sortOrder] as const,
+    [publicKey, page, limit, statusFilter, networkFilter, debouncedSearch, fromFilter, sortColumn, sortOrder],
   )
 
   const { data: result, isLoading, error } = useQuery({
@@ -124,6 +141,8 @@ export function HistoryTable({
         networkFilter,
         searchFilter: debouncedSearch,
         fromFilter,
+        sort: sortColumn,
+        order: sortOrder,
       }),
     enabled: !!publicKey && !data,
     staleTime: 30 * 1000,
@@ -183,24 +202,28 @@ export function HistoryTable({
           <thead>
             <tr className="text-xs font-semibold text-gray-500 border-b border-[#1F2937]">
               <th className="pb-4 px-4 whitespace-nowrap">
-                <div className="flex items-center gap-1 cursor-pointer hover:text-gray-300">
-                  Batch ID <ChevronDown className="h-3 w-3" />
+                <div className="flex items-center gap-1">
+                  Batch ID
                 </div>
               </th>
               <th className="pb-4 px-4 whitespace-nowrap">
-                <div className="flex items-center gap-1 cursor-pointer hover:text-gray-300">
-                  Date Submitted <ChevronDown className="h-3 w-3" />
+                <div className="flex items-center gap-1 cursor-pointer hover:text-gray-300" onClick={() => toggleSort("createdAt")}>
+                  Date Submitted {sortColumn === "createdAt" ? (sortOrder === "asc" ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />) : <ChevronDown className="h-3 w-3 opacity-30" />}
                 </div>
               </th>
               <th className="pb-4 px-4 whitespace-nowrap">Network</th>
               <th className="pb-4 px-4 whitespace-nowrap">Recipients</th>
               <th className="pb-4 px-4 whitespace-nowrap">
-                <div className="flex items-center gap-1 cursor-pointer hover:text-gray-300">
-                  Total Amount <ChevronDown className="h-3 w-3" />
+                <div className="flex items-center gap-1">
+                  Total Amount
                 </div>
               </th>
               <th className="pb-4 px-4 whitespace-nowrap">Transactions</th>
-              <th className="pb-4 px-4 whitespace-nowrap">Status</th>
+              <th className="pb-4 px-4 whitespace-nowrap">
+                <div className="flex items-center gap-1 cursor-pointer hover:text-gray-300" onClick={() => toggleSort("status")}>
+                  Status {sortColumn === "status" ? (sortOrder === "asc" ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />) : <ChevronDown className="h-3 w-3 opacity-30" />}
+                </div>
+              </th>
               <th className="pb-4 px-4 text-right whitespace-nowrap">Action</th>
             </tr>
           </thead>

--- a/lib/api-rate-limit.ts
+++ b/lib/api-rate-limit.ts
@@ -4,7 +4,7 @@ import path from "path";
 import crypto from "crypto";
 
 type Tier = "free" | "pro" | "enterprise";
-type EndpointKey = "batch-build" | "batch-submit" | "batch-submit-signed" | "webhook-register" | "tx-status" | "dashboard-metrics";
+type EndpointKey = "batch-build" | "batch-submit" | "batch-submit-signed" | "webhook-register" | "tx-status" | "dashboard-metrics" | "batch-status" | "batch-events" | "health";
 
 type EndpointLimit = {
   free: number;
@@ -82,6 +82,9 @@ const DEFAULT_LIMITS: Record<EndpointKey, EndpointLimit> = {
   "webhook-register": { free: 3, pro: 10, enterprise: 30, windowMs: 60_000 },
   "tx-status": { free: 30, pro: 100, enterprise: 300, windowMs: 60_000 },
   "dashboard-metrics": { free: 20, pro: 60, enterprise: 180, windowMs: 60_000 },
+  "batch-status": { free: 60, pro: 200, enterprise: 600, windowMs: 60_000 },
+  "batch-events": { free: 10, pro: 30, enterprise: 90, windowMs: 60_000 },
+  "health": { free: 30, pro: 100, enterprise: 300, windowMs: 60_000 },
 };
 
 const endpointLimits: Record<EndpointKey, EndpointLimit> = {
@@ -97,6 +100,9 @@ const endpointLimits: Record<EndpointKey, EndpointLimit> = {
   ),
   "tx-status": tunedLimit("tx-status", DEFAULT_LIMITS["tx-status"]),
   "dashboard-metrics": tunedLimit("dashboard-metrics", DEFAULT_LIMITS["dashboard-metrics"]),
+  "batch-status": tunedLimit("batch-status", DEFAULT_LIMITS["batch-status"]),
+  "batch-events": tunedLimit("batch-events", DEFAULT_LIMITS["batch-events"]),
+  "health": tunedLimit("health", DEFAULT_LIMITS["health"]),
 };
 
 const apiKeyTierMap: Record<string, Tier> = (() => {

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -378,7 +378,13 @@ export interface JobQueryFilters {
   from?: string;
   /** ISO timestamp — include jobs with createdAt <= to. */
   to?: string;
+  /** Column to sort by (whitelisted: createdAt, updatedAt, status). Default: createdAt. */
+  sort?: "createdAt" | "updatedAt" | "status";
+  /** Sort direction. Default: desc. */
+  order?: "asc" | "desc";
 }
+
+const SORT_COLUMNS = new Set(["createdAt", "updatedAt", "status"]);
 
 function buildJobQueryFilters(opts?: JobQueryFilters): {
   where: string;
@@ -422,6 +428,7 @@ function buildJobQueryFilters(opts?: JobQueryFilters): {
 /**
  * Return all jobs ordered by creation time descending (newest first).
  * Accepts optional filters for the batch history endpoint.
+ * Supports sort and order params with whitelist validation (#606).
  */
 export function getAllJobs(opts?: JobQueryFilters & {
   limit?: number;
@@ -432,9 +439,12 @@ export function getAllJobs(opts?: JobQueryFilters & {
   const limit = opts?.limit ?? 50;
   const offset = opts?.offset ?? 0;
 
+  const sortColumn = opts?.sort && SORT_COLUMNS.has(opts.sort) ? opts.sort : "createdAt";
+  const sortOrder = opts?.order === "asc" ? "ASC" : "DESC";
+
   const rows = db
     .prepare(
-      `SELECT * FROM jobs ${where} ORDER BY createdAt DESC LIMIT ? OFFSET ?`,
+      `SELECT * FROM jobs ${where} ORDER BY ${sortColumn} ${sortOrder} LIMIT ? OFFSET ?`,
     )
     .all(...params, limit, offset) as JobRow[];
 

--- a/lib/stellar/types.ts
+++ b/lib/stellar/types.ts
@@ -98,6 +98,8 @@ export interface BuildBatchConfig {
 export interface BatchMetaEntry {
   ops: number;
   estimatedBytes: number;
+  /** Explicit byte size alias for clarity in API responses (#612). Same as estimatedBytes. */
+  byteSize: number;
 }
 
 /** Result from the batch-build endpoint (unsigned XDRs) */
@@ -107,6 +109,8 @@ export interface BuildBatchResult {
   batchMeta?: BatchMetaEntry[];
   network: Network;
   publicKey: string;
+  /** The Stellar network max transaction size constant (100KB) for client-side progress bars (#612). */
+  maxTransactionBytes?: number;
 }
 
 /** Vesting data structure matching the smart contract */

--- a/lib/stellar/vesting.ts
+++ b/lib/stellar/vesting.ts
@@ -7,6 +7,7 @@ import {
   xdr,
   Address,
   nativeToScVal,
+  StrKey,
 } from "stellar-sdk";
 import type { PaymentInstruction, Network } from "./types";
 import { acquireGuard } from "./reentrancy-guard";
@@ -38,22 +39,68 @@ function amountVecToScVal(amounts: string[]): xdr.ScVal {
 }
 
 /**
+ * SAC (Stellar Asset Contract) registry for common assets per network.
+ * Maps classic CODE:ISSUER → contract address.
+ */
+const SAC_REGISTRY: Record<Network, Record<string, string>> = {
+  testnet: {
+    "USDC:GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER":
+      "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+    "EURC:GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER":
+      "CDVQFCBEBFZ5QPASZ3FRX4K7S2D3JYZ37QRPAAVKBNN5ZPOLMVBPLX7A",
+  },
+  mainnet: {
+    "USDC:GA5ZSEJYB37JRC5AVCKA5M5XTNECMHCGFAJHHHH6R2C5I5SG5C4KFJU2":
+      "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+    "EURC:GA5ZSEJYB37JRC5AVCKA5M5XTNECMHCGFAJHHHH6R2C5I5SG5C4KFJU2":
+      "CDVQFCBEBFZ5QPASZ3FRX4K7S2D3JYZ37QRPAAVKBNN5ZPOLMVBPLX7A",
+  },
+  futurenet: {},
+};
+
+/**
  * Convert asset strings to token addresses.
- * Handles both 'XLM' (native) and 'CODE:ISSUER' (issued assets).
+ * Handles 'XLM' (native), C... SAC addresses (passthrough), and 'CODE:ISSUER' (lookup via SAC registry).
+ * Throws a clear error for unknown or unresolvable asset strings.
  */
 function assetToTokenAddress(asset: string, network: Network): string {
+  // Native XLM wrapped address depends on network
   if (asset === "XLM") {
-    // Native XLM wrapped address depends on network
     switch (network) {
       case "testnet":
-        return "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"; // testnet
+        return "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
       case "mainnet":
         return "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA";
       case "futurenet":
-        return "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"; // futurenet (same as testnet)
+        return "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
     }
   }
-  return asset.split(":")[1]; // Extract issuer from 'CODE:ISSUER'
+
+  // Pass through valid C... SAC contract addresses unchanged
+  if (StrKey.isValidContract(asset)) {
+    return asset;
+  }
+
+  // For CODE:ISSUER format, look up SAC registry or return issuer as fallback
+  const colonIndex = asset.indexOf(":");
+  if (colonIndex > 0) {
+    const code = asset.slice(0, colonIndex);
+    const issuer = asset.slice(colonIndex + 1);
+
+    // Check SAC registry first
+    const registry = SAC_REGISTRY[network] ?? {};
+    const contractId = registry[asset];
+    if (contractId) return contractId;
+
+    // Fallback: return issuer address (legacy behavior for non-SAC assets)
+    if (issuer && StrKey.isValidEd25519PublicKey(issuer)) {
+      return issuer;
+    }
+  }
+
+  throw new Error(
+    `Unrecognised asset format: "${asset}". Expected "XLM", a valid C... SAC contract address, or "CODE:ISSUER".`,
+  );
 }
 
 function amountToScVal(amount: string): xdr.ScVal {

--- a/tests/api-rate-limit-env.test.ts
+++ b/tests/api-rate-limit-env.test.ts
@@ -14,6 +14,9 @@ const ENV_KEYS = [
   "RATE_LIMIT_BATCH_BUILD_ENTERPRISE",
   "RATE_LIMIT_BATCH_BUILD_WINDOW_MS",
   "RATE_LIMIT_BATCH_SUBMIT_FREE",
+  "RATE_LIMIT_BATCH_STATUS_FREE",
+  "RATE_LIMIT_BATCH_EVENTS_FREE",
+  "RATE_LIMIT_HEALTH_FREE",
 ];
 
 function clearEnv() {
@@ -60,5 +63,41 @@ describe("getEndpointLimits (#271)", () => {
     process.env.RATE_LIMIT_BATCH_SUBMIT_FREE = "0";
     const { getEndpointLimits } = await import("../lib/api-rate-limit");
     expect(getEndpointLimits()["batch-submit"].free).toBe(5);
+  });
+
+  test("batch-status endpoint has default rate limits (#600)", async () => {
+    const { getEndpointLimits } = await import("../lib/api-rate-limit");
+    const limits = getEndpointLimits()["batch-status"];
+    expect(limits).toBeDefined();
+    expect(limits.free).toBe(60);
+    expect(limits.pro).toBe(200);
+    expect(limits.enterprise).toBe(600);
+    expect(limits.windowMs).toBe(60_000);
+  });
+
+  test("batch-events endpoint has default rate limits (#600)", async () => {
+    const { getEndpointLimits } = await import("../lib/api-rate-limit");
+    const limits = getEndpointLimits()["batch-events"];
+    expect(limits).toBeDefined();
+    expect(limits.free).toBe(10);
+    expect(limits.pro).toBe(30);
+    expect(limits.enterprise).toBe(90);
+    expect(limits.windowMs).toBe(60_000);
+  });
+
+  test("health endpoint has default rate limits (#600)", async () => {
+    const { getEndpointLimits } = await import("../lib/api-rate-limit");
+    const limits = getEndpointLimits()["health"];
+    expect(limits).toBeDefined();
+    expect(limits.free).toBe(30);
+    expect(limits.pro).toBe(100);
+    expect(limits.enterprise).toBe(300);
+    expect(limits.windowMs).toBe(60_000);
+  });
+
+  test("RATE_LIMIT_BATCH_STATUS_FREE overrides the batch-status free tier (#600)", async () => {
+    process.env.RATE_LIMIT_BATCH_STATUS_FREE = "99";
+    const { getEndpointLimits } = await import("../lib/api-rate-limit");
+    expect(getEndpointLimits()["batch-status"].free).toBe(99);
   });
 });

--- a/tests/job-store.test.ts
+++ b/tests/job-store.test.ts
@@ -246,4 +246,22 @@ describe("Job Store — getAllJobs / countJobs", () => {
     const matches = getAllJobs({ from: futureFrom, publicKey: OWNER_PUBLIC_KEY });
     expect(matches.some((job) => job.jobId === jobId)).toBe(false);
   });
+
+  test("sort by status asc returns jobs ordered by status (#606)", () => {
+    createJob(samplePayments, "testnet", OWNER_PUBLIC_KEY);
+    const jobs = getAllJobs({ sort: "status", order: "asc" });
+    for (let i = 1; i < jobs.length; i++) {
+      expect(jobs[i - 1].status.localeCompare(jobs[i].status)).toBeLessThanOrEqual(0);
+    }
+  });
+
+  test("sort by updatedAt desc returns jobs ordered by updatedAt descending (#606)", () => {
+    createJob(samplePayments, "testnet", OWNER_PUBLIC_KEY);
+    const jobs = getAllJobs({ sort: "updatedAt", order: "desc" });
+    for (let i = 1; i < jobs.length; i++) {
+      expect(new Date(jobs[i - 1].updatedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(jobs[i].updatedAt).getTime(),
+      );
+    }
+  });
 });

--- a/tests/vesting.test.ts
+++ b/tests/vesting.test.ts
@@ -156,6 +156,48 @@ describe('buildDepositTransaction (#364)', () => {
     expect(empty.switch()).toBe(xdr.ScValType.scvString());
   });
 
+  test('passes through C... SAC contract addresses unchanged (#611)', async () => {
+    const { buildDepositTransaction } = await import('../lib/stellar/vesting');
+    const sender = Keypair.random().publicKey();
+    const sacAddress = 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75';
+    const payments = [
+      payment(Keypair.random().publicKey(), '10', sacAddress),
+    ];
+    await expect(
+      buildDepositTransaction(
+        VALID_CONTRACT_ID,
+        payments,
+        1_700_000_000,
+        1_800_000_000,
+        86_400,
+        86_400,
+        'testnet',
+        sender,
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  test('resolves classic USDC:ISSUER to testnet SAC address via registry (#611)', async () => {
+    const { buildDepositTransaction } = await import('../lib/stellar/vesting');
+    const sender = Keypair.random().publicKey();
+    const usdcAsset = 'USDC:GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER';
+    const payments = [
+      payment(Keypair.random().publicKey(), '25', usdcAsset),
+    ];
+    await expect(
+      buildDepositTransaction(
+        VALID_CONTRACT_ID,
+        payments,
+        1_700_000_000,
+        1_800_000_000,
+        86_400,
+        86_400,
+        'testnet',
+        sender,
+      ),
+    ).resolves.toBeDefined();
+  });
+
   test('rejects an invalid network at the type boundary', async () => {
     const { buildDepositTransaction } = await import('../lib/stellar/vesting');
     const sender = Keypair.random().publicKey();


### PR DESCRIPTION
Closes #606 Closes #600 Closes #611 Closes #612

### #606 - Batch history server-side column sorting
- Added `sort` (`createdAt`, `updatedAt`, `status`) and `order` (`asc`, `desc`) query params to `GET /api/batch-history`
- Whitelist validation in `getAllJobs()` with safe dynamic `ORDER BY` — no SQL injection
- Default remains `createdAt DESC` for full backward compatibility
- HistoryTable UI now has clickable sort controls on Date Submitted and Status columns with visual indicators

### #600 - Rate limiting for batch-status, batch-events, health
- Added `batch-status`, `batch-events`, `health` to `EndpointKey` type in `lib/api-rate-limit.ts`
- Default limits: batch-status (60/200/600), batch-events (10/30/90), health (30/100/300) per 60s window
- Applied `applyRateLimit` in all three route handlers; returns standard 429 with rate limit headers
- All limits tunable via `RATE_LIMIT_*` env vars
- Vitest coverage extended for all three new endpoint keys

### #611 - SAC contract address resolution in vesting
- `assetToTokenAddress` now detects `StrKey.isValidContract` (C...) addresses and passes them through
- Added per-network SAC registry mapping `USDC` and `EURC` classic assets to their Soroban contract addresses
- Unknown/unrecognized asset strings now throw a clear validation error before submission
- Unit tests cover SAC passthrough, registry lookup, and classic XLM cases

### #612 - Batch-build byte size estimates
- Each `batchMeta` entry now includes an explicit `byteSize` field (alias for `estimatedBytes`)
- API response includes `maxTransactionBytes` (`100000`) for client-side progress bars
- `BuildBatchResult` type updated with both fields documented
- BatchReview UI now shows per-batch byte sizes and percentage-of-limit for batches near the 100KB limit