### PR TITLE
closes: #553 Validate consistent memo across all payments in a single transaction batch

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -21,6 +21,7 @@ import { safeJsonResponse } from "@/lib/safe-json";
 import { horizonUrl } from "@/lib/stellar/network-config";
 
 import {
+  BatchMemoConflictError,
   createBatches,
   estimateBatchTransactionSize,
   STELLAR_TRANSACTION_SIZE_LIMIT_BYTES,
@@ -232,6 +233,13 @@ export async function POST(request: NextRequest) {
     }), rate);
   } catch (error) {
     console.error("Batch build error:", error);
+    if (error instanceof BatchMemoConflictError) {
+      return setRateLimitHeaders(safeJsonResponse(
+        { error: error.message },
+        { status: 400 },
+      ), rate);
+    }
+
     return setRateLimitHeaders(safeJsonResponse(
       {
         error:

--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -13,6 +13,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createHash } from "crypto";
 import { Keypair, StrKey } from "stellar-sdk";
 import { validatePaymentInstructions } from "@/lib/stellar";
+import { BatchMemoConflictError, createBatches } from "@/lib/stellar/batcher";
 import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
 import { safeJsonResponse } from "@/lib/safe-json";
 import { createIdempotentJob, IdempotencyConflictError } from "@/lib/job-store";
@@ -39,6 +40,8 @@ type BatchSubmitAcceptedResponse = {
   totalTransactions?: number;
   message: string;
 };
+
+const MAX_OPS = 100;
 
 function buildIdempotencyKey(body: RequestBody, headerKey: string | null): { idempotencyKey: string; requestHash: string } {
   const canonicalBody = canonicalizeIdempotencyPayload({
@@ -209,13 +212,27 @@ export async function POST(request: NextRequest) {
     const validation = validatePaymentInstructions(payments);
     if (!validation.valid) {
       const errors = Array.from(validation.errors.entries())
-        .map(([idx, err]) => `Row ${idx}: ${err}`)
+        .map(([idx, err]) => `Row ${idx + 1}: ${err}`)
         .slice(0, 5);
       logger.warn({ requestId, validationErrors: errors }, "Invalid payment instructions validation failure");
       return NextResponse.json(
         { error: `Invalid payment instructions: ${errors.join("; ")}` },
         { status: 400 },
       );
+    }
+
+    try {
+      await createBatches(payments, MAX_OPS, { network });
+    } catch (error) {
+      if (error instanceof BatchMemoConflictError) {
+        logger.warn({ requestId, error: error.message }, "Batch memo validation failure");
+        return NextResponse.json(
+          { error: error.message },
+          { status: 400 },
+        );
+      }
+
+      throw error;
     }
 
     const outcome = createIdempotentJob<BatchSubmitAcceptedResponse>({

--- a/components/dashboard/FileFormatDocumentation.tsx
+++ b/components/dashboard/FileFormatDocumentation.tsx
@@ -64,10 +64,13 @@ GDVXMSTPXZ7QFWDZ7QFWDZ7QFWDZ7QFWDZ7QFWDZ7QFWDZ7Q,75.25,XLM,,`}</code>
               <p className="text-slate-300 text-sm">
                 All recipient addresses must be valid Stellar addresses. Memo is
                 optional: text memos must be 28 bytes or less, ID memos must be
-                valid integers. Stellar supports one memo per transaction. Large
-                memos increase transaction size; batches approaching 90KB may be
-                split automatically, and very large single payments can exceed
-                the 100KB network limit.
+                valid integers. Stellar supports one memo per transaction, so
+                rows grouped into the same transaction must use the same memo and
+                memo type. If recipients need distinct memo values, they must be
+                split into separate transactions. Large memos increase
+                transaction size; batches approaching 90KB may be split
+                automatically, and very large single payments can exceed the
+                100KB network limit.
               </p>
             </div>
           </div>

--- a/lib/stellar/batcher.ts
+++ b/lib/stellar/batcher.ts
@@ -33,6 +33,78 @@ export interface CreateBatchesOptions {
   sourcePublicKey?: string;
 }
 
+export class BatchMemoConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BatchMemoConflictError";
+  }
+}
+
+function getPaymentRowNumber(
+  payment: PaymentInstruction,
+  fallbackIndex: number,
+): number {
+  return (payment.rowIndex ?? fallbackIndex) + 1;
+}
+
+function getMemoSignature(payment: PaymentInstruction): string | undefined {
+  if (!payment.memo) {
+    return undefined;
+  }
+
+  return `${getEffectiveMemoType(payment)}:${payment.memo}`;
+}
+
+function formatMemoForError(payment: PaymentInstruction): string {
+  return `${getEffectiveMemoType(payment)} memo "${payment.memo}"`;
+}
+
+function getEffectiveMemoType(payment: PaymentInstruction): "text" | "id" {
+  return payment.memoType === "id" ? "id" : "text";
+}
+
+function validateConsistentBatchMemo(
+  payments: PaymentInstruction[],
+  batchStartIndex: number,
+  transactionIndex: number,
+): void {
+  const memoPayments = payments
+    .map((payment, offset) => ({
+      payment,
+      rowNumber: getPaymentRowNumber(payment, batchStartIndex + offset),
+      signature: getMemoSignature(payment),
+    }))
+    .filter((entry): entry is {
+      payment: PaymentInstruction;
+      rowNumber: number;
+      signature: string;
+    } => entry.signature !== undefined);
+
+  if (memoPayments.length <= 1) {
+    return;
+  }
+
+  const firstMemo = memoPayments[0];
+  const conflictingMemos = memoPayments.filter(
+    (entry) => entry.signature !== firstMemo.signature,
+  );
+
+  if (conflictingMemos.length === 0) {
+    return;
+  }
+
+  const rows = memoPayments
+    .map(
+      ({ payment, rowNumber }) =>
+        `Row ${rowNumber} has ${formatMemoForError(payment)}`,
+    )
+    .join("; ");
+
+  throw new BatchMemoConflictError(
+    `Conflicting memos in transaction batch ${transactionIndex + 1}: ${rows}. Stellar supports one memo per transaction; rows in the same transaction must use the same memo.`,
+  );
+}
+
 export const STELLAR_TRANSACTION_SIZE_LIMIT_BYTES = 100_000;
 const DEFAULT_TRANSACTION_SIZE_HEADROOM_BYTES = 95_000;
 const SIZE_ESTIMATION_ACCOUNT = new Account(
@@ -144,6 +216,7 @@ export async function createBatches(
 ): Promise<Batch[]> {
   const batches: Batch[] = [];
   let currentBatch: PaymentInstruction[] = [];
+  let currentBatchStartIndex = 0;
   let transactionIndex = 0;
   const maxTransactionBytes =
     options.maxTransactionBytes ?? DEFAULT_TRANSACTION_SIZE_HEADROOM_BYTES;
@@ -180,7 +253,12 @@ export async function createBatches(
     return estimateBatchTransactionSize(payments, network, dynamicFee);
   }
 
-  for (const instruction of instructions) {
+  for (
+    let instructionIndex = 0;
+    instructionIndex < instructions.length;
+    instructionIndex++
+  ) {
+    const instruction = instructions[instructionIndex];
     const candidateBatch = [...currentBatch, instruction];
     const exceedsOperationLimit =
       candidateBatch.length > maxOperationsPerTransaction;
@@ -191,6 +269,11 @@ export async function createBatches(
       (exceedsOperationLimit || exceedsSizeLimit) &&
       currentBatch.length > 0
     ) {
+      validateConsistentBatchMemo(
+        currentBatch,
+        currentBatchStartIndex,
+        transactionIndex,
+      );
       batches.push({
         transactionIndex,
         payments: currentBatch,
@@ -206,11 +289,20 @@ export async function createBatches(
       );
     }
 
+    if (currentBatch.length === 0) {
+      currentBatchStartIndex = instructionIndex;
+    }
+
     currentBatch.push(instruction);
   }
 
   // Add remaining payments as final batch
   if (currentBatch.length > 0) {
+    validateConsistentBatchMemo(
+      currentBatch,
+      currentBatchStartIndex,
+      transactionIndex,
+    );
     batches.push({
       transactionIndex,
       payments: currentBatch,

--- a/tests/batcher.test.ts
+++ b/tests/batcher.test.ts
@@ -95,6 +95,96 @@ describe('Batch Creation', () => {
       }),
     ).rejects.toThrow('exceeds the Stellar transaction size limit');
   });
+
+  test('allows matching memos in the same transaction batch', async () => {
+    const payments = [
+      { ...samplePayments[0], memo: 'invoice-1', memoType: 'text' as const },
+      { ...samplePayments[1], memo: 'invoice-1', memoType: 'text' as const },
+    ];
+
+    const batches = await createBatches(payments, 100);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].payments).toHaveLength(2);
+  });
+
+  test('treats omitted memo type as a text memo for batch consistency', async () => {
+    const payments = [
+      { ...samplePayments[0], memo: 'invoice-1' },
+      { ...samplePayments[1], memo: 'invoice-1', memoType: 'text' as const },
+    ];
+
+    const batches = await createBatches(payments, 100);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].payments).toHaveLength(2);
+  });
+
+  test('allows a single memo in a transaction batch', async () => {
+    const payments = [
+      { ...samplePayments[0], memo: 'invoice-1', memoType: 'text' as const },
+      samplePayments[1],
+    ];
+
+    const batches = await createBatches(payments, 100);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0].payments).toHaveLength(2);
+  });
+
+  test('rejects conflicting memo values in the same transaction batch', async () => {
+    const payments = [
+      { ...samplePayments[0], memo: 'invoice-1', memoType: 'text' as const },
+      { ...samplePayments[1], memo: 'invoice-2', memoType: 'text' as const },
+    ];
+
+    await expect(createBatches(payments, 100)).rejects.toThrow(
+      'Conflicting memos in transaction batch 1: Row 1 has text memo "invoice-1"; Row 2 has text memo "invoice-2"',
+    );
+  });
+
+  test('rejects conflicting memo types in the same transaction batch', async () => {
+    const payments = [
+      { ...samplePayments[0], memo: '12345', memoType: 'id' as const },
+      { ...samplePayments[1], memo: '12345', memoType: 'text' as const },
+    ];
+
+    await expect(createBatches(payments, 100)).rejects.toThrow(
+      'Row 1 has id memo "12345"; Row 2 has text memo "12345"',
+    );
+  });
+
+  test('allows distinct memos after operation-limit splitting', async () => {
+    const payments = [
+      { ...samplePayments[0], memo: 'invoice-1', memoType: 'text' as const },
+      { ...samplePayments[1], memo: 'invoice-2', memoType: 'text' as const },
+    ];
+
+    const batches = await createBatches(payments, 1);
+
+    expect(batches).toHaveLength(2);
+  });
+
+  test('reports preserved upload row numbers for conflicting memos', async () => {
+    const payments = [
+      {
+        ...samplePayments[0],
+        memo: 'invoice-1',
+        memoType: 'text' as const,
+        rowIndex: 4,
+      },
+      {
+        ...samplePayments[1],
+        memo: 'invoice-2',
+        memoType: 'text' as const,
+        rowIndex: 9,
+      },
+    ];
+
+    await expect(createBatches(payments, 100)).rejects.toThrow(
+      'Row 5 has text memo "invoice-1"; Row 10 has text memo "invoice-2"',
+    );
+  });
 });
 
 describe('Asset Parsing', () => {


### PR DESCRIPTION
closes #553 

Adds validation to prevent conflicting per-payment memos from being silently collapsed into a single Stellar transaction memo.

Changes
Added batch-level memo consistency validation in create Batches.
Raises a clear BatchMemoConflictError when rows in the same transaction batch use different memo values or memo types.
Error messages include affected row numbers and memo values.
Updated wallet-build and server-submit flows to surface memo conflicts as 400 validation errors.
Fixed server-submit row error numbering from zero-based to one-based.
Added batcher tests for:matching memos
omitted memo type defaulting to text
one memo in a batch
conflicting memo values
conflicting memo types
distinct memos after transaction splitting
preserved upload row numbers

Updated file format documentation to explain Stellar’s one-memo-per-transaction constraint.

Testing
Ran git diff --check
