### PR TITLE
Add API route tests for batch-events SSE and batch-history pagination

### DIFF
--- a/app/api/batch-events/[jobId]/route.ts
+++ b/app/api/batch-events/[jobId]/route.ts
@@ -17,7 +17,7 @@ interface RouteParams {
   params: Promise<{ jobId: string }>;
 }
 
-const POLL_INTERVAL_MS = 1000;
+const POLL_INTERVAL_MS = Number(process.env.BATCH_EVENTS_POLL_INTERVAL_MS ?? "1000");
 
 function serializeJobEvent(job: ReturnType<typeof getJob>): string {
   if (!job) return "";
@@ -59,18 +59,29 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
   const encoder = new TextEncoder();
   let intervalId: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
 
   const stream = new ReadableStream({
     start(controller) {
+      const closeStream = () => {
+        if (intervalId) clearInterval(intervalId);
+        intervalId = null;
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
+      };
+
       const tick = () => {
         try {
+          if (closed) return;
+
           const job = getJob(jobId, publicKey);
 
           if (!job) {
             const errEvent = `data: ${JSON.stringify({ error: `Job not found: ${jobId}` })}\n\n`;
             controller.enqueue(encoder.encode(errEvent));
-            if (intervalId) clearInterval(intervalId);
-            controller.close();
+            closeStream();
             return;
           }
 
@@ -78,21 +89,20 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           controller.enqueue(encoder.encode(event));
 
           if (job.status === "completed" || job.status === "failed") {
-            if (intervalId) clearInterval(intervalId);
-            controller.close();
+            closeStream();
           }
         } catch {
-          if (intervalId) clearInterval(intervalId);
-          controller.close();
+          closeStream();
         }
       };
 
       tick();
-      intervalId = setInterval(tick, POLL_INTERVAL_MS);
+      if (!closed) {
+        intervalId = setInterval(tick, POLL_INTERVAL_MS);
+      }
 
       request.signal.addEventListener("abort", () => {
-        if (intervalId) clearInterval(intervalId);
-        controller.close();
+        closeStream();
       });
     },
     cancel() {

--- a/tests/batch-events-api.test.ts
+++ b/tests/batch-events-api.test.ts
@@ -1,0 +1,162 @@
+/**
+ * HTTP-level tests for GET /api/batch-events/:jobId (SSE)
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.JOB_STORE_PATH = ":memory:";
+  process.env.BATCH_EVENTS_POLL_INTERVAL_MS = "10";
+});
+
+import { NextRequest } from "next/server";
+import { Keypair } from "stellar-sdk";
+import { createJob, updateJob } from "@/lib/job-store";
+
+import { GET } from "@/app/api/batch-events/[jobId]/route";
+
+vi.mock("@/lib/api-rate-limit", () => ({
+  applyRateLimit: vi.fn(() => ({
+    blocked: false,
+    response: undefined,
+    remaining: 99,
+    limit: 100,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+const samplePayments = [
+  {
+    address: "GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER",
+    amount: "100",
+    asset: "XLM",
+  },
+];
+
+function makeReq(url: string) {
+  return new NextRequest(url);
+}
+
+async function collectSseText(
+  res: Response,
+  opts?: { timeoutMs?: number },
+) {
+  const reader = res.body?.getReader();
+  expect(reader).toBeTruthy();
+
+  const decoder = new TextDecoder();
+  let text = "";
+  const timeoutMs = opts?.timeoutMs ?? 1000;
+
+  while (true) {
+    const read = reader!.read();
+    const timeout = new Promise<ReadableStreamReadResult<Uint8Array>>((_, reject) => {
+      setTimeout(() => reject(new Error("Timed out waiting for SSE chunk")), timeoutMs);
+    });
+    const { done, value } = await Promise.race([read, timeout]);
+    if (done) break;
+
+    text += decoder.decode(value, { stream: true });
+  }
+
+  return text;
+}
+
+describe("GET /api/batch-events/:jobId", () => {
+  test("returns 400 when publicKey is missing", async () => {
+    const jobId = "any-job";
+    const req = makeReq(`http://localhost/api/batch-events/${jobId}`);
+
+    const res = await GET(req as never, { params: Promise.resolve({ jobId }) } as never);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/publicKey/i);
+  });
+
+  test("returns 400 when publicKey is invalid", async () => {
+    const jobId = "any-job";
+    const req = makeReq(`http://localhost/api/batch-events/${jobId}?publicKey=bad`);
+
+    const res = await GET(req as never, { params: Promise.resolve({ jobId }) } as never);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/publicKey/i);
+  });
+
+  test("sends SSE frames and closes on completed terminal state", async () => {
+    const OWNER = Keypair.random();
+
+    const jobId = createJob(samplePayments, "testnet", OWNER.publicKey());
+    updateJob(jobId, { status: "processing", totalBatches: 2, completedBatches: 0 });
+
+    const req = makeReq(
+      `http://localhost/api/batch-events/${jobId}?publicKey=${encodeURIComponent(OWNER.publicKey())}`,
+    );
+    const res = await GET(req as never, { params: Promise.resolve({ jobId }) } as never);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/event-stream/i);
+
+    // Move job to terminal shortly after the SSE request starts.
+    setTimeout(() => {
+      updateJob(jobId, {
+        status: "completed",
+        totalBatches: 2,
+        completedBatches: 2,
+        result: {
+          batchId: jobId,
+          totalRecipients: 1,
+          totalAmount: "100",
+          totalTransactions: 1,
+          network: "testnet",
+          timestamp: new Date().toISOString(),
+          results: [],
+          summary: { successful: 1, failed: 0 },
+        },
+      });
+    }, 0);
+
+    const sseText = await collectSseText(res);
+
+    expect(sseText).toContain("data:");
+    expect(sseText).toContain('"status":"processing"');
+    expect(sseText).toContain('"status":"completed"');
+    expect(sseText).toContain("\n\n");
+  });
+
+  test("does not leak other user's job (emits error and closes)", async () => {
+    const OWNER = Keypair.random();
+    const OTHER = Keypair.random();
+
+    const otherJobId = createJob(samplePayments, "testnet", OTHER.publicKey());
+    updateJob(otherJobId, { status: "processing", totalBatches: 1, completedBatches: 0 });
+
+    const req = makeReq(
+      `http://localhost/api/batch-events/${otherJobId}?publicKey=${encodeURIComponent(OWNER.publicKey())}`,
+    );
+    const res = await GET(req as never, { params: Promise.resolve({ jobId: otherJobId }) } as never);
+
+    const sseText = await collectSseText(res);
+
+    expect(sseText).toMatch(/Job not found/i);
+    expect(sseText).toMatch(/"error"/);
+    expect(sseText).toContain("\n\n");
+  });
+
+  test("unknown job emits an error event and closes", async () => {
+    const OWNER = Keypair.random();
+    const jobId = "missing-job";
+    const req = makeReq(
+      `http://localhost/api/batch-events/${jobId}?publicKey=${encodeURIComponent(OWNER.publicKey())}`,
+    );
+
+    const res = await GET(req as never, { params: Promise.resolve({ jobId }) } as never);
+    const sseText = await collectSseText(res);
+
+    expect(res.status).toBe(200);
+    expect(sseText).toMatch(/Job not found: missing-job/i);
+    expect(sseText).toMatch(/"error"/);
+  });
+});

--- a/tests/batch-history-api.test.ts
+++ b/tests/batch-history-api.test.ts
@@ -1,0 +1,227 @@
+/**
+ * HTTP-level tests for GET /api/batch-history
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+vi.hoisted(() => {
+  process.env.JOB_STORE_PATH = ":memory:";
+});
+
+import { NextRequest } from "next/server";
+import { Keypair } from "stellar-sdk";
+import { createJob, updateJob } from "@/lib/job-store";
+
+import { GET } from "@/app/api/batch-history/route";
+
+const samplePayments = [
+  {
+    address: "GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER",
+    amount: "100",
+    asset: "XLM",
+  },
+];
+
+function makeRequest(params: Record<string, string | undefined>) {
+  const url = new URL("http://localhost/api/batch-history");
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) url.searchParams.set(k, v);
+  }
+  return new NextRequest(url);
+}
+
+describe("GET /api/batch-history", () => {
+  test("returns 400 when publicKey is missing", async () => {
+    const res = await GET(makeRequest({} as any) as never);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/publicKey/i);
+  });
+
+  test("returns 400 when publicKey is invalid", async () => {
+    const res = await GET(makeRequest({ publicKey: "not-a-key" }) as never);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toMatch(/publicKey/i);
+  });
+
+  test("paginates items and returns pagination metadata", async () => {
+    const OWNER = Keypair.random();
+
+    // Seed 5 jobs for OWNER
+    for (let i = 0; i < 5; i++) {
+      const jobId = createJob(samplePayments, "testnet", OWNER.publicKey());
+      updateJob(jobId, { status: "completed", totalBatches: 1, completedBatches: 1 });
+    }
+
+    const res = await GET(
+      makeRequest({ publicKey: OWNER.publicKey(), page: "1", limit: "2" }) as never,
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.items).toHaveLength(2);
+    expect(json.pagination).toEqual(
+      expect.objectContaining({ page: 1, limit: 2, total: 5, totalPages: 3 }),
+    );
+    expect(json.aggregateMetrics).toBeDefined();
+  });
+
+  test("filters by status and network", async () => {
+    const OWNER = Keypair.random();
+
+    const completedId = createJob(samplePayments, "testnet", OWNER.publicKey());
+    updateJob(completedId, {
+      status: "completed",
+      totalBatches: 2,
+      completedBatches: 2,
+      result: {
+        batchId: completedId,
+        totalRecipients: 1,
+        totalAmount: "200",
+        totalTransactions: 2,
+        network: "testnet",
+        timestamp: new Date().toISOString(),
+        results: [],
+        summary: { successful: 1, failed: 0 },
+      },
+    });
+
+    const failedId = createJob(samplePayments, "testnet", OWNER.publicKey());
+    updateJob(failedId, {
+      status: "failed",
+      totalBatches: 2,
+      completedBatches: 0,
+      error: "boom",
+    });
+
+    const mainnetId = createJob(samplePayments, "mainnet", OWNER.publicKey());
+    updateJob(mainnetId, { status: "completed", totalBatches: 1, completedBatches: 1 });
+
+    const res = await GET(
+      makeRequest({ publicKey: OWNER.publicKey(), status: "completed", network: "testnet" }) as never,
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+
+    const ids = json.items.map((x: any) => x.jobId);
+    expect(ids).toContain(completedId);
+    expect(ids).not.toContain(failedId);
+    expect(ids).not.toContain(mainnetId);
+
+    for (const item of json.items) {
+      expect(item.status).toBe("completed");
+      expect(item.network).toBe("testnet");
+    }
+  });
+
+  test("filters by date range and search term", async () => {
+    const OWNER = Keypair.random();
+
+    const matchingId = createJob(
+      [
+        {
+          ...samplePayments[0],
+          amount: "25",
+        },
+      ],
+      "testnet",
+      OWNER.publicKey(),
+    );
+    updateJob(matchingId, {
+      status: "completed",
+      totalBatches: 1,
+      completedBatches: 1,
+      result: {
+        batchId: matchingId,
+        totalRecipients: 1,
+        totalAmount: "25",
+        totalTransactions: 1,
+        network: "testnet",
+        timestamp: new Date().toISOString(),
+        results: [
+          {
+            recipient: samplePayments[0].address,
+            amount: "25",
+            asset: "XLM",
+            status: "success",
+            transactionHash: "unique-search-token",
+          },
+        ],
+        summary: { successful: 1, failed: 0 },
+      },
+    });
+
+    const excludedId = createJob(samplePayments, "testnet", OWNER.publicKey());
+    updateJob(excludedId, { status: "completed", totalBatches: 1, completedBatches: 1 });
+
+    const from = new Date(Date.now() - 60_000).toISOString();
+    const to = new Date(Date.now() + 60_000).toISOString();
+    const res = await GET(
+      makeRequest({
+        publicKey: OWNER.publicKey(),
+        from,
+        to,
+        search: "unique-search-token",
+      }) as never,
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.items.map((item: any) => item.jobId)).toEqual([matchingId]);
+    expect(json.items.map((item: any) => item.jobId)).not.toContain(excludedId);
+    expect(json.pagination.total).toBe(1);
+  });
+
+  test("tenant isolation: does not leak other users jobs", async () => {
+    const OWNER = Keypair.random();
+    const OTHER = Keypair.random();
+
+    const ownerJobId = createJob(samplePayments, "testnet", OWNER.publicKey());
+    updateJob(ownerJobId, { status: "processing", totalBatches: 1, completedBatches: 0 });
+
+    const otherJobId = createJob(samplePayments, "testnet", OTHER.publicKey());
+    updateJob(otherJobId, { status: "completed", totalBatches: 1, completedBatches: 1 });
+
+    const res = await GET(makeRequest({ publicKey: OWNER.publicKey() }) as never);
+    const json = await res.json();
+
+    const ids = json.items.map((x: any) => x.jobId);
+    expect(ids).toContain(ownerJobId);
+    expect(ids).not.toContain(otherJobId);
+  });
+
+  test("response shape includes required fields", async () => {
+    const OWNER = Keypair.random();
+
+    const jobId = createJob(samplePayments, "testnet", OWNER.publicKey());
+    updateJob(jobId, { status: "queued", totalBatches: 0, completedBatches: 0 });
+
+    const res = await GET(
+      makeRequest({ publicKey: OWNER.publicKey(), limit: "1", page: "1" }) as never,
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.items).toHaveLength(1);
+
+    const item = json.items[0];
+    expect(item).toEqual(
+      expect.objectContaining({
+        jobId,
+        status: expect.any(String),
+        network: expect.any(String),
+        totalBatches: expect.any(Number),
+        completedBatches: expect.any(Number),
+        totalPayments: expect.any(Number),
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      }),
+    );
+    expect(item).toHaveProperty("summary");
+    expect(item).toHaveProperty("totalAmount");
+  });
+});


### PR DESCRIPTION
Closes #557 

---

<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Add API Route Tests for batch-events SSE and batch-history Pagination</h1>
<h2>In a Nutshell</h2>
<p>This PR adds test coverage for the batch-events SSE endpoint and batch-history pagination, and hardens the SSE route implementation to avoid double-closing the stream and to make the poll interval configurable via an environment variable. It closes issue #557 and aims to reduce regressions by exercising server-sent-events behavior and pagination logic in tests.</p>
<hr>
<h2>Summary</h2>

  |  
-- | --
What | Adds automated tests for batch-events (SSE) and batch-history pagination, plus a small robustness fix to the SSE route implementation.
Why | Increase test coverage for real-time job event streaming and pagination to catch regressions and ensure correct behavior under aborts/timeouts.
Closes | #557


<hr>
<h2>Key Changes</h2>
<h3>Tests</h3>
<p>Adds tests that exercise:</p>
<ul>
<li>The SSE <code>/batch-events/[jobId]</code> route (streaming job events until job completion or failure).</li>
<li><code>batch-history</code> pagination logic (page sizes, offsets, and boundary conditions).</li>
</ul>
<p>These tests improve confidence in SSE behavior and history pagination.</p>
<h3>Code — <code>app/api/batch-events/[jobId]/route.ts</code></h3>
<ul>
<li><strong>Configurable poll interval:</strong> <code>POLL_INTERVAL_MS</code> now reads <code>Number(process.env.BATCH_EVENTS_POLL_INTERVAL_MS ?? "1000")</code>.</li>
<li><strong>Prevent double-close:</strong> Adds a <code>closed</code> flag and a <code>closeStream</code> helper to prevent multiple clears/closes and to centralize cleanup.</li>
<li><strong>Safer interval handling:</strong> Ensures the interval is only set if the stream is still open, and that abort/exception paths use the centralized close behavior.</li>
</ul>
<p><strong>Overall:</strong> safer, less error-prone SSE streaming, with better support for test timing via an env var.</p>
<hr>
<h2>How to Test Locally</h2>
<ol>
<li>Run the repository's test command and confirm the new tests pass:
<pre><code class="language-bash">npm test# oryarn test# orpnpm test
</code></pre></li>
<li>(Optional) Set <code>BATCH_EVENTS_POLL_INTERVAL_MS</code> to a small value to speed up polling during tests:
<pre><code class="language-bash">BATCH_EVENTS_POLL_INTERVAL_MS=50 npm test
</code></pre></li>
<li>If running tests in watch/dev mode that simulate streaming aborts, verify the stream cleans up intervals and does not throw due to double-close.</li>
</ol>
<hr>
<h2>Risk Assessment</h2>
<ul>
<li><strong>Merge risk:</strong> Low — changes are primarily test additions plus a small, conservative hardening of the SSE route.</li>
<li><strong>Areas to review:</strong>
<ul>
<li>Ensure the env var naming and default value are acceptable to ops/documentation.</li>
<li>Confirm tests are deterministic (they rely on the configurable poll interval).</li>
</ul>
</li>
</ul>
<hr>
<h2>Checklist (for Maintainers / Reviewers)</h2>
<ul>
<li>[ ] Confirm CI passes on all platforms.</li>
<li>[ ] Verify the tests run deterministically in CI (no flaky timeouts).</li>
<li>[ ] Confirm the environment variable name (<code>BATCH_EVENTS_POLL_INTERVAL_MS</code>) is documented if intended for production tuning.</li>
<li>[ ] Quick sanity-review of the SSE close/abort logic to ensure no edge cases were missed.</li>
</ul>
<hr>
<h2>Related</h2>
<ul>
<li>Closes #557</li>
</ul>
<hr>
<h2>Diff Stats</h2>
<p>Adds ~409 lines, deletes 10, across 3 files changed.</p>
<hr>
</body>
</html>