### PR TITLE
fix: resolve four open source contribution issues

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -282,6 +282,22 @@ The contract uses Soroban's standard upgradeability pattern. Upgrades are gated 
 - `UpgradeProposed(new_wasm_hash, execute_at)`
 - `UpgradeExecuted(new_wasm_hash)`
 
+## React Query Provider
+
+A single `QueryClientProvider` wraps the entire application tree in the root
+`app/layout.tsx` via the `QueryProvider` component (`components/query-provider.tsx`).
+No other layout or page component should nest a second `QueryClientProvider` or
+create a separate `QueryClient` instance — nested providers create independent
+caches, breaking `invalidateQueries` across the app and causing duplicate network
+fetches for the same query key.
+
+- Default `staleTime` is 30 000 ms, retry count is 1, and `refetchOnWindowFocus`
+  is disabled (see `components/query-provider.tsx`).
+- Dashboard routes (wrapped by `DashboardLayout` in `components/dashboard-layout.tsx`)
+  rely on the root provider; do not reintroduce a second provider there.
+- All `useQuery`, `useMutation`, and `invalidateQueries` calls share the same
+  `QueryClient` instance and cache namespace.
+
 ## Testing Strategy
 
 ### Unit Tests

--- a/app/dashboard/history/[jobId]/page.tsx
+++ b/app/dashboard/history/[jobId]/page.tsx
@@ -70,6 +70,18 @@ export default function BatchDetailPage({
   const [retryPollError, setRetryPollError] = useState<string | null>(null);
   const [retryJobData, setRetryJobData] = useState<JobStatusResponse | null>(null);
   const retryNotificationRef = useRef<string | null>(null);
+  const retryPollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryPollCancelledRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      retryPollCancelledRef.current = true;
+      if (retryPollTimeoutRef.current !== null) {
+        clearTimeout(retryPollTimeoutRef.current);
+        retryPollTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   const { data, error, isLoading } = useQuery({
     queryKey: ["job", jobId, publicKey],
@@ -104,8 +116,6 @@ export default function BatchDetailPage({
       setRetryPollError(null);
       toast.success(`Retry job queued (${newJobId})`);
 
-      let cancelled = false;
-
       const poll = async () => {
         try {
           const r = await fetch(
@@ -113,18 +123,17 @@ export default function BatchDetailPage({
           );
           if (!r.ok) throw new Error(`Status fetch failed (${r.status})`);
           const jb = (await r.json()) as JobStatusResponse;
-          if (cancelled) return;
+          if (retryPollCancelledRef.current) return;
           setRetryJobData(jb);
           if (jb.status === "queued" || jb.status === "processing") {
-            setTimeout(poll, 2000);
+            retryPollTimeoutRef.current = setTimeout(poll, 2000);
           }
         } catch (err) {
-          if (!cancelled) setRetryPollError((err as Error).message);
+          if (!retryPollCancelledRef.current) setRetryPollError((err as Error).message);
         }
       };
 
       poll();
-      // keep retrying state while polling
     } catch (e) {
       toast.error((e as Error).message);
     } finally {

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -5,27 +5,24 @@ import { AppSidebar } from "./app-sidebar"
 import { AppHeader } from "./app-header"
 import { WalletGate } from "@/components/dashboard/WalletGate"
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar"
-import { QueryProvider } from "./query-provider"
 import { NotificationsProvider } from "@/contexts/NotificationsContext"
 
 export function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
-    <QueryProvider>
-      <NotificationsProvider>
-        <SidebarProvider defaultOpen={true}>
-          <div className="flex min-h-screen w-full bg-background text-foreground">
-            <AppSidebar />
-            <SidebarInset className="flex flex-col bg-transparent">
-              <AppHeader />
-              <main className="flex-1 px-4 md:px-8 py-8">
-                <div className="mx-auto w-full max-w-[1200px]">
-                  <WalletGate>{children}</WalletGate>
-                </div>
-              </main>
-            </SidebarInset>
-          </div>
-        </SidebarProvider>
-      </NotificationsProvider>
-    </QueryProvider>
+    <NotificationsProvider>
+      <SidebarProvider defaultOpen={true}>
+        <div className="flex min-h-screen w-full bg-background text-foreground">
+          <AppSidebar />
+          <SidebarInset className="flex flex-col bg-transparent">
+            <AppHeader />
+            <main className="flex-1 px-4 md:px-8 py-8">
+              <div className="mx-auto w-full max-w-[1200px]">
+                <WalletGate>{children}</WalletGate>
+              </div>
+            </main>
+          </SidebarInset>
+        </div>
+      </SidebarProvider>
+    </NotificationsProvider>
   )
 }

--- a/components/dashboard/HistoryFilterBar.tsx
+++ b/components/dashboard/HistoryFilterBar.tsx
@@ -52,12 +52,12 @@ export function HistoryFilterBar({ values, onChange, className }: HistoryFilterB
       </div>
 
       <div className="space-y-2">
-        <label className="text-sm font-medium text-gray-400">Date Range</label>
+        <label className="text-sm font-medium text-gray-400" htmlFor="history-date-range">Date Range</label>
         <Select
           value={values.dateRange}
           onValueChange={(v) => update("dateRange", v as DateRangeValue)}
         >
-          <SelectTrigger className="bg-[#121827] border-[#1F2937] text-white focus:ring-[#00D98B]/20">
+          <SelectTrigger id="history-date-range" className="bg-[#121827] border-[#1F2937] text-white focus:ring-[#00D98B]/20">
             <SelectValue placeholder="Select Range" />
           </SelectTrigger>
           <SelectContent className="bg-[#121827] border-[#1F2937] text-white">
@@ -70,12 +70,12 @@ export function HistoryFilterBar({ values, onChange, className }: HistoryFilterB
       </div>
 
       <div className="space-y-2">
-        <label className="text-sm font-medium text-gray-400">Network</label>
+        <label className="text-sm font-medium text-gray-400" htmlFor="history-network">Network</label>
         <Select
           value={values.network}
           onValueChange={(v) => update("network", v as NetworkValue)}
         >
-          <SelectTrigger className="bg-[#121827] border-[#1F2937] text-white focus:ring-[#00D98B]/20">
+          <SelectTrigger id="history-network" className="bg-[#121827] border-[#1F2937] text-white focus:ring-[#00D98B]/20">
             <SelectValue placeholder="All Networks" />
           </SelectTrigger>
           <SelectContent className="bg-[#121827] border-[#1F2937] text-white">
@@ -87,12 +87,12 @@ export function HistoryFilterBar({ values, onChange, className }: HistoryFilterB
       </div>
 
       <div className="space-y-2">
-        <label className="text-sm font-medium text-gray-400">Status</label>
+        <label className="text-sm font-medium text-gray-400" htmlFor="history-status">Status</label>
         <Select
           value={values.status}
           onValueChange={(v) => update("status", v as StatusValue)}
         >
-          <SelectTrigger className="bg-[#121827] border-[#1F2937] text-white focus:ring-[#00D98B]/20">
+          <SelectTrigger id="history-status" className="bg-[#121827] border-[#1F2937] text-white focus:ring-[#00D98B]/20">
             <SelectValue placeholder="All Status" />
           </SelectTrigger>
           <SelectContent className="bg-[#121827] border-[#1F2937] text-white">

--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -656,7 +656,7 @@ impl BatchVestingContract {
             for j in 0..token_transfers.len() {
                 let (t, amt) = token_transfers.get(j).unwrap();
                 if t == token {
-                    token_transfers.set(j, (t.clone(), amt + amount));
+                    token_transfers.set(j, (t.clone(), amt.checked_add(amount).unwrap_or_else(|| soroban_sdk::panic_with_error!(&env, VestingError::Overflow))));
                     found = true;
                     break;
                 }


### PR DESCRIPTION
closes #507 
closes #517 
closes #519 
closes #567 

## Summary

Resolves four open source contribution issues: duplicate React Query provider, HistoryFilterBar accessibility gaps, batch detail polling memory leak, and unchecked arithmetic in the Soroban deposit contract.

---

### 1. Duplicate QueryClientProvider — Cache Incoherence

**Files:** `components/dashboard-layout.tsx`, `DEVELOPMENT.md`

**Problem:** `QueryClientProvider` was mounted twice — once in root `app/layout.tsx` via `QueryProvider` and again in `components/dashboard-layout.tsx` wrapping the dashboard shell. Nested providers created independent React Query caches, breaking `invalidateQueries` across the app and causing duplicate network fetches.

**Fix:**
- Removed the `QueryProvider` wrapper and its import from `components/dashboard-layout.tsx`. The root `app/layout.tsx` provider is now the single `QueryClient` instance for the entire tree.
- Added an architecture note in `DEVELOPMENT.md` documenting the single-provider contract and the default `staleTime`/retry settings.

**Verification:**
- No other component creates a separate `QueryClient` or nests another `QueryClientProvider`.
- `invalidateQueries` from hooks like `useBatchHistory` now shares the same cache as dashboard components.

---

### 2. HistoryFilterBar — Programmatic Label Associations

**File:** `components/dashboard/HistoryFilterBar.tsx`

**Problem:** The search field was correctly associated (`htmlFor="history-search"`), but the Date Range, Network, and Status selects used bare `<label>` elements with no `htmlFor` attribute and no `id` on the `SelectTrigger` buttons. Screen readers could not announce the label-control relationship, and clicking a label did not focus or open the corresponding select.

**Fix:**
- Added stable `id` attributes to each `SelectTrigger`:
  - `history-date-range`
  - `history-network`
  - `history-status`
- Added matching `htmlFor` attributes to the corresponding `<label>` elements.

**Verification:**
- All four filter controls now have programmatic label associations.
- Clicking a label focuses the corresponding select.
- Screen readers announce the label when the select receives focus.
- No visual regression to the filter grid layout.

---

### 3. Batch Detail Retry Polling — setTimeout Cleanup

**File:** `app/dashboard/history/[jobId]/page.tsx`

**Problem:** The `handleRetry` function in the batch detail page started a manual `setTimeout` polling loop after `/api/batch-retry` without cleanup on component unmount. The `cancelled` flag was a local variable in the async function — never set to `true` in a `useEffect` return. Navigating away mid-retry left timers firing and `setState` calls on unmounted components, causing React warnings, wasted `/api/batch-status` requests, and potential memory leaks.

**Fix:**
- Added `retryPollTimeoutRef` to store the `setTimeout` ID.
- Added `retryPollCancelledRef` to manage the cancelled flag across async boundaries.
- Added a `useEffect` cleanup that:
  - Sets `retryPollCancelledRef.current = true`
  - Clears the timeout via `clearTimeout` if a timer is pending
- Updated `handleRetry` to use the refs instead of local variables, and to store the timer ID from `setTimeout` in the ref.

**Verification:**
- Navigating away during retry polling stops all further status fetches.
- No "Can't perform a React state update on an unmounted component" warnings.
- Retry completion still updates the UI when the user remains on the page.

---

### 4. Soroban Deposit — Checked Arithmetic for Token Accumulation

**File:** `contracts/batch-vesting/src/lib.rs`

**Problem:** In the `deposit` function, per-token transfer totals were accumulated using `amt + amount` (unchecked `i128` addition) when merging duplicate tokens. Large batches or whale-sized vesting schedules could cause addition overflow, leading to contract panics or wrapped values before `token_client.transfer`.

**Fix:**
- Replaced `amt + amount` with `amt.checked_add(amount).unwrap_or_else(|| soroban_sdk::panic_with_error!(&env, VestingError::Overflow))`.
- This follows the existing pattern already used throughout the contract (`checked_add` on `BatchCounter`, `checked_mul` in `calculate_vested_amount`, and fee calculations).

**Verification:**
- Token transfer accumulation uses `checked_add` consistently.
- Overflow returns a defined `VestingError::Overflow` instead of silent wrapping or panic.
- Existing deposit happy-path tests remain green.
