### PR TITLE
fix(wallet-gate): allow settings page without a connected wallet

### DIFF
--- a/components/dashboard/WalletGate.tsx
+++ b/components/dashboard/WalletGate.tsx
@@ -5,7 +5,10 @@ import { usePathname } from "next/navigation";
 import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
 import { useWallet } from "@/contexts/WalletContext";
 
-const PUBLIC_DASHBOARD_PATHS = new Set(["/dashboard/docs"]);
+// Settings is intentionally public: it hosts the wallet connect UI, so blocking
+// it without a wallet creates a catch-22 where users can't find the connect flow.
+// Wallet-specific actions inside the page remain gated by publicKey checks there.
+const PUBLIC_DASHBOARD_PATHS = new Set(["/dashboard/docs", "/dashboard/settings"]);
 
 export function WalletGate({ children }: { children: ReactNode }) {
   const pathname = usePathname();

--- a/components/dashboard/dashboard-wallet-empty.tsx
+++ b/components/dashboard/dashboard-wallet-empty.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Wallet } from "lucide-react";
 import { ConnectWalletButton } from "@/components/connect-wallet-button";
 import {
@@ -35,6 +36,16 @@ export function DashboardWalletEmpty({ className }: { className?: string }) {
       </EmptyHeader>
       <EmptyContent>
         <ConnectWalletButton />
+        <p className="mt-3 text-sm text-slate-400">
+          Or go to{" "}
+          <Link
+            href="/dashboard/settings"
+            className="text-emerald-400 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 rounded"
+          >
+            Settings
+          </Link>{" "}
+          to manage your wallet connection.
+        </p>
       </EmptyContent>
     </Empty>
   );


### PR DESCRIPTION
Closes #524
Closes #529
Closes #533
Closes #539

## What was done

Resolved the catch-22 in `WalletGate` where unauthenticated users were blocked from `/dashboard/settings` — the very page that hosts the wallet connect UI — making it impossible to onboard or connect a wallet through the dashboard.

### `components/dashboard/WalletGate.tsx`

Added `/dashboard/settings` to `PUBLIC_DASHBOARD_PATHS`:

```ts
// Before
const PUBLIC_DASHBOARD_PATHS = new Set(["/dashboard/docs"]);

// After
const PUBLIC_DASHBOARD_PATHS = new Set(["/dashboard/docs", "/dashboard/settings"]);
```

A comment explains the reasoning: settings is intentionally public because it hosts the wallet connect UI. Wallet-specific actions inside the settings page (`copy address`, `Switch Wallet`, `Disconnect`) are already conditional on `publicKey` in `settings/page.tsx`, so no sensitive operations become exposed — only the page shell and theme/appearance controls are visible without a wallet.

All other gated routes (`/dashboard`, `/dashboard/history`, `/dashboard/new-batch`, etc.) remain protected as before.

### `components/dashboard/dashboard-wallet-empty.tsx`

Added a "Settings" link below `ConnectWalletButton` in the `DashboardWalletEmpty` empty state:

- When `WalletGate` blocks a user on any gated route, the empty state now shows a clear secondary path: *"Or go to **Settings** to manage your wallet connection."*
- Uses Next.js `Link` for client-side navigation (no full page reload)
- Accessible: `focus-visible:ring-2` focus ring and `underline-offset-2 hover:underline` for keyboard and pointer users