### PR TITLE
fix(a11y): add role=alert to demo page error banner for screen readers

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -350,7 +350,14 @@ export default function Home() {
         </div>
 
         {error && (
-          <div className="bg-destructive/10 border border-destructive text-destructive rounded-lg p-4 mb-6">
+          // role="alert" (aria-live="assertive" implicitly) so screen readers
+          // announce batch build / signing / parse failures the moment setError
+          // populates them, matching the convention used in ManualBatchEntry and
+          // ui/field.tsx (#569).
+          <div
+            role="alert"
+            className="bg-destructive/10 border border-destructive text-destructive rounded-lg p-4 mb-6"
+          >
             <p className="font-semibold">Error</p>
             <p className="text-sm mt-1">{error}</p>
           </div>

--- a/tests/demo-error-alert.test.ts
+++ b/tests/demo-error-alert.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Accessibility regression guard for #569.
+ *
+ * The demo page (`app/demo/page.tsx`) renders fatal / validation errors in a
+ * styled container when `error` state is set. It was a plain <div> with no
+ * `role="alert"`, so screen readers did not announce batch submission failures,
+ * signing cancellations, or parse errors when they appeared dynamically.
+ *
+ * Asserting the announcement at runtime would need jsdom + an a11y tree; instead
+ * we statically pin that the error banner carries `role="alert"` (the same
+ * convention used by ManualBatchEntry and ui/field.tsx), which is exactly the
+ * attribute that makes the live region announce on insertion.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const DEMO_PAGE = path.join(process.cwd(), "app", "demo", "page.tsx");
+const SOURCE = readFileSync(DEMO_PAGE, "utf8");
+
+describe("demo page error banner accessibility (#569)", () => {
+  test("renders the error block only when error state is set", () => {
+    // Guards against the banner being made always-present (which would make a
+    // role="alert" region announce stale/empty content).
+    expect(SOURCE).toMatch(/\{error && \(/);
+  });
+
+  test("error banner container declares role=\"alert\"", () => {
+    // The error <div> (styled with the destructive palette) must carry
+    // role="alert" so it is an assertive live region.
+    const errorBlock = SOURCE.slice(
+      SOURCE.indexOf("{error && ("),
+      SOURCE.indexOf("{error && (") + 400,
+    );
+    expect(errorBlock).toMatch(/role="alert"/);
+    expect(errorBlock).toMatch(/bg-destructive\/10/);
+  });
+});


### PR DESCRIPTION
## Summary

The demo page (`app/demo/page.tsx`) renders fatal and validation errors in a styled `div` when `error` state is set, but the container was a plain `<div>` with no `role="alert"` or `aria-live` semantics. Screen readers therefore did not announce batch submission failures, signing cancellations, or parse errors when they appeared dynamically after a user action — critical feedback that must be perceivable immediately. Other components (`ManualBatchEntry`, `ui/field.tsx`) already use `role="alert"` for error feedback; the demo now follows the same convention.

## Changes

- Add `role="alert"` to the demo error banner container. `role="alert"` carries an implicit `aria-live="assertive"`, so the region is announced the moment `setError` populates it. The banner is still rendered only when `error` is set, so the live region never announces stale/empty content. Visual styling (classes) is unchanged.

## Tests

- `tests/demo-error-alert.test.ts`: static regression guard asserting the error banner is conditionally rendered and carries `role="alert"` with the unchanged destructive styling — following the source-assertion, no-jsdom convention established in `demo-page-hooks.test.ts`.

## Acceptance criteria

- [x] Demo error banner uses `role="alert"`.
- [x] Screen readers announce new errors when `setError` populates messages (assertive live region inserted on error).
- [x] Visual styling of the error panel is unchanged.
- [x] Pattern documented (inline comment) for future demo inline errors.

Closes #569