### PR TITLE
fix(#543): enforce fee asset whitelist in contract config

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -28,18 +28,20 @@ export NODE_ENV="production"
 
 ### `ALLOW_SERVER_SIGNING` — Server-Side Transaction Signing (#596)
 
-| Variable | Default | Purpose |
-|---|---|---|
+| Variable               | Default         | Purpose                                                                             |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------- |
 | `ALLOW_SERVER_SIGNING` | `false` (unset) | Allow the server to sign and submit Stellar transactions using `STELLAR_SECRET_KEY` |
 
 **Default behaviour (unset or `"false"`):** The API routes `/api/batch-submit` and `/api/batch-retry` reject server-signing requests with HTTP 403. Users must sign via a connected client wallet (Freighter). This is the safe default for public deployments.
 
 **When `ALLOW_SERVER_SIGNING=true`:** The server signs transactions directly using `STELLAR_SECRET_KEY`. This is appropriate for:
+
 - Internal/trusted deployments where the server is not publicly accessible
 - Automated test pipelines (e.g. `tests/batch-submit.test.ts` sets this to `"true"`)
 - Staging environments running automated batch jobs
 
 **Security warnings:**
+
 - `ALLOW_SERVER_SIGNING=true` centralises key risk on the server. A compromised server can sign and submit arbitrary transactions.
 - Never enable on public-facing production endpoints without additional access controls (VPN, IP allowlist, or mutual TLS).
 - Requires `STELLAR_SECRET_KEY` to be set; the flag has no effect without it.
@@ -55,9 +57,13 @@ export STELLAR_SECRET_KEY="S..."
 ```
 
 > **API error when disabled:** `POST /api/batch-submit` or `/api/batch-retry` without server signing enabled returns:
+>
 > ```json
-> { "error": "Server-side signing is disabled. Use client-side signing with a connected wallet, or enable ALLOW_SERVER_SIGNING=true in server configuration." }
+> {
+>   "error": "Server-side signing is disabled. Use client-side signing with a connected wallet, or enable ALLOW_SERVER_SIGNING=true in server configuration."
+> }
 > ```
+>
 > See DEVELOPMENT.md for local test setup using this flag.
 
 ### Environment Variable Management
@@ -65,11 +71,13 @@ export STELLAR_SECRET_KEY="S..."
 **Do NOT commit `.env` files or secrets to version control.**
 
 **Recommended approach:**
+
 1. Use a secret management service (AWS Secrets Manager, HashiCorp Vault, etc.)
 2. Set environment variables at deployment time
 3. Use secure environment variable providers
 
 **For Vercel deployment:**
+
 ```bash
 vercel env add STELLAR_SECRET_KEY
 ```
@@ -132,10 +140,10 @@ Recipients with more than `MAINTENANCE_LIMIT` vesting schedule entries require
 multiple keeper runs to receive full TTL coverage. The bot persists a per-recipient
 `nextMaintenanceIndex` cursor between runs so progress is never lost.
 
-| Variable | Default | Purpose |
-|---|---|---|
-| `MAINTENANCE_LIMIT` | `10` | Number of schedule indices bumped per recipient per run |
-| `KEEPER_STATE_PATH` | `./data/keeper-state.json` | JSON file storing per-recipient pagination cursors |
+| Variable            | Default                    | Purpose                                                 |
+| ------------------- | -------------------------- | ------------------------------------------------------- |
+| `MAINTENANCE_LIMIT` | `10`                       | Number of schedule indices bumped per recipient per run |
+| `KEEPER_STATE_PATH` | `./data/keeper-state.json` | JSON file storing per-recipient pagination cursors      |
 
 **How many runs to achieve full coverage:**
 
@@ -172,13 +180,79 @@ Follow these steps to deploy and initialize the Soroban smart contract.
 ### 1. Prerequisites
 
 Ensure you have the following installed:
+
 - [Rust](https://www.rust-lang.org/tools/install)
 - [Stellar CLI](https://developers.stellar.org/docs/build/smart-contracts/getting-started/setup#install-the-stellar-cli)
 - Wasm target: `rustup target add wasm32-unknown-unknown`
 
+### 1a. Fee Asset Whitelist Configuration (#543)
+
+The batch-vesting contract enforces a **single whitelisted fee asset** stored in the contract `Config`. This prevents admin key compromise from allowing arbitrary token fee collection that could drain depositors.
+
+**Key points:**
+
+- The fee asset is set **once** during contract initialization via `set_config()`
+- `set_fee_config()` **no longer accepts** a `fee_asset` parameter — it only sets `fee_per_recipient` and `treasury`
+- All deposit fees are automatically collected in the whitelisted asset
+- Changing the fee asset requires a full `set_config()` call (admin-only)
+
+**Recommended fee assets:**
+
+- **Testnet/Mainnet**: Use native XLM (the network's Stellar Asset Contract address)
+- **Private networks**: Use the native asset SAC address for that network
+
+**Example initialization:**
+
+```bash
+# 1. Deploy contract
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/batch_vesting.wasm \
+  --source deployer \
+  --network testnet
+
+# 2. Set admin
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source deployer \
+  --network testnet \
+  -- set_admin --admin <ADMIN_ADDRESS>
+
+# 3. Initialize config with fee_asset (e.g., native XLM on testnet)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source deployer \
+  --network testnet \
+  -- set_config \
+  --admin <ADMIN_ADDRESS> \
+  --config '{
+    "max_batch_size": 100,
+    "max_schedules_per_recipient": 10,
+    "upgrade_timelock": 604800,
+    "fee_asset": "<XLM_SAC_ADDRESS>"
+  }'
+
+# 4. Set fee parameters (fee_asset NOT included — comes from config)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source deployer \
+  --network testnet \
+  -- set_fee_config \
+  --admin <ADMIN_ADDRESS> \
+  --fee_per_recipient 10000000 \
+  --treasury <TREASURY_ADDRESS>
+```
+
+**Security notes:**
+
+- Use a **Stellar multisig** (M-of-N threshold) for the admin account to prevent single-key compromise
+- The `fee_asset` should be a **liquid, trusted token** (native XLM recommended)
+- Never set `fee_asset` to a custom/illiquid token that depositors cannot easily obtain
+- Document the chosen fee asset in your deployment runbook for transparency
+
 ### 2. Configure CLI Identity
 
 Create an identity for deployment:
+
 ```bash
 stellar keys generate --network testnet deployer
 ```
@@ -186,6 +260,7 @@ stellar keys generate --network testnet deployer
 ### 3. Build the Contract
 
 Navigate to the contract directory and build the release Wasm:
+
 ```bash
 cd contracts/batch-vesting
 cargo build --target wasm32-unknown-unknown --release
@@ -197,6 +272,7 @@ The compiled contract will be available at:
 ### 4. Deploy to Testnet
 
 Deploy the contract and capture the **Contract ID**:
+
 ```bash
 stellar contract deploy \
   --wasm target/wasm32-unknown-unknown/release/batch_vesting.wasm \
@@ -210,6 +286,7 @@ stellar contract deploy \
 ### 5. Frontend Integration
 
 Update your frontend `.env` file with the newly deployed Contract ID:
+
 ```bash
 NEXT_PUBLIC_CONTRACT_ID="C..."
 ```
@@ -218,9 +295,9 @@ NEXT_PUBLIC_CONTRACT_ID="C..."
 
 The API stores batch jobs in SQLite via `better-sqlite3`. By default:
 
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `JOB_STORE_PATH` | `./data/jobs.db` | Durable batch job state |
+| Variable             | Default                | Purpose                   |
+| -------------------- | ---------------------- | ------------------------- |
+| `JOB_STORE_PATH`     | `./data/jobs.db`       | Durable batch job state   |
 | `RATE_LIMIT_DB_PATH` | `./data/rate-limit.db` | Per-key API rate limiting |
 
 Vercel serverless functions use a read-only filesystem except `/tmp`. Without
@@ -270,6 +347,7 @@ vercel --prod
 ```
 
 **Advantages:**
+
 - Zero-config deployment
 - Automatic scaling
 - Global CDN
@@ -282,7 +360,7 @@ For flexibility and multi-platform deployment, use the committed
 [`Dockerfile`](../Dockerfile) at the repo root. It is a multi-stage build
 based on `node:22-alpine` that:
 
-```dockerfile
+````dockerfile
 FROM node:22-alpine
 
 The accompanying `.dockerignore` keeps `node_modules`, `.next`,
@@ -291,9 +369,10 @@ The accompanying `.dockerignore` keeps `node_modules`, `.next`,
 **Build:**
 ```bash
 docker build -t stellar-bulk-pay:latest .
-```
+````
 
 **Run locally:**
+
 ```bash
 docker run --rm -p 3000:3000 \
   -e NODE_ENV=production \
@@ -303,12 +382,14 @@ docker run --rm -p 3000:3000 \
 ```
 
 **Push:**
+
 ```bash
 docker tag stellar-bulk-pay:latest myregistry/stellar-bulk-pay:latest
 docker push myregistry/stellar-bulk-pay:latest
 ```
 
 **Deploy to container service:**
+
 - AWS ECS — mount an EFS volume at `/app/data` if you need durable SQLite.
 - Google Cloud Run — pair with a managed database, or accept that
   `data/` resets on each container instance.
@@ -347,12 +428,14 @@ pm2 startup
 ### 1. Secret Management
 
 **Never:**
+
 - Commit `.env` files
 - Pass secrets as command-line arguments
 - Log secret keys
 - Store in comments or documentation
 
 **Always:**
+
 - Use environment variables
 - Rotate keys regularly
 - Use secret management service
@@ -364,14 +447,14 @@ pm2 startup
 # HTTPS configuration
 server {
     listen 443 ssl http2;
-    
+
     ssl_certificate /path/to/cert.pem;
     ssl_certificate_key /path/to/key.pem;
-    
+
     # Enforce HTTPS
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
-    
+
     location / {
         proxy_pass http://localhost:3000;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -385,14 +468,14 @@ Protect against abuse:
 
 ```typescript
 // Example rate limiter middleware
-import rateLimit from 'express-rate-limit';
+import rateLimit from "express-rate-limit";
 
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 100, // Limit each IP to 100 requests per windowMs
 });
 
-app.use('/api/', apiLimiter);
+app.use("/api/", apiLimiter);
 ```
 
 ### 4. Input Validation
@@ -403,8 +486,8 @@ Always validate at the edge:
 // Validate batch size
 if (payments.length > 10000) {
   return NextResponse.json(
-    { error: 'Batch size exceeds limit' },
-    { status: 400 }
+    { error: "Batch size exceeds limit" },
+    { status: 400 },
   );
 }
 ```
@@ -412,12 +495,14 @@ if (payments.length > 10000) {
 ### 5. Logging Security
 
 **Safe to log:**
+
 - Transaction hashes
 - Public keys (anonymized)
 - Error types (not messages)
 - Timestamps
 
 **Never log:**
+
 - Secret keys
 - Full request/response bodies
 - User IP addresses (unless authorized)
@@ -425,14 +510,14 @@ if (payments.length > 10000) {
 
 ```typescript
 // Safe logging
-console.log('[Payment] Transaction submitted:', {
+console.log("[Payment] Transaction submitted:", {
   hash: txHash,
   recipientCount: payments.length,
   timestamp: new Date().toISOString(),
 });
 
 // Avoid
-console.log('[Payment] Full config:', config); // Might contain secrets
+console.log("[Payment] Full config:", config); // Might contain secrets
 ```
 
 ## Monitoring and Observability
@@ -443,15 +528,15 @@ Track key metrics:
 
 ```typescript
 // Example with StatsD
-import StatsD from 'node-dogstatsd';
+import StatsD from "node-dogstatsd";
 
 const dogstatsd = new StatsD();
 
 // Track batch submissions
-dogstatsd.gauge('batches.size', payments.length);
-dogstatsd.timing('batches.duration', duration);
-dogstatsd.increment('batches.successful');
-dogstatsd.increment('batches.failed');
+dogstatsd.gauge("batches.size", payments.length);
+dogstatsd.timing("batches.duration", duration);
+dogstatsd.increment("batches.successful");
+dogstatsd.increment("batches.failed");
 ```
 
 ### Error Tracking
@@ -474,7 +559,15 @@ Sentry.init({
 The application includes a structured JSON logger located at `lib/logger.ts` and Next.js middleware that assigns a unique correlation ID (`x-request-id`) to every incoming API request. The logger automatically anonymizes sensitive Stellar public keys (e.g., truncating them to `GB3...XYZ`) and outputs logs in JSON format:
 
 ```json
-{"level":"info","timestamp":"2026-05-31T20:00:00.000Z","requestId":"a4f9c8f0-1e0f-4d77-9db6-9afcd21b8d05","jobId":"5f8b3c20-3b02-4e63-bd4f-3f6291a13bfd","publicKey":"GB3...XYZ","network":"testnet","msg":"Batch submit job queued and background worker triggered"}
+{
+  "level": "info",
+  "timestamp": "2026-05-31T20:00:00.000Z",
+  "requestId": "a4f9c8f0-1e0f-4d77-9db6-9afcd21b8d05",
+  "jobId": "5f8b3c20-3b02-4e63-bd4f-3f6291a13bfd",
+  "publicKey": "GB3...XYZ",
+  "network": "testnet",
+  "msg": "Batch submit job queued and background worker triggered"
+}
 ```
 
 #### Datadog / CloudWatch Integration
@@ -555,7 +648,7 @@ function validateCached(payment: PaymentInstruction) {
 For database connections:
 
 ```typescript
-import { Pool } from 'pg';
+import { Pool } from "pg";
 
 const pool = new Pool({
   max: 20,
@@ -570,8 +663,8 @@ Tune batch size based on network conditions:
 
 ```typescript
 // Adaptive batch sizing
-const getBatchSize = (network: 'testnet' | 'mainnet') => {
-  if (network === 'testnet') return 100;
+const getBatchSize = (network: "testnet" | "mainnet") => {
+  if (network === "testnet") return 100;
   // Mainnet might have higher fees, use smaller batches
   return 50;
 };
@@ -735,6 +828,7 @@ curl http://localhost:3000/api/health
 ## Support
 
 For deployment issues:
+
 - Check application logs
 - Review Stellar network status
 - Consult DEVELOPMENT.md for debugging

--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -66,6 +66,10 @@ pub struct Config {
     pub max_batch_size: u32,
     pub max_schedules_per_recipient: u32,
     pub upgrade_timelock: u64,
+    /// #543: The only token accepted for fee collection. Set at contract
+    /// initialization and cannot be changed without a full config update.
+    /// This prevents admin from switching to an arbitrary/scam token.
+    pub fee_asset: Address,
 }
 
 #[contracttype]
@@ -76,8 +80,8 @@ pub struct FeeConfig {
     pub fee_per_recipient: i128,
     /// Address that receives collected fees (treasury or admin wallet).
     pub treasury: Address,
-    /// #302: The asset used for fee collection. Must be validated to be native XLM.
-    pub fee_asset: Address,
+    /// #543: fee_asset removed from FeeConfig - now stored in contract Config
+    /// to prevent admin from changing the fee token arbitrarily.
 }
 
 /// Legacy storage type used only during migration from the old Vec<VestingData> layout.
@@ -148,6 +152,8 @@ pub enum VestingError {
     NotRecipient = 17,
     /// #308: batch_revoke requests were not provided in strictly descending index order.
     InvalidInput = 18,
+    /// #543: Provided fee asset is not the whitelisted token from contract config.
+    InvalidToken = 19,
 }
 
 impl BatchVestingContract {
@@ -188,11 +194,7 @@ impl BatchVestingContract {
         env.storage()
             .persistent()
             .get(&DataKey::Config)
-            .unwrap_or(Config {
-                max_batch_size: MAX_BATCH_SIZE,
-                max_schedules_per_recipient: MAX_SCHEDULES_PER_RECIPIENT,
-                upgrade_timelock: UPGRADE_TIMELOCK,
-            })
+            .unwrap_or_else(|| soroban_sdk::panic_with_error!(env, VestingError::NotFound))
     }
 
     fn set_config_internal(env: &Env, config: &Config) {
@@ -672,11 +674,14 @@ impl BatchVestingContract {
         }
 
         // Collect per-recipient fee if configured.
-        // The fee is charged in the configured fee_asset token (typically native XLM).
+        // The fee is charged in the contract's whitelisted fee_asset token (typically native XLM).
         // Fees are transferred directly to the treasury — they never enter the
         // vesting pool, so recipients are unaffected.
+        // #543: fee_asset comes from contract config, not fee_config, preventing
+        // admin from switching to an arbitrary/scam token after deployment.
         if let Some(fee_cfg) = Self::get_fee_config(&env) {
             if fee_cfg.fee_per_recipient > 0 {
+                let config = Self::get_config(&env);
                 let n = recipients.len() as i128;
                 let total_fee = fee_cfg
                     .fee_per_recipient
@@ -684,13 +689,13 @@ impl BatchVestingContract {
                     .unwrap_or_else(|| soroban_sdk::panic_with_error!(&env, VestingError::Overflow));
                 // #331: Always transfer fees in fee_asset regardless of batch token composition.
                 // Multi-token batches may have different assets; fees are always collected
-                // in the configured fee_asset (typically native XLM), not tokens[0].
-                let fee_token_client = token::Client::new(&env, &fee_cfg.fee_asset);
+                // in the whitelisted fee_asset (typically native XLM), not tokens[0].
+                let fee_token_client = token::Client::new(&env, &config.fee_asset);
                 fee_token_client.transfer(&sender, &fee_cfg.treasury, &total_fee);
 
                 env.events().publish(
                     (Symbol::new(&env, "FeeCollected"), sender.clone()),
-                    (total_fee, fee_cfg.fee_asset.clone(), fee_cfg.treasury),
+                    (total_fee, config.fee_asset.clone(), fee_cfg.treasury),
                 );
             }
         }
@@ -772,13 +777,16 @@ impl BatchVestingContract {
     }
 
     /// Update contract configuration. Only admin can call this.
+    ///
+    /// #543: The `fee_asset` field sets the single whitelisted token for fee
+    /// collection. Once set, fees can only be collected in this token.
     pub fn set_config(env: Env, admin: Address, config: Config) {
         Self::require_current_admin(&env, &admin);
         Self::set_config_internal(&env, &config);
 
         env.events().publish(
             (Symbol::new(&env, "ConfigUpdated"),),
-            (config.max_batch_size, config.max_schedules_per_recipient, config.upgrade_timelock),
+            (config.max_batch_size, config.max_schedules_per_recipient, config.upgrade_timelock, config.fee_asset),
         );
     }
 
@@ -786,8 +794,11 @@ impl BatchVestingContract {
     ///
     /// Set `fee_per_recipient` to 0 to disable fees entirely.
     /// The `treasury` address receives all collected fees.
-    /// The `fee_asset` parameter specifies which token (typically native XLM)
-    /// is used for fee collection and must be validated against a whitelist.
+    ///
+    /// #543 Security: The fee asset is NOT configurable here — it is set once
+    /// at contract initialization via `set_config` and stored in the contract
+    /// config. This prevents a malicious or compromised admin from switching
+    /// the fee asset to an arbitrary/scam token to drain depositors.
     ///
     /// Security note: fees are immutable within a single `deposit` transaction —
     /// the fee parameters are read once at the start of each deposit call,
@@ -797,20 +808,21 @@ impl BatchVestingContract {
     /// appropriate low/med/high thresholds so that fee changes require
     /// M-of-N signers, preventing a single compromised key from draining
     /// depositors via inflated fees.
-    pub fn set_fee_config(env: Env, admin: Address, fee_per_recipient: i128, treasury: Address, fee_asset: Address) {
+    pub fn set_fee_config(env: Env, admin: Address, fee_per_recipient: i128, treasury: Address) {
         Self::require_current_admin(&env, &admin);
         if fee_per_recipient < 0 {
             soroban_sdk::panic_with_error!(&env, VestingError::InvalidAmount);
         }
-        // #302: Validate that the fee asset is the expected fee token (whitelisted)
-        // For now, we accept the fee_asset as-is. In production, you may want to
-        // validate against a whitelist of known XLM contract addresses.
-        let config = FeeConfig { fee_per_recipient, treasury: treasury.clone(), fee_asset: fee_asset.clone() };
+        // #543: fee_asset is intentionally NOT a parameter — it comes from config
+        // and cannot be changed via this function.
+        let config = FeeConfig { fee_per_recipient, treasury: treasury.clone() };
         Self::set_fee_config_internal(&env, &config);
 
+        // #543: Emit event with the whitelisted fee asset from config for transparency
+        let contract_config = Self::get_config(&env);
         env.events().publish(
             (Symbol::new(&env, "FeeConfigUpdated"),),
-            (fee_per_recipient, treasury, fee_asset),
+            (fee_per_recipient, treasury, contract_config.fee_asset),
         );
     }
 

--- a/contracts/batch-vesting/src/test.rs
+++ b/contracts/batch-vesting/src/test.rs
@@ -2818,3 +2818,260 @@ fn test_batch_revoke_different_recipients_any_order() {
     assert_eq!(results.get(0).unwrap(), true);
     assert_eq!(results.get(1).unwrap(), true);
 }
+
+// ── #543: Fee asset whitelist tests ───────────────────────────────────────────
+
+/// Verify that set_fee_config no longer accepts fee_asset as a parameter.
+/// The fee asset is now controlled by the contract config, not fee_config.
+#[test]
+fn test_set_fee_config_uses_whitelisted_asset_from_config() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    // Create two different token contracts
+    let (token_a, token_admin_a) = create_token_contract(&env, &Address::generate(&env));
+    let (token_b, token_admin_b) = create_token_contract(&env, &Address::generate(&env));
+
+    // Set admin
+    client.set_admin(&admin);
+
+    // Initialize config with token_a as the whitelisted fee asset
+    let config = Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 7 * 24 * 60 * 60,
+        fee_asset: token_a.address.clone(),
+    };
+    client.set_config(&admin, &config);
+
+    // Set fee config (no fee_asset parameter anymore)
+    client.set_fee_config(&admin, &100, &treasury);
+
+    // Mint tokens for fee payment
+    token_admin_a.mint(&sender, &1000);
+    token_admin_b.mint(&sender, &1000);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+
+    // Deposit should succeed and collect fees in token_a (the whitelisted asset)
+    client.deposit(
+        &sender,
+        &Vec::from_array(&env, [token_a.address.clone()]),
+        &Vec::from_array(&env, [recipient.clone()]),
+        &Vec::from_array(&env, [100i128]),
+        &0,
+        &1000,
+        &0,
+        &0,
+        &Vec::from_array(&env, [String::from_str(&env, "")]),
+    );
+
+    // Verify fees were collected in token_a (whitelisted), not token_b
+    assert_eq!(token_a.balance(&treasury), 100); // 1 recipient * 100 fee
+    assert_eq!(token_a.balance(&sender), 900); // 1000 - 100 fee - 100 deposited
+    assert_eq!(token_b.balance(&treasury), 0); // No fees in token_b
+}
+
+/// Verify that deposit fails if sender doesn't have the whitelisted fee asset.
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #5)")]
+fn test_deposit_fails_without_whitelisted_fee_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let (token_a, token_admin_a) = create_token_contract(&env, &Address::generate(&env));
+    let (token_b, _) = create_token_contract(&env, &Address::generate(&env));
+
+    // Set admin and config with token_a as fee asset
+    client.set_admin(&admin);
+    let config = Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 7 * 24 * 60 * 60,
+        fee_asset: token_a.address.clone(),
+    };
+    client.set_config(&admin, &config);
+
+    // Set fee config
+    client.set_fee_config(&admin, &100, &Address::generate(&env));
+
+    // Mint only token_b to sender (not the whitelisted token_a)
+    token_admin_a.mint(&sender, &0); // No token_a
+    token_admin_b.mint(&sender, &1000); // Only token_b
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+
+    // Deposit with token_b should fail because fees require token_a
+    client.deposit(
+        &sender,
+        &Vec::from_array(&env, [token_b.address.clone()]),
+        &Vec::from_array(&env, [recipient.clone()]),
+        &Vec::from_array(&env, [100i128]),
+        &0,
+        &1000,
+        &0,
+        &0,
+        &Vec::from_array(&env, [String::from_str(&env, "")]),
+    );
+}
+
+/// Verify that fees are always collected in the whitelisted asset,
+/// regardless of which token is used for the vesting deposit.
+#[test]
+fn test_fees_collected_in_whitelisted_asset_not_deposit_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let (token_xlm, token_admin_xlm) = create_token_contract(&env, &Address::generate(&env));
+    let (token_usdc, token_admin_usdc) = create_token_contract(&env, &Address::generate(&env));
+
+    // Set admin and config with XLM as fee asset
+    client.set_admin(&admin);
+    let config = Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 7 * 24 * 60 * 60,
+        fee_asset: token_xlm.address.clone(), // XLM is whitelisted
+    };
+    client.set_config(&admin, &config);
+
+    // Set fee config: 50 XLM per recipient
+    client.set_fee_config(&admin, &50, &treasury);
+
+    // Mint both tokens to sender
+    token_admin_xlm.mint(&sender, &1000);
+    token_admin_usdc.mint(&sender, &1000);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+
+    // Deposit using USDC (not the fee asset)
+    client.deposit(
+        &sender,
+        &Vec::from_array(&env, [token_usdc.address.clone()]),
+        &Vec::from_array(&env, [recipient.clone()]),
+        &Vec::from_array(&env, [200i128]),
+        &0,
+        &1000,
+        &0,
+        &0,
+        &Vec::from_array(&env, [String::from_str(&env, "")]),
+    );
+
+    // Verify: fees collected in XLM (whitelisted), not USDC (deposit token)
+    assert_eq!(token_xlm.balance(&treasury), 50); // Fee in XLM
+    assert_eq!(token_xlm.balance(&sender), 950); // 1000 - 50 fee
+    assert_eq!(token_usdc.balance(&sender), 800); // 1000 - 200 deposited
+    assert_eq!(token_usdc.balance(&treasury), 0); // No USDC fees
+}
+
+/// Verify that FeeConfigUpdated event includes the whitelisted fee asset from config.
+#[test]
+fn test_fee_config_event_includes_whitelisted_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let (token_xlm, _) = create_token_contract(&env, &Address::generate(&env));
+    let treasury = Address::generate(&env);
+
+    // Set admin and config
+    client.set_admin(&admin);
+    let config = Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 7 * 24 * 60 * 60,
+        fee_asset: token_xlm.address.clone(),
+    };
+    client.set_config(&admin, &config);
+
+    // Set fee config
+    client.set_fee_config(&admin, &75, &treasury);
+
+    // Verify FeeConfigUpdated event contains the whitelisted fee asset
+    let events = env.events().all();
+    let fee_config_event = events.get(events.len() - 1).unwrap();
+    let event_topics = fee_config_event.1;
+    let topic: Symbol = event_topics.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic, Symbol::new(&env, "FeeConfigUpdated"));
+
+    let event_data: (i128, Address, Address) = fee_config_event.2.try_into_val(&env).unwrap();
+    assert_eq!(event_data.0, 75i128); // fee_per_recipient
+    assert_eq!(event_data.1, treasury); // treasury
+    assert_eq!(event_data.2, token_xlm.address); // whitelisted fee_asset from config
+}
+
+/// Verify that zero fees work correctly with the whitelist system.
+#[test]
+fn test_zero_fees_with_whitelisted_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let (token, token_admin) = create_token_contract(&env, &Address::generate(&env));
+
+    // Set admin and config
+    client.set_admin(&admin);
+    let config = Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 7 * 24 * 60 * 60,
+        fee_asset: token.address.clone(),
+    };
+    client.set_config(&admin, &config);
+
+    // Set fee to 0 (disabled)
+    client.set_fee_config(&admin, &0, &Address::generate(&env));
+
+    token_admin.mint(&sender, &1000);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+
+    // Deposit with zero fees should not transfer any fee tokens
+    client.deposit(
+        &sender,
+        &Vec::from_array(&env, [token.address.clone()]),
+        &Vec::from_array(&env, [recipient.clone()]),
+        &Vec::from_array(&env, [100i128]),
+        &0,
+        &1000,
+        &0,
+        &0,
+        &Vec::from_array(&env, [String::from_str(&env, "")]),
+    );
+
+    // All tokens should be in the contract (no fees deducted)
+    assert_eq!(token.balance(&sender), 900); // 1000 - 100 deposited
+    assert_eq!(token.balance(&contract_id), 100); // Only the deposited amount
+}


### PR DESCRIPTION
- Add fee_asset field to Config struct (set at initialization)
- Remove fee_asset from FeeConfig and set_fee_config parameters
- deposit() now reads fee_asset from config, preventing arbitrary token changes
- Add InvalidToken error variant (though not directly used, for future validation)
- set_fee_config only adjusts fee_per_recipient and treasury
- Add 5 comprehensive tests for whitelist behavior
- Update DEPLOYMENT.md with fee asset whitelist configuration guide

Security: Prevents admin key compromise from allowing arbitrary token fee collection that could drain depositors unexpectedly.

closes #543