### PR TITLE
fix: add idempotency protection to batch-retry endpoint (#550)

### DIFF
--- a/app/api/batch-retry/route.ts
+++ b/app/api/batch-retry/route.ts
@@ -9,10 +9,19 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { StrKey } from "stellar-sdk";
-import { createJob, getJob } from "@/lib/job-store";
+import { createIdempotentJob, getJob, IdempotencyConflictError } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
 import { safeJsonResponse } from "@/lib/safe-json";
 import { logger } from "@/lib/logger";
+import { createHash } from "crypto";
+
+/**
+ * Generate a SHA-256 hash of the request body for idempotency checking.
+ * This ensures that the same idempotency key with a different body is rejected.
+ */
+function hashRequestBody(body: { jobId: string; publicKey: string }): string {
+    return createHash("sha256").update(JSON.stringify(body)).digest("hex");
+}
 
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get("x-request-id");
@@ -20,6 +29,10 @@ export async function POST(request: NextRequest) {
         const body = (await request.json()) as { jobId?: string; publicKey?: string };
         const jobId = body.jobId;
         const publicKey = body.publicKey;
+
+        // Extract or derive idempotency key for duplicate retry protection (#550)
+        const idempotencyKey = request.headers.get("Idempotency-Key") 
+            ?? createHash("sha256").update(`${jobId}-${publicKey}`).digest("hex");
 
         if (!jobId || typeof jobId !== "string") {
             logger.warn({ requestId }, "Missing jobId in retry request");
@@ -161,21 +174,49 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        const retryJobId = createJob(failedPayments, job.network, job.publicKey);
-        void processJobInBackground(retryJobId, failedPayments, job.network, secretKey, undefined, requestId || undefined);
+        // Generate request hash for idempotency conflict detection
+        const requestHash = hashRequestBody({ jobId, publicKey });
 
-        logger.info({ requestId, jobId, retryJobId }, "Retry job successfully created and triggered");
-
-        return safeJsonResponse(
-            {
+        // Use createIdempotentJob to prevent duplicate retry jobs (#550)
+        const idempotentResult = createIdempotentJob({
+            idempotencyKey,
+            requestHash,
+            payments: failedPayments,
+            network: job.network,
+            publicKey: job.publicKey,
+            buildResponseBody: (retryJobId) => ({
                 jobId: retryJobId,
                 originalJobId: job.jobId,
                 failedPayments: failedPayments.length,
                 message: "Retry job queued. Poll /api/batch-status/" + retryJobId + " for progress.",
-            },
-            { status: 202 },
-        );
+            }),
+        });
+
+        // Only trigger background processing if this is not a replayed request
+        if (!idempotentResult.replayed) {
+            void processJobInBackground(
+                idempotentResult.jobId,
+                failedPayments,
+                job.network,
+                secretKey,
+                undefined,
+                requestId || undefined,
+            );
+            logger.info({ requestId, jobId, retryJobId: idempotentResult.jobId }, "Retry job successfully created and triggered");
+        } else {
+            logger.info({ requestId, jobId, retryJobId: idempotentResult.jobId }, "Retry request replayed - returning existing job");
+        }
+
+        return safeJsonResponse(idempotentResult.responseBody, { status: 202 });
     } catch (error: unknown) {
+        if (error instanceof IdempotencyConflictError) {
+            logger.warn({ requestId, jobId }, "Idempotency key reused with different body");
+            return NextResponse.json(
+                { error: "Idempotency key already exists for a different request body" },
+                { status: 409 },
+            );
+        }
+
         logger.error({ requestId }, "Batch retry error", error);
         return safeJsonResponse(
             {

--- a/app/dashboard/history/[jobId]/page.tsx
+++ b/app/dashboard/history/[jobId]/page.tsx
@@ -87,9 +87,14 @@ export default function BatchDetailPage({
 
     setRetrying(true);
     try {
+      // Generate idempotency key to prevent duplicate retry jobs on double-click (#550)
+      const idempotencyKey = crypto.randomUUID();
       const res = await fetch("/api/batch-retry", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { 
+          "Content-Type": "application/json",
+          "Idempotency-Key": idempotencyKey,
+        },
         body: JSON.stringify({ jobId, publicKey }),
       });
 

--- a/tests/batch-retry.test.ts
+++ b/tests/batch-retry.test.ts
@@ -46,10 +46,10 @@ const completedResult: BatchResult = {
     summary: { successful: 1, failed: 1 },
 };
 
-function makeRequest(body: Record<string, unknown>) {
+function makeRequest(body: Record<string, unknown>, headers?: Record<string, string>) {
     return new Request("http://localhost/api/batch-retry", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...headers },
         body: JSON.stringify(body),
     });
 }
@@ -98,5 +98,65 @@ describe("POST /api/batch-retry (#388)", () => {
         expect(retryJob?.publicKey).toBe(OWNER);
         expect(retryJob?.payments).toHaveLength(1);
         expect(retryJob?.payments[0].address).toBe(RECIPIENT_BAD);
+    });
+
+    test("duplicate retry requests with same idempotency key return same jobId (#550)", async () => {
+        const idempotencyKey = "test-idempotency-key-123";
+        
+        const res1 = await POST(makeRequest(
+            { jobId, publicKey: OWNER },
+            { "Idempotency-Key": idempotencyKey }
+        ) as never);
+        expect(res1.status).toBe(202);
+        const body1 = await res1.json();
+        const firstJobId = body1.jobId;
+        expect(firstJobId).toBeDefined();
+
+        // Second request with same idempotency key should return same job
+        const res2 = await POST(makeRequest(
+            { jobId, publicKey: OWNER },
+            { "Idempotency-Key": idempotencyKey }
+        ) as never);
+        expect(res2.status).toBe(202);
+        const body2 = await res2.json();
+        expect(body2.jobId).toBe(firstJobId);
+        expect(body2.failedPayments).toBe(1);
+
+        // Only one job should exist in the store
+        const allJobs = getJob(firstJobId, OWNER);
+        expect(allJobs).toBeDefined();
+    });
+
+    test("idempotency key reused with different body returns 409 (#550)", async () => {
+        const idempotencyKey = "test-idempotency-key-conflict";
+        
+        const res1 = await POST(makeRequest(
+            { jobId, publicKey: OWNER },
+            { "Idempotency-Key": idempotencyKey }
+        ) as never);
+        expect(res1.status).toBe(202);
+
+        // Second request with same key but different publicKey should conflict
+        const res2 = await POST(makeRequest(
+            { jobId, publicKey: OTHER },
+            { "Idempotency-Key": idempotencyKey }
+        ) as never);
+        expect(res2.status).toBe(409);
+        const body2 = await res2.json();
+        expect(body2.error).toMatch(/idempotency/i);
+    });
+
+    test("derived idempotency key prevents duplicate retries without header (#550)", async () => {
+        // When no Idempotency-Key header is provided, the endpoint derives one from jobId+publicKey
+        const res1 = await POST(makeRequest({ jobId, publicKey: OWNER }) as never);
+        expect(res1.status).toBe(202);
+        const body1 = await res1.json();
+        const firstJobId = body1.jobId;
+
+        // Second request without header should still be idempotent due to derived key
+        const res2 = await POST(makeRequest({ jobId, publicKey: OWNER }) as never);
+        expect(res2.status).toBe(202);
+        const body2 = await res2.json();
+        expect(body2.jobId).toBe(firstJobId);
     });
 });


### PR DESCRIPTION
- Use createIdempotentJob instead of createJob to prevent duplicate retry jobs
- Accept Idempotency-Key header or derive from jobId+publicKey (SHA-256)
- Add request hash validation to detect key reuse with different body
- Return 409 when idempotency key conflicts with different request body
- Only trigger background processing for non-replayed requests
- Update UI to generate and send Idempotency-Key header on retry
- Add integration tests for duplicate request idempotency

Prevents double payouts when users double-click retry or network clients auto-retry.

Closes #550 