### PR TITLE
fix(vesting): decimal-safe stroop conversion for i128 amounts

### DIFF
--- a/lib/stellar/utils.ts
+++ b/lib/stellar/utils.ts
@@ -44,6 +44,7 @@ export function formatAmount(amount: string | number): string {
 
 // Stellar uses 7 decimal places (1 XLM = 10,000,000 stroops)
 const STELLAR_DECIMALS = 7
+const STELLAR_STROOPS_PER_UNIT = new Big(10 ** STELLAR_DECIMALS)
 const STELLAR_MAX_AMOUNT = new Big('922337203685.4775807')
 
 /**
@@ -104,6 +105,37 @@ export function parseStellarAmount(s: string): Big {
   }
 
   return amount
+}
+
+/**
+ * Converts a human-readable Stellar amount string into i128 stroops (bigint).
+ *
+ * Stellar amounts have exactly 7 decimal places of precision; 1 unit = 10,000,000
+ * stroops. This uses big.js decimal arithmetic instead of `parseFloat`, so values
+ * like "123456789.1234567" or "0.0000001" convert to the exact stroop integer with
+ * no binary floating-point rounding error. Invalid, negative, out-of-range, or
+ * over-precise inputs are rejected by {@link parseStellarAmount} before conversion,
+ * so a malformed amount never reaches Soroban as a wrong i128 value.
+ *
+ * This is the single source of truth for stroop conversion shared by the vesting
+ * deposit/claim code and any other Soroban i128 amount serialization (#506).
+ *
+ * @param amount - The amount string to convert (e.g. "100.1234567")
+ * @returns The amount in stroops as a bigint (e.g. 1001234567n)
+ * @throws {Error} If the input is not a valid Stellar amount string
+ *
+ * @example
+ * amountToStroopsI128("0.0000001")     // → 1n
+ * amountToStroopsI128("100")           // → 1000000000n
+ * amountToStroopsI128("99999999.9999999") // → 999999999999999n
+ * amountToStroopsI128("0.12345678")    // → throws (8 decimal places)
+ */
+export function amountToStroopsI128(amount: string): bigint {
+  const value = parseStellarAmount(amount)
+  // parseStellarAmount guarantees ≤ 7 decimal places, so multiplying by 1e7
+  // yields an exact integer; round(0) is defensive and never discards data here.
+  const stroops = value.times(STELLAR_STROOPS_PER_UNIT).round(0)
+  return BigInt(stroops.toFixed(0))
 }
 
 /**

--- a/lib/stellar/vesting.ts
+++ b/lib/stellar/vesting.ts
@@ -11,6 +11,7 @@ import {
 } from "stellar-sdk";
 import type { PaymentInstruction, Network } from "./types";
 import { acquireGuard } from "./reentrancy-guard";
+import { amountToStroopsI128 } from "./utils";
 
 const SOROBAN_RPC_URLS: Record<Network, string> = {
   testnet: "https://soroban-testnet.stellar.org",
@@ -26,15 +27,16 @@ function addressVecToScVal(addresses: string[]): xdr.ScVal {
 }
 
 /**
- * Serialize an array of i128 amounts (in stroops) to ScVal Vec<i128>
- * Amounts are passed as string decimals; we convert to i128 stroops (7 decimal places).
+ * Serialize an array of i128 amounts (in stroops) to ScVal Vec<i128>.
+ * Amounts are passed as string decimals; we convert to i128 stroops (7 decimal
+ * places) using decimal-safe big.js arithmetic via {@link amountToStroopsI128}.
+ * Invalid or over-precise amounts throw before any RPC simulation (#506).
  */
 function amountVecToScVal(amounts: string[]): xdr.ScVal {
   return xdr.ScVal.scvVec(
-    amounts.map((amt) => {
-      const stroops = BigInt(Math.round(parseFloat(amt) * 1e7));
-      return nativeToScVal(stroops, { type: "i128" });
-    }),
+    amounts.map((amt) =>
+      nativeToScVal(amountToStroopsI128(amt), { type: "i128" }),
+    ),
   );
 }
 
@@ -104,8 +106,7 @@ function assetToTokenAddress(asset: string, network: Network): string {
 }
 
 function amountToScVal(amount: string): xdr.ScVal {
-  const stroops = BigInt(Math.round(parseFloat(amount) * 1e7));
-  return nativeToScVal(stroops, { type: "i128" });
+  return nativeToScVal(amountToStroopsI128(amount), { type: "i128" });
 }
 
 async function buildSorobanTransaction(

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -11,6 +11,7 @@ import {
   parseStellarAmount,
   formatStellarAmount,
   sumStellarAmounts,
+  amountToStroopsI128,
 } from "../lib/stellar/utils";
 
 // ---------------------------------------------------------------------------
@@ -138,5 +139,73 @@ describe("formatStellarAmount", () => {
 
   test("pads short decimals to 7 places", () => {
     expect(formatStellarAmount(new Big("100.5"))).toBe("100.5000000");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// amountToStroopsI128 — decimal-safe stroop conversion (#506)
+//
+// These assert EXACT i128 stroop integers for the boundary amounts that the old
+// `BigInt(Math.round(parseFloat(amt) * 1e7))` path could not represent faithfully.
+// ---------------------------------------------------------------------------
+
+describe("amountToStroopsI128 — exact stroop values", () => {
+  test("converts whole number to stroops", () => {
+    expect(amountToStroopsI128("100")).toBe(1_000_000_000n);
+  });
+
+  test("converts a single stroop (smallest unit)", () => {
+    expect(amountToStroopsI128("0.0000001")).toBe(1n);
+  });
+
+  test("converts zero", () => {
+    expect(amountToStroopsI128("0")).toBe(0n);
+  });
+
+  test("converts max-precision 7-decimal value exactly", () => {
+    // parseFloat("0.1234567") * 1e7 = 1234566.9999999998 → Math.round = 1234567,
+    // but other values drift; big.js is exact for all of them.
+    expect(amountToStroopsI128("0.1234567")).toBe(1_234_567n);
+  });
+
+  test("converts large payroll amount without float drift", () => {
+    expect(amountToStroopsI128("123456789.1234567")).toBe(1_234_567_891_234_567n);
+  });
+
+  test("converts the 9s edge case exactly", () => {
+    expect(amountToStroopsI128("99999999.9999999")).toBe(999_999_999_999_999n);
+  });
+
+  test("preserves trailing zeros as the same stroop integer", () => {
+    expect(amountToStroopsI128("1.5")).toBe(15_000_000n);
+    expect(amountToStroopsI128("1.5000000")).toBe(15_000_000n);
+  });
+
+  test("converts the maximum Stellar amount", () => {
+    expect(amountToStroopsI128("922337203685.4775807")).toBe(
+      9_223_372_036_854_775_807n,
+    );
+  });
+
+  test("rejects more than 7 decimal places before conversion", () => {
+    expect(() => amountToStroopsI128("0.12345678")).toThrow(
+      /more than 7 decimal places/,
+    );
+  });
+
+  test("rejects scientific notation", () => {
+    expect(() => amountToStroopsI128("1e7")).toThrow(/scientific notation/);
+  });
+
+  test("rejects NaN / non-numeric strings", () => {
+    expect(() => amountToStroopsI128("abc")).toThrow(/not a valid number/);
+  });
+
+  test("rejects empty strings", () => {
+    expect(() => amountToStroopsI128("")).toThrow(/non-empty string/);
+  });
+
+  test("rejects negative amounts", () => {
+    expect(() => amountToStroopsI128("-1")).toThrow(/negative/);
   });
 });

--- a/tests/vesting.test.ts
+++ b/tests/vesting.test.ts
@@ -249,6 +249,62 @@ describe('buildRevokeTransaction (#392)', () => {
   });
 });
 
+describe('amount precision in buildDepositTransaction (#506)', () => {
+  test('encodes high-precision amounts as exact i128 stroops', async () => {
+    const callSpy = vi.spyOn(Contract.prototype, 'call');
+    const { buildDepositTransaction } = await import('../lib/stellar/vesting');
+
+    const sender = Keypair.random().publicKey();
+    // Amounts that the old parseFloat path could not represent faithfully.
+    const payments = [
+      payment(Keypair.random().publicKey(), '0.1234567'),
+      payment(Keypair.random().publicKey(), '123456789.1234567'),
+      payment(Keypair.random().publicKey(), '99999999.9999999'),
+    ];
+
+    await buildDepositTransaction(
+      VALID_CONTRACT_ID,
+      payments,
+      1_700_000_000,
+      1_800_000_000,
+      86_400,
+      86_400,
+      'testnet',
+      sender,
+    ).catch(() => undefined);
+
+    expect(callSpy).toHaveBeenCalled();
+    // deposit args: [sender, tokens, recipients, amounts, ...]
+    const amountsVec = callSpy.mock.calls[0][4] as xdr.ScVal;
+    const decoded = scValToNative(amountsVec) as bigint[];
+    expect(decoded).toEqual([
+      1_234_567n,
+      1_234_567_891_234_567n,
+      999_999_999_999_999n,
+    ]);
+    callSpy.mockRestore();
+  });
+
+  test('rejects amounts with more than 7 decimal places before RPC', async () => {
+    const { buildDepositTransaction } = await import('../lib/stellar/vesting');
+    const sender = Keypair.random().publicKey();
+    const payments = [payment(Keypair.random().publicKey(), '0.12345678')];
+
+    await expect(
+      buildDepositTransaction(
+        VALID_CONTRACT_ID,
+        payments,
+        1_700_000_000,
+        1_800_000_000,
+        86_400,
+        86_400,
+        'testnet',
+        sender,
+      ),
+    ).rejects.toThrow(/more than 7 decimal places/);
+  });
+});
+
 describe('buildTransferVestingRightsTransaction', () => {
   test('transfer_vesting_rights passes three contract arguments', async () => {
     const callSpy = vi.spyOn(Contract.prototype, 'call');


### PR DESCRIPTION
## Summary

`amountVecToScVal` and `amountToScVal` in `lib/stellar/vesting.ts` converted human-readable amount strings to stroops with `BigInt(Math.round(parseFloat(amt) * 1e7))`. `parseFloat` introduces binary floating-point rounding error, cannot faithfully represent every Stellar 7-decimal value, and throws nothing on `NaN` or scientific-notation input — so a malformed or high-precision amount (e.g. `"123456789.1234567"`) could serialize to a wrong i128 value sent to the Soroban `deposit` contract, causing rejected transactions or incorrect vesting totals.

## Changes

- Add a shared `amountToStroopsI128(amount: string): bigint` helper in `lib/stellar/utils.ts`, built on the existing `parseStellarAmount` / big.js path. It returns the exact stroop integer and rejects amounts that are over 7 decimal places, negative, out of range, empty, or in scientific notation **before** any RPC simulation.
- Rewrite `amountVecToScVal` and `amountToScVal` to use the shared helper instead of `parseFloat`, giving vesting and payment code one source of truth for stroop conversion.

## Tests

- `tests/utils.test.ts`: exact stroop assertions for boundary amounts, trailing zeros, single-stroop, max Stellar amount, and rejection of invalid/over-precise/scientific-notation/negative inputs.
- `tests/vesting.test.ts`: a deposit-encoding test that decodes the i128 amounts vec and asserts exact stroop values for high-precision fixtures (`0.1234567`, `123456789.1234567`, `99999999.9999999`), plus a test that an 8-decimal amount is rejected before RPC.

All `tests/utils.test.ts` (35) and `tests/vesting.test.ts` (11) pass.

## Acceptance criteria

- [x] `amountVecToScVal` and `amountToScVal` use decimal-safe parsing (no `parseFloat`).
- [x] Unit tests assert exact stroop values for 7-decimal edge cases.
- [x] Invalid precision strings fail validation before RPC simulation.
- [x] No regression in vesting deposit integration tests.

Closes #506