### PR TITLE
fix: add busy_timeout and retry logic for SQLite databases

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -223,6 +223,11 @@ The API stores batch jobs in SQLite via `better-sqlite3`. By default:
 | `JOB_STORE_PATH` | `./data/jobs.db` | Durable batch job state |
 | `RATE_LIMIT_DB_PATH` | `./data/rate-limit.db` | Per-key API rate limiting |
 
+SQLite is configured with:
+- **WAL mode** (Write-Ahead Logging)** for improved read concurrency.
+- **`busy_timeout = 5000ms`** to avoid immediate SQLITE_BUSY errors during concurrent writes.
+- **Retry with jitter** in `updateJob` to gracefully handle transient lock conflicts.
+
 Vercel serverless functions use a read-only filesystem except `/tmp`. Without
 explicit paths, job persistence can fail silently or reset on every cold start.
 

--- a/lib/api-rate-limit.ts
+++ b/lib/api-rate-limit.ts
@@ -37,6 +37,7 @@ function getDb(): Database.Database {
   _db = new Database(RATE_LIMIT_DB_PATH);
   _db.pragma("journal_mode = WAL");
   _db.pragma("foreign_keys = ON");
+  _db.pragma("busy_timeout = 5000");
 
   _db.exec(`
     CREATE TABLE IF NOT EXISTS rate_buckets (

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -84,6 +84,7 @@ function getDb(): Database.Database {
   // WAL mode for better concurrent read performance
   _db.pragma("journal_mode = WAL");
   _db.pragma("foreign_keys = ON");
+  _db.pragma("busy_timeout = 5000");
 
   _db.exec(`
     CREATE TABLE IF NOT EXISTS jobs (
@@ -326,46 +327,69 @@ export function updateJob(
   patch: Partial<Omit<JobState, "jobId" | "createdAt">>,
 ): void {
   const db = getDb();
+  let attempts = 0;
+  const maxAttempts = 2;
+  
+  while (attempts < maxAttempts) {
+    try {
+      const run = db.transaction(() => {
+        const row = db.prepare("SELECT * FROM jobs WHERE jobId = ?").get(jobId) as
+          | JobRow
+          | undefined;
+        if (!row) return;
 
-  const run = db.transaction(() => {
-    const row = db.prepare("SELECT * FROM jobs WHERE jobId = ?").get(jobId) as
-      | JobRow
-      | undefined;
-    if (!row) return;
+        const now = new Date().toISOString();
+        const nextVersion = row.version + 1;
 
-    const now = new Date().toISOString();
-    const nextVersion = row.version + 1;
+        const result = db.prepare(
+          `
+          UPDATE jobs SET
+            status           = ?,
+            totalBatches     = ?,
+            completedBatches = ?,
+            result           = ?,
+            error            = ?,
+            updatedAt        = ?,
+            version          = ?
+          WHERE jobId = ? AND version = ?
+        `,
+        ).run(
+          patch.status ?? row.status,
+          patch.totalBatches ?? row.totalBatches,
+          patch.completedBatches ?? row.completedBatches,
+          patch.result !== undefined ? JSON.stringify(patch.result) : row.result,
+          patch.error ?? row.error,
+          now,
+          nextVersion,
+          jobId,
+          row.version,
+        );
 
-    const result = db.prepare(
-      `
-      UPDATE jobs SET
-        status           = ?,
-        totalBatches     = ?,
-        completedBatches = ?,
-        result           = ?,
-        error            = ?,
-        updatedAt        = ?,
-        version          = ?
-      WHERE jobId = ? AND version = ?
-    `,
-    ).run(
-      patch.status ?? row.status,
-      patch.totalBatches ?? row.totalBatches,
-      patch.completedBatches ?? row.completedBatches,
-      patch.result !== undefined ? JSON.stringify(patch.result) : row.result,
-      patch.error ?? row.error,
-      now,
-      nextVersion,
-      jobId,
-      row.version,
-    );
+        if (result.changes === 0) {
+          throw new Error(`Concurrent modification error: job ${jobId} was updated by another process.`);
+        }
+      });
 
-    if (result.changes === 0) {
-      throw new Error(`Concurrent modification error: job ${jobId} was updated by another process.`);
+      run();
+      return;
+    } catch (error: any) {
+      attempts++;
+      
+      // Check if it's an SQLITE_BUSY error
+      const isSqliteBusy = 
+        error.code === "SQLITE_BUSY" || 
+        (typeof error.message === "string" && error.message.includes("SQLITE_BUSY"));
+      
+      if (!isSqliteBusy || attempts >= maxAttempts) {
+        throw error;
+      }
+      
+      // Wait with jitter before retrying
+      const jitter = Math.random() * 100;
+      const waitMs = 100 + jitter;
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, waitMs);
     }
-  });
-
-  run();
+  }
 }
 
 export interface JobQueryFilters {


### PR DESCRIPTION
Add busy_timeout = 5000ms to both job and rate limit databases to avoid SQLITE_BUSY errors. Add retry with jitter for SQLITE_BUSY in updateJob. Update DEPLOYMENT.md with SQLite configuration details.

## Changes Made
1. Added busy_timeout pragma to both databases (5000ms)
   
   - In lib/job-store.ts : Added _db.pragma("busy_timeout = 5000"); after WAL mode and foreign keys are enabled
   - In lib/api-rate-limit.ts : Added _db.pragma("busy_timeout = 5000"); after WAL mode and foreign keys are enabled
2. Added retry with jitter for SQLITE_BUSY in updateJob()
   
   - Added a loop that retries once if an SQLITE_BUSY error occurs
   - Uses random jitter (100-200ms) to avoid thundering herd problem
   - Still propagates errors after retry or for non-SQLITE_BUSY errors
3. Updated DEPLOYMENT.md
   
   - Added section explaining SQLite configuration:
     - WAL mode for read concurrency
     - busy_timeout = 5000ms for lock waiting
     - Retry with jitter in updateJob
   - Kept existing hosting recommendations
Closes #548 