### PR TITLE
fix(seo): add SVG favicon entry to root layout metadata icons

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,6 +46,10 @@ export const metadata: Metadata = {
   icons: {
     icon: [
       {
+        url: "/icon.svg",
+        type: "image/svg+xml",
+      },
+      {
         url: "/icon-light-32x32.png",
         type: "image/png",
         media: "(prefers-color-scheme: light)",


### PR DESCRIPTION
## Summary

The GitHub Actions contract CI workflow (issue #419) and per-route SEO metadata with Open Graph/Twitter cards (issue #425) are fully implemented upstream in `.github/workflows/contract.yml` and `lib/seo.ts` with `makePageMetadata()` applied to all routes via page or layout files.

This commit completes the favicon specification noted in issue #425: registers the existing `public/icon.svg` asset as the first icon entry in root layout metadata with `type: "image/svg+xml"`. SVG icons scale to any resolution without pixelation, while the existing PNG fallbacks handle environments that don't support SVG favicons.

## Changes

- `app/layout.tsx` — prepend `{ url: "/icon.svg", type: "image/svg+xml" }` to the `icons.icon` array before the PNG entries

closes #419
closes #425