### PR TITLE
fix(query): centralize batch-history query keys and propagate invalidation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -306,6 +306,21 @@ fetches for the same query key.
 - All `useQuery`, `useMutation`, and `invalidateQueries` calls share the same
   `QueryClient` instance and cache namespace.
 
+### Query keys
+
+Query keys come from the central factory in `lib/query-keys.ts` — do not write
+raw string-literal keys in hooks or components. The hierarchy is parent → child:
+
+- `batchHistoryKeys.all(publicKey)` → `["batch-history", publicKey]` (parent)
+- `batchHistoryKeys.list(publicKey, …filters)` → `["batch-history", publicKey, …filters]` (children: pagination/filter/sort)
+- `dashboardMetricsKeys.all(publicKey)` / `dashboardMetricsKeys.detail(publicKey, network, range)`
+
+TanStack Query matches partially by default (`exact: false`), so **invalidate via
+the `.all(publicKey)` parent** to refetch every paginated/filtered child list.
+Batch history and dashboard metrics are separate namespaces: when a batch
+completes, invalidate **both** parents (see `contexts/BatchFlowContext.tsx`) so the
+recent table, the history page, and the metric cards all refresh.
+
 ## Testing Strategy
 
 ### Unit Tests

--- a/contexts/BatchFlowContext.tsx
+++ b/contexts/BatchFlowContext.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useWallet } from "@/contexts/WalletContext";
 import { useNotifications } from "@/contexts/NotificationsContext";
-import { BATCH_HISTORY_QUERY_KEY } from "@/lib/dashboard/fetch-history";
+import { batchHistoryKeys, dashboardMetricsKeys } from "@/lib/query-keys";
 import { parsePaymentFile, analyzeParsedPayments } from "@/lib/stellar/parser";
 import { getBatchSummary } from "@/lib/stellar/summary";
 import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
@@ -202,8 +202,16 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
             setResult(data.result ?? null);
             setIsSubmitting(false);
             setStep(4);
+            // Invalidate the batch-history parent key: partial matching
+            // (exact: false default) refreshes every paginated/filtered list —
+            // recent table, history page — for this account (#521).
             void queryClient.invalidateQueries({
-              queryKey: [BATCH_HISTORY_QUERY_KEY, ownerPublicKey],
+              queryKey: batchHistoryKeys.all(ownerPublicKey),
+            });
+            // A completed batch also changes the dashboard metric cards, which
+            // live in a separate namespace and would otherwise stay stale (#521 / #523).
+            void queryClient.invalidateQueries({
+              queryKey: dashboardMetricsKeys.all(ownerPublicKey),
             });
             pushBatchNotification({
               jobId: data.jobId ?? id,

--- a/hooks/use-batch-history.ts
+++ b/hooks/use-batch-history.ts
@@ -4,10 +4,12 @@ import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { BatchResult } from '@/lib/stellar/types';
 import { fetchBatchHistory, setCachedHistory, clearCachedHistory } from '@/lib/batch-history-adapter';
+import { batchHistoryKeys } from '@/lib/query-keys';
 
 export function useBatchHistory(publicKey?: string | null) {
   const queryClient = useQueryClient();
-  const queryKey = ['batch-history', publicKey] as const;
+  // Central key factory (#521): this account's parent batch-history key.
+  const queryKey = batchHistoryKeys.all(publicKey);
 
   const { data: history = [], isLoading, error } = useQuery({
     queryKey,

--- a/hooks/use-dashboard-metrics.ts
+++ b/hooks/use-dashboard-metrics.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import type { BatchJobNetwork } from "@/lib/stellar/types";
+import { dashboardMetricsKeys } from "@/lib/query-keys";
 
 export interface DashboardMetricsTimeSeriesPoint {
   date: string;
@@ -42,7 +43,7 @@ export function useDashboardMetrics(
   network: BatchJobNetwork,
   range?: "7d" | "30d" | "90d",
 ) {
-  const queryKey = ["dashboard-metrics", publicKey, network, range] as const;
+  const queryKey = dashboardMetricsKeys.detail(publicKey, network, range);
 
   const { data: metrics, isLoading, error } = useQuery({
     queryKey,

--- a/lib/dashboard/fetch-history.ts
+++ b/lib/dashboard/fetch-history.ts
@@ -23,13 +23,23 @@ export interface BatchHistoryResponse {
   }
 }
 
-export const BATCH_HISTORY_QUERY_KEY = "batch-history" as const
+import { BATCH_HISTORY_QUERY_KEY, batchHistoryKeys } from "@/lib/query-keys"
 
+// Re-exported from the central query-key factory (#521) so existing imports
+// (`@/lib/dashboard/fetch-history`) keep working while there is one source of
+// truth for the key structure.
+export { BATCH_HISTORY_QUERY_KEY, batchHistoryKeys }
+
+/**
+ * Builds a specific (paginated/filtered) batch-history query key.
+ * Thin wrapper over `batchHistoryKeys.list` kept for call-site brevity in the
+ * dashboard tables; invalidation should always target `batchHistoryKeys.all`.
+ */
 export function batchHistoryQueryKey(
   publicKey: string | null | undefined,
   ...rest: unknown[]
 ) {
-  return [BATCH_HISTORY_QUERY_KEY, publicKey, ...rest] as const
+  return batchHistoryKeys.list(publicKey, ...rest)
 }
 
 export async function fetchHistory(params: {

--- a/lib/query-keys.ts
+++ b/lib/query-keys.ts
@@ -1,0 +1,55 @@
+/**
+ * Central React Query key factory (#521).
+ *
+ * Before this module, batch-history keys were built three different ways:
+ *   - hooks/use-batch-history.ts:     ["batch-history", publicKey]
+ *   - components/dashboard/*Table:    ["batch-history", publicKey, page, limit, …filters]
+ *   - contexts/BatchFlowContext.tsx:  [BATCH_HISTORY_QUERY_KEY, publicKey]
+ * and dashboard metrics used a separate ["dashboard-metrics", …] namespace that
+ * nothing invalidated when a batch completed. The inconsistency made
+ * `invalidateQueries` behaviour unpredictable and left metric cards stale.
+ *
+ * This module is the single source of truth for those keys. The hierarchy is:
+ *
+ *   batchHistoryKeys.root                       → ["batch-history"]
+ *   batchHistoryKeys.all(pk)                     → ["batch-history", pk]            (parent)
+ *   batchHistoryKeys.list(pk, …filters)          → ["batch-history", pk, …filters]  (children)
+ *
+ *   dashboardMetricsKeys.root                    → ["dashboard-metrics"]
+ *   dashboardMetricsKeys.all(pk)                 → ["dashboard-metrics", pk]        (parent)
+ *   dashboardMetricsKeys.detail(pk, net, range)  → ["dashboard-metrics", pk, net, range]
+ *
+ * TanStack Query matches partially by default (`exact: false`), so invalidating
+ * a parent key (`*.all(pk)`) refetches every child list/detail built from
+ * `*.list(pk, …)` / `*.detail(pk, …)`. Always invalidate via the `.all(pk)`
+ * parent so paginated/filtered queries propagate correctly.
+ */
+
+export const BATCH_HISTORY_QUERY_KEY = "batch-history" as const;
+export const DASHBOARD_METRICS_QUERY_KEY = "dashboard-metrics" as const;
+
+type PublicKey = string | null | undefined;
+
+export const batchHistoryKeys = {
+  /** Bare namespace — matches every batch-history query for every account. */
+  root: [BATCH_HISTORY_QUERY_KEY] as const,
+  /** Parent key for one account. Use this for invalidation (matches all lists). */
+  all: (publicKey: PublicKey) => [BATCH_HISTORY_QUERY_KEY, publicKey] as const,
+  /** Specific paginated/filtered list key. `rest` carries page/limit/filters. */
+  list: (publicKey: PublicKey, ...rest: unknown[]) =>
+    [BATCH_HISTORY_QUERY_KEY, publicKey, ...rest] as const,
+};
+
+export const dashboardMetricsKeys = {
+  /** Bare namespace — matches every dashboard-metrics query for every account. */
+  root: [DASHBOARD_METRICS_QUERY_KEY] as const,
+  /** Parent key for one account. Use this for invalidation. */
+  all: (publicKey: PublicKey) =>
+    [DASHBOARD_METRICS_QUERY_KEY, publicKey] as const,
+  /** Specific metrics query for an account + network (+ optional range). */
+  detail: (
+    publicKey: PublicKey,
+    network: string,
+    range?: "7d" | "30d" | "90d",
+  ) => [DASHBOARD_METRICS_QUERY_KEY, publicKey, network, range] as const,
+};

--- a/tests/query-keys.test.ts
+++ b/tests/query-keys.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the central React Query key factory (#521).
+ *
+ * Pins the key hierarchy and — critically — proves that invalidating the parent
+ * `batchHistoryKeys.all(pk)` key propagates to paginated/filtered list queries
+ * built from `batchHistoryKeys.list(pk, …)`, which was the core bug: history was
+ * invalidated with a key that callers worried would not match the longer table
+ * keys, and dashboard metrics were never invalidated at all.
+ */
+
+import { describe, expect, test } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import {
+  batchHistoryKeys,
+  dashboardMetricsKeys,
+  BATCH_HISTORY_QUERY_KEY,
+  DASHBOARD_METRICS_QUERY_KEY,
+} from "../lib/query-keys";
+
+describe("key factory shape", () => {
+  test("batchHistoryKeys builds parent and child keys", () => {
+    expect(batchHistoryKeys.all("GABC")).toEqual(["batch-history", "GABC"]);
+    expect(batchHistoryKeys.list("GABC", 1, 20, "completed")).toEqual([
+      "batch-history",
+      "GABC",
+      1,
+      20,
+      "completed",
+    ]);
+    expect(batchHistoryKeys.root).toEqual([BATCH_HISTORY_QUERY_KEY]);
+  });
+
+  test("dashboardMetricsKeys builds parent and detail keys", () => {
+    expect(dashboardMetricsKeys.all("GABC")).toEqual([
+      "dashboard-metrics",
+      "GABC",
+    ]);
+    expect(dashboardMetricsKeys.detail("GABC", "testnet", "30d")).toEqual([
+      "dashboard-metrics",
+      "GABC",
+      "testnet",
+      "30d",
+    ]);
+    expect(dashboardMetricsKeys.root).toEqual([DASHBOARD_METRICS_QUERY_KEY]);
+  });
+
+  test("a child list key is a strict prefix-extension of the parent key", () => {
+    const parent = batchHistoryKeys.all("GABC");
+    const child = batchHistoryKeys.list("GABC", 2, 50, "failed");
+    expect(child.slice(0, parent.length)).toEqual([...parent]);
+  });
+});
+
+describe("invalidation propagation", () => {
+  test("invalidating the parent key invalidates paginated/filtered children", async () => {
+    const qc = new QueryClient();
+    const pk = "GABC";
+
+    const listKey = batchHistoryKeys.list(pk, 1, 20, "completed");
+    const otherListKey = batchHistoryKeys.list(pk, 2, 20, "failed");
+    qc.setQueryData(listKey, { items: [] });
+    qc.setQueryData(otherListKey, { items: [] });
+
+    expect(qc.getQueryState(listKey)?.isInvalidated).toBe(false);
+
+    await qc.invalidateQueries({ queryKey: batchHistoryKeys.all(pk) });
+
+    // Both filtered/paginated table queries are marked stale by the parent key.
+    expect(qc.getQueryState(listKey)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(otherListKey)?.isInvalidated).toBe(true);
+  });
+
+  test("invalidation is scoped to the account (no cross-account bleed)", async () => {
+    const qc = new QueryClient();
+
+    const mine = batchHistoryKeys.list("GME", 1, 20);
+    const theirs = batchHistoryKeys.list("GYOU", 1, 20);
+    qc.setQueryData(mine, { items: [] });
+    qc.setQueryData(theirs, { items: [] });
+
+    await qc.invalidateQueries({ queryKey: batchHistoryKeys.all("GME") });
+
+    expect(qc.getQueryState(mine)?.isInvalidated).toBe(true);
+    expect(qc.getQueryState(theirs)?.isInvalidated).toBe(false);
+  });
+
+  test("batch-history and dashboard-metrics are independent namespaces", async () => {
+    const qc = new QueryClient();
+    const pk = "GABC";
+
+    const history = batchHistoryKeys.list(pk, 1, 20);
+    const metrics = dashboardMetricsKeys.detail(pk, "testnet");
+    qc.setQueryData(history, { items: [] });
+    qc.setQueryData(metrics, { totalPayments: 0 });
+
+    // Invalidating history alone must NOT touch the metrics namespace...
+    await qc.invalidateQueries({ queryKey: batchHistoryKeys.all(pk) });
+    expect(qc.getQueryState(metrics)?.isInvalidated).toBe(false);
+
+    // ...which is why a completed batch must cross-invalidate metrics explicitly.
+    await qc.invalidateQueries({ queryKey: dashboardMetricsKeys.all(pk) });
+    expect(qc.getQueryState(metrics)?.isInvalidated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

React Query keys for batch history were incompatible across the codebase. `hooks/use-batch-history.ts` used `['batch-history', publicKey]`, the dashboard tables used a longer `['batch-history', publicKey, page, limit, …filters]` key, and `contexts/BatchFlowContext.tsx` used yet another literal. Dashboard metrics lived in a separate `['dashboard-metrics', …]` namespace that nothing invalidated when a batch completed — so after a submit the recent table, history page, and metric cards could all go stale, and invalidation behaviour was hard to reason about.

## Changes

- **`lib/query-keys.ts` (new)** — single source of truth:
  - `batchHistoryKeys.root / .all(publicKey) / .list(publicKey, …filters)`
  - `dashboardMetricsKeys.root / .all(publicKey) / .detail(publicKey, network, range)`
  - Documented parent → child hierarchy; invalidation always targets the `.all(publicKey)` parent so TanStack Query's default partial matching (`exact: false`) refetches every paginated/filtered child.
- **Migrations** to the factory: `hooks/use-batch-history.ts`, `hooks/use-dashboard-metrics.ts`, and `lib/dashboard/fetch-history.ts` (now delegates to and re-exports the factory, so existing `batchHistoryQueryKey` imports in `HistoryTable`/`RecentBatchesTable` keep working with no raw literals).
- **`contexts/BatchFlowContext.tsx`** — on batch completion, invalidate `batchHistoryKeys.all(publicKey)` (propagates to all lists) **and** cross-invalidate `dashboardMetricsKeys.all(publicKey)` so metric cards refresh (#521 / #523).
- **`DEVELOPMENT.md`** — documents the key hierarchy and the invalidate-the-parent rule.

## Tests

- `tests/query-keys.test.ts`: key-shape assertions plus a real `QueryClient` proving that invalidating the parent key propagates to paginated/filtered child queries, stays scoped per account (no cross-account bleed), and keeps the batch-history and dashboard-metrics namespaces independent.
- Existing `tests/fetch-history.test.ts` (which pins `batchHistoryQueryKey` output) still passes via the delegating wrapper.

## Acceptance criteria

- [x] Central query-keys module defines the batch history key structure.
- [x] `invalidateQueries` after submit refreshes dashboard metrics, recent table, and history page.
- [x] No raw string-literal query keys in the migrated dashboard hooks/components.
- [x] Predictable parent/child key relationships (verified by tests).

Closes #521