### PR TITLE
fix(batch): harden BatchErrorBoundary restore against corrupt sessionStorage

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -356,7 +356,15 @@ export default function Home() {
           </div>
         )}
 
-        <BatchErrorBoundary storageKey="demo_batch_payments" onRestore={handleRestore}>
+        <BatchErrorBoundary
+          storageKey="demo_batch_payments"
+          onRestore={handleRestore}
+          validate={(parsed) =>
+            Array.isArray(parsed) &&
+            parsed.length > 0 &&
+            parsed.every((p) => p !== null && typeof p === "object")
+          }
+        >
           {/* ── Upload ────────────────────────────────────────────────── */}
           {state === "upload" && (
             <div className="space-y-6">

--- a/components/BatchErrorBoundary.tsx
+++ b/components/BatchErrorBoundary.tsx
@@ -1,17 +1,85 @@
 "use client";
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { safeJsonParse } from "@/lib/safe-json";
 
 interface BatchErrorBoundaryProps {
   children: ReactNode;
   storageKey: string;
   onRestore?: (saved: unknown) => void;
+  /**
+   * Optional type guard run against the parsed payload before `onRestore`.
+   * Lets each caller assert the shape it expects (e.g. a payments array).
+   * Defaults to {@link isRestorablePayload}, which accepts any non-empty
+   * object or array.
+   */
+  validate?: (parsed: unknown) => boolean;
 }
 
 interface BatchErrorBoundaryState {
   hasError: boolean;
   errorMessage: string | null;
+  restoreError: string | null;
+}
+
+/**
+ * Default guard: a payload is restorable if it is a non-empty array or a
+ * plain object with at least one key. Empty / `null` / primitive payloads are
+ * treated as nothing meaningful to restore.
+ */
+export function isRestorablePayload(parsed: unknown): boolean {
+  if (Array.isArray(parsed)) return parsed.length > 0;
+  if (parsed !== null && typeof parsed === "object") {
+    return Object.keys(parsed as Record<string, unknown>).length > 0;
+  }
+  return false;
+}
+
+const CORRUPT_MESSAGE =
+  "Saved batch data was corrupted and could not be restored. It has been cleared — please start a new batch.";
+const INVALID_MESSAGE =
+  "Saved batch data was incomplete and could not be restored. It has been cleared — please start a new batch.";
+
+export type RestoreOutcome =
+  | { status: "empty" }
+  | { status: "restored"; value: unknown }
+  | { status: "corrupt"; message: string }
+  | { status: "invalid"; message: string };
+
+/**
+ * Pure restore decision shared by the boundary and its tests.
+ *
+ * Reads `storageKey` from `storage`, parses it without throwing, and validates
+ * the shape. Corrupt or invalid payloads are removed from storage so a poisoned
+ * key cannot break the recovery flow on every retry (#516). Kept side-effect-
+ * light (only `removeItem`) and DOM-free so it is unit-testable in Node with a
+ * fake storage.
+ */
+export function restoreFromStorage(
+  storage: Pick<Storage, "getItem" | "removeItem">,
+  storageKey: string,
+  validate: (parsed: unknown) => boolean = isRestorablePayload,
+): RestoreOutcome {
+  const saved = storage.getItem(storageKey);
+  if (saved === null || saved === undefined) {
+    return { status: "empty" };
+  }
+
+  const parsed = safeJsonParse(saved);
+  if (!parsed.ok) {
+    console.error("Failed to restore batch flow state:", parsed.error);
+    storage.removeItem(storageKey);
+    return { status: "corrupt", message: CORRUPT_MESSAGE };
+  }
+
+  if (!validate(parsed.value)) {
+    storage.removeItem(storageKey);
+    return { status: "invalid", message: INVALID_MESSAGE };
+  }
+
+  return { status: "restored", value: parsed.value };
 }
 
 export class BatchErrorBoundary extends Component<
@@ -21,9 +89,12 @@ export class BatchErrorBoundary extends Component<
   state: BatchErrorBoundaryState = {
     hasError: false,
     errorMessage: null,
+    restoreError: null,
   };
 
-  static getDerivedStateFromError(error: Error): BatchErrorBoundaryState {
+  static getDerivedStateFromError(
+    error: Error,
+  ): Partial<BatchErrorBoundaryState> {
     return {
       hasError: true,
       errorMessage: error.message,
@@ -35,19 +106,38 @@ export class BatchErrorBoundary extends Component<
   }
 
   private handleRestore = () => {
-    const saved = window.sessionStorage.getItem(this.props.storageKey);
-    if (saved && this.props.onRestore) {
-      try {
-        this.props.onRestore(JSON.parse(saved) as unknown);
-      } catch (error) {
-        console.error("Failed to restore batch flow state:", error);
-      }
-    }
+    const { storageKey, onRestore, validate } = this.props;
+    const outcome = restoreFromStorage(
+      window.sessionStorage,
+      storageKey,
+      validate,
+    );
 
-    this.setState({
-      hasError: false,
-      errorMessage: null,
-    });
+    switch (outcome.status) {
+      case "corrupt":
+      case "invalid":
+        // Never let a bad payload throw out of the click handler. Surface a
+        // clear message and keep the recovery UI on screen so the user is not
+        // stuck on the error panel.
+        toast.error(outcome.message);
+        this.setState({ restoreError: outcome.message });
+        return;
+      case "restored":
+        onRestore?.(outcome.value);
+        this.setState({
+          hasError: false,
+          errorMessage: null,
+          restoreError: null,
+        });
+        return;
+      case "empty":
+      default:
+        this.setState({
+          hasError: false,
+          errorMessage: null,
+          restoreError: null,
+        });
+    }
   };
 
   render() {
@@ -56,10 +146,18 @@ export class BatchErrorBoundary extends Component<
     }
 
     return (
-      <div className="rounded-xl border border-red-500/30 bg-red-950/20 p-6 text-center">
-        <h2 className="text-lg font-semibold text-red-200">Batch flow needs to be restored</h2>
+      <div
+        role="alert"
+        aria-live="assertive"
+        className="rounded-xl border border-red-500/30 bg-red-950/20 p-6 text-center"
+      >
+        <h2 className="text-lg font-semibold text-red-200">
+          Batch flow needs to be restored
+        </h2>
         <p className="mt-2 text-sm text-red-100/70">
-          {this.state.errorMessage ?? "The batch screen failed to render."}
+          {this.state.restoreError ??
+            this.state.errorMessage ??
+            "The batch screen failed to render."}
         </p>
         <Button onClick={this.handleRestore} className="mt-5">
           Try again

--- a/lib/safe-json.ts
+++ b/lib/safe-json.ts
@@ -36,3 +36,43 @@ export function safeJsonResponse(
     },
   });
 }
+
+/**
+ * Discriminated result of a {@link safeJsonParse} call.
+ */
+export type SafeJsonParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: Error };
+
+/**
+ * Parses a JSON string without throwing.
+ *
+ * `JSON.parse` throws a `SyntaxError` on corrupt, partial, or manually edited
+ * input. Callers that read untrusted storage (sessionStorage / localStorage,
+ * which extensions or truncation can corrupt) should use this instead so a bad
+ * payload becomes a handled `{ ok: false }` result rather than an uncaught
+ * exception that crashes the surrounding UI (#516).
+ *
+ * @param raw - The string to parse. `null`/`undefined` are treated as failures.
+ * @returns `{ ok: true, value }` on success, or `{ ok: false, error }` otherwise.
+ *
+ * @example
+ * const result = safeJsonParse<Payment[]>(sessionStorage.getItem(key));
+ * if (result.ok) restore(result.value);
+ * else showError(result.error.message);
+ */
+export function safeJsonParse<T = unknown>(
+  raw: string | null | undefined,
+): SafeJsonParseResult<T> {
+  if (typeof raw !== "string") {
+    return { ok: false, error: new Error("No JSON string to parse") };
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw) as T };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}

--- a/tests/batch-error-boundary.test.ts
+++ b/tests/batch-error-boundary.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the BatchErrorBoundary restore logic (#516).
+ *
+ * The boundary's "Try again" handler used to call `JSON.parse` on raw
+ * sessionStorage data with no guard, so corrupt / partial / hand-edited storage
+ * threw a SyntaxError out of the click handler and left the user stuck on the
+ * error panel. Mounting the class component would need jsdom + testing-library;
+ * following the repo convention (see demo-page-hooks.test.ts) we instead test
+ * the pure, DOM-free decision function `restoreFromStorage` against a fake
+ * storage, which is exactly what the handler delegates to.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import {
+  restoreFromStorage,
+  isRestorablePayload,
+} from "../components/BatchErrorBoundary";
+
+/** Minimal in-memory Storage stand-in capturing removeItem calls. */
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (key: string) => (map.has(key) ? map.get(key)! : null),
+    removeItem: vi.fn((key: string) => {
+      map.delete(key);
+    }),
+    has: (key: string) => map.has(key),
+  };
+}
+
+describe("restoreFromStorage — corrupt JSON (#516)", () => {
+  test("does not throw on invalid JSON and reports a corrupt outcome", () => {
+    const storage = fakeStorage({ demo_batch_payments: "{broken" });
+
+    let outcome!: ReturnType<typeof restoreFromStorage>;
+    expect(() => {
+      outcome = restoreFromStorage(storage, "demo_batch_payments");
+    }).not.toThrow();
+
+    expect(outcome.status).toBe("corrupt");
+    if (outcome.status === "corrupt") {
+      expect(outcome.message).toMatch(/corrupted/i);
+    }
+  });
+
+  test("clears the corrupt key from storage after a failed parse", () => {
+    const storage = fakeStorage({ demo_batch_payments: "not json at all" });
+
+    restoreFromStorage(storage, "demo_batch_payments");
+
+    expect(storage.removeItem).toHaveBeenCalledWith("demo_batch_payments");
+    expect(storage.has("demo_batch_payments")).toBe(false);
+  });
+});
+
+describe("restoreFromStorage — valid payloads", () => {
+  test("restores a valid non-empty payments array", () => {
+    const payments = [{ address: "GABC", amount: "10", asset: "XLM" }];
+    const storage = fakeStorage({
+      demo_batch_payments: JSON.stringify(payments),
+    });
+
+    const outcome = restoreFromStorage(storage, "demo_batch_payments");
+
+    expect(outcome.status).toBe("restored");
+    if (outcome.status === "restored") {
+      expect(outcome.value).toEqual(payments);
+    }
+    expect(storage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test("restores a valid object payload (new-batch state shape)", () => {
+    const state = { step: 2, selectedNetwork: "testnet" };
+    const storage = fakeStorage({ new_batch_state: JSON.stringify(state) });
+
+    const outcome = restoreFromStorage(storage, "new_batch_state");
+
+    expect(outcome.status).toBe("restored");
+    if (outcome.status === "restored") {
+      expect(outcome.value).toEqual(state);
+    }
+  });
+});
+
+describe("restoreFromStorage — empty and invalid shapes", () => {
+  test("returns empty when nothing is saved", () => {
+    const storage = fakeStorage();
+    const outcome = restoreFromStorage(storage, "demo_batch_payments");
+    expect(outcome.status).toBe("empty");
+    expect(storage.removeItem).not.toHaveBeenCalled();
+  });
+
+  test("treats well-formed JSON that fails the validator as invalid and clears it", () => {
+    // Valid JSON, but an empty array fails a 'non-empty payments' guard.
+    const storage = fakeStorage({ demo_batch_payments: "[]" });
+
+    const outcome = restoreFromStorage(
+      storage,
+      "demo_batch_payments",
+      (parsed) => Array.isArray(parsed) && parsed.length > 0,
+    );
+
+    expect(outcome.status).toBe("invalid");
+    expect(storage.removeItem).toHaveBeenCalledWith("demo_batch_payments");
+  });
+});
+
+describe("isRestorablePayload — default guard", () => {
+  test("accepts non-empty arrays and objects", () => {
+    expect(isRestorablePayload([1])).toBe(true);
+    expect(isRestorablePayload({ step: 1 })).toBe(true);
+  });
+
+  test("rejects empty arrays, empty objects, null, and primitives", () => {
+    expect(isRestorablePayload([])).toBe(false);
+    expect(isRestorablePayload({})).toBe(false);
+    expect(isRestorablePayload(null)).toBe(false);
+    expect(isRestorablePayload("string")).toBe(false);
+    expect(isRestorablePayload(42)).toBe(false);
+  });
+});

--- a/tests/safe-json.test.ts
+++ b/tests/safe-json.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, test, expect } from "vitest";
+import { safeJsonParse } from "../lib/safe-json";
 
 // Test the BigInt replacer logic directly since safeJsonResponse depends on Next.js
 function bigIntReplacer(_key: string, value: unknown): unknown {
@@ -71,5 +72,27 @@ describe("BigInt-safe JSON serialization", () => {
   test("regular JSON.stringify throws on BigInt", () => {
     const data = { value: BigInt(123) };
     expect(() => JSON.stringify(data)).toThrow(TypeError);
+  });
+});
+
+describe("safeJsonParse (#516)", () => {
+  test("parses valid JSON into an ok result", () => {
+    const result = safeJsonParse<{ a: number }>('{"a":1}');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toEqual({ a: 1 });
+  });
+
+  test("does not throw on corrupt JSON and returns an error result", () => {
+    let result!: ReturnType<typeof safeJsonParse>;
+    expect(() => {
+      result = safeJsonParse("{broken");
+    }).not.toThrow();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBeInstanceOf(Error);
+  });
+
+  test("returns an error result for null / undefined input", () => {
+    expect(safeJsonParse(null).ok).toBe(false);
+    expect(safeJsonParse(undefined).ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`BatchErrorBoundary` ("Restore saved batch" / "Try again") parsed `sessionStorage` with a bare `JSON.parse`. Corrupt, partial, or hand-edited storage — or extension interference, or truncation of large batch state — threw a `SyntaxError` out of the click handler, crashing the recovery UI and leaving users stuck on the error screen. The boundary guards the longest batch flows (`app/dashboard/new-batch/page.tsx` and `app/demo/page.tsx`), exactly where session data is largest and most prone to truncation.

## Changes

- **`lib/safe-json.ts`**: add `safeJsonParse<T>()` — a non-throwing JSON parse returning a discriminated `{ ok: true, value } | { ok: false, error }` result for untrusted storage reads.
- **`components/BatchErrorBoundary.tsx`**: route restore through a pure, DOM-free `restoreFromStorage` helper that parses without throwing, validates the parsed shape via an optional type guard (default: non-empty array/object), removes the corrupt or invalid key from `sessionStorage`, and returns a clear outcome. The handler surfaces a toast and an inline message on failure while keeping the recovery UI visible, so a poisoned key can never block recovery on retry.
- **`app/demo/page.tsx`**: pass a payments-array `validate` guard to the boundary. The default guard keeps the boundary reusable for the object-shaped `new_batch_state`.

## Tests

- `tests/batch-error-boundary.test.ts`: corrupt JSON does not throw and clears the key; valid array and object payloads restore; empty storage; well-formed-but-invalid payloads are cleared; default guard behavior. (Follows the repo's no-jsdom convention from `demo-page-hooks.test.ts` by testing the pure decision function the handler delegates to.)
- `tests/safe-json.test.ts`: `safeJsonParse` happy path, corrupt input, and null/undefined.

All tests in both files pass.

## Acceptance criteria

- [x] Invalid `sessionStorage` JSON does not crash the restore handler.
- [x] User sees a clear error when restore data is corrupt.
- [x] Valid saved batches still restore successfully.
- [x] Corrupt keys are removed from `sessionStorage` after a failed parse.

Closes #516