### PR TITLE
fix: add batch_id to VestingRevoked event and fix keeper balance check

### DIFF
--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -934,7 +934,7 @@ impl BatchVestingContract {
 
         env.events().publish(
             (Symbol::new(&env, "VestingRevoked"), recipient, sender),
-            (revoked_amount, pending_vested, token, vesting.memo),
+            (revoked_amount, pending_vested, token, vesting.memo.clone(), vesting.batch_id),
         );
     }
 
@@ -1141,7 +1141,7 @@ impl BatchVestingContract {
 
             env.events().publish(
                 (Symbol::new(&env, "VestingRevoked"), recipient.clone(), sender),
-                (revoked_amount, pending_vested, token, vesting.memo),
+                (revoked_amount, pending_vested, token, vesting.memo.clone(), vesting.batch_id),
             );
             results.set(k, true);
         }
@@ -1242,7 +1242,7 @@ impl BatchVestingContract {
 
             env.events().publish(
                 (Symbol::new(&env, "VestingRevoked"), recipient.clone(), sender),
-                (revoked_amount, pending_vested, token, vesting.memo),
+                (revoked_amount, pending_vested, token, vesting.memo.clone(), vesting.batch_id),
             );
         }
     }

--- a/lib/stellar/vesting-events.ts
+++ b/lib/stellar/vesting-events.ts
@@ -21,6 +21,7 @@ export interface VestingRevokedEventPayload {
   pendingVested: string;
   token: string;
   memo: string;
+  batchId: number;
 }
 
 export interface VestingPartiallyRevokedEventPayload {
@@ -187,6 +188,7 @@ export function parseVestingRevoked(payload: unknown): VestingRevokedEventPayloa
     pendingVested: toAmountString(fields[1]),
     token: toTokenAddress(fields[2]),
     memo: fields.length > 3 ? toMemo(fields[3]) : "",
+    batchId: fields.length > 4 ? Number(fields[4]) : 0,
   };
 }
 

--- a/scripts/keeper.ts
+++ b/scripts/keeper.ts
@@ -1,6 +1,7 @@
 // scripts/keeper.ts
 import {
   rpc as SorobanRpc,
+  Horizon,
   Networks,
   Keypair,
   TransactionBuilder,
@@ -94,15 +95,18 @@ async function sendAlert(message: string) {
   }
 }
 
-async function checkBalance(server: SorobanRpc.Server, publicKey: string) {
+async function checkBalance(_server: SorobanRpc.Server, publicKey: string) {
   try {
-    const account = await server.getAccount(publicKey);
-    // SorobanRpc Account type doesn't expose balances in its TS definitions;
-    // cast to any to access the underlying Horizon balance data.
-    const nativeBalance = (account as any).balances?.find(
-      (b: any) => b.asset_type === "native",
+    const horizonServer = new Horizon.Server(
+      NETWORK_PASSPHRASE === Networks.PUBLIC
+        ? "https://horizon.stellar.org"
+        : "https://horizon-testnet.stellar.org",
     );
-    const balance = Number(nativeBalance?.balance || "0");
+    const account = await horizonServer.loadAccount(publicKey);
+    const nativeEntry = account.balances.find(
+      (b) => b.asset_type === "native",
+    );
+    const balance = Number(nativeEntry?.balance ?? "0");
 
     if (balance < LOW_BALANCE_THRESHOLD) {
       await sendAlert(


### PR DESCRIPTION
## Summary

- **#545**: Append `batch_id` to the `VestingRevoked` event payload in `contracts/batch-vesting/src/lib.rs` (three emit sites). Update `VestingRevokedEventPayload` interface and `parseVestingRevoked` in `lib/stellar/vesting-events.ts` to parse and expose the new field.
- **#537**: Fix `checkBalance` in `scripts/keeper.ts` to use `Horizon.Server.loadAccount()` instead of `SorobanRpc.Server.getAccount()`. The Soroban RPC endpoint does not return balance data; Horizon does. The correct Horizon endpoint is selected from `NETWORK_PASSPHRASE`.
- **#419**: No changes required — `contract.yml` already runs `cargo test --manifest-path batch-vesting/Cargo.toml` on every PR touching `contracts/**`.

## Changes

- `contracts/batch-vesting/src/lib.rs` — three `VestingRevoked` event emit sites now include `vesting.batch_id` in the payload tuple
- `lib/stellar/vesting-events.ts` — `VestingRevokedEventPayload.batchId: number` field added; `parseVestingRevoked` reads `fields[4]` (defaults to `0` for backwards-compatible payloads)
- `scripts/keeper.ts` — `Horizon` imported; `checkBalance` rewrites balance lookup via `horizonServer.loadAccount()`

closes #545
closes #537