### PR TITLE
fix: persist settings payment preferences and apply in BatchFlowConte…

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import {
   Card,
   CardContent,
@@ -26,6 +26,11 @@ import { DangerZoneCard } from "@/components/dashboard/settings/DangerZoneCard";
 import { SecuritySettingsCard } from "@/components/dashboard/settings/SecuritySettingsCard";
 import { ApiDeveloperCard } from "@/components/dashboard/settings/ApiDeveloperCard";
 import { useTheme } from "next-themes";
+import {
+  loadSettingsPreferences,
+  saveSettingsPreferences,
+  type SettingsPreferences,
+} from "@/lib/settings-prefs";
 
 export default function SettingsPage() {
   const { publicKey, connect, disconnect, isConnecting } = useWallet();
@@ -38,9 +43,50 @@ export default function SettingsPage() {
   const [completionNotifications, setCompletionNotifications] = useState(true);
   const [mounted, setMounted] = useState(false);
 
+  // Load preferences from localStorage on mount
   useEffect(() => {
     setMounted(true);
+    const prefs = loadSettingsPreferences();
+    setDefaultNetwork(prefs.defaultNetwork);
+    setDefaultAsset(prefs.defaultAsset);
+    setBatchValidation(prefs.batchValidation);
+    setCompletionNotifications(prefs.completionNotifications);
   }, []);
+
+  // Debounced save to localStorage
+  const debouncedSave = useCallback(
+    (() => {
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+      return (prefs: Partial<SettingsPreferences>) => {
+        if (timeoutId) clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+          saveSettingsPreferences(prefs);
+        }, 500);
+      };
+    })(),
+    []
+  );
+
+  // Update handlers to save preferences
+  const handleDefaultNetworkChange = useCallback((value: string) => {
+    setDefaultNetwork(value);
+    debouncedSave({ defaultNetwork: value as "testnet" | "mainnet" });
+  }, [debouncedSave]);
+
+  const handleDefaultAssetChange = useCallback((value: string) => {
+    setDefaultAsset(value);
+    debouncedSave({ defaultAsset: value as "xlm" | "usdc" | "usdt" });
+  }, [debouncedSave]);
+
+  const handleBatchValidationChange = useCallback((checked: boolean) => {
+    setBatchValidation(checked);
+    debouncedSave({ batchValidation: checked });
+  }, [debouncedSave]);
+
+  const handleCompletionNotificationsChange = useCallback((checked: boolean) => {
+    setCompletionNotifications(checked);
+    debouncedSave({ completionNotifications: checked });
+  }, [debouncedSave]);
 
   const handleCopyAddress = () => {
     if (publicKey) {
@@ -237,7 +283,7 @@ export default function SettingsPage() {
             <label className="text-sm text-slate-400 font-medium">
               Default Network
             </label>
-            <Select value={defaultNetwork} onValueChange={setDefaultNetwork}>
+            <Select value={defaultNetwork} onValueChange={handleDefaultNetworkChange}>
               <SelectTrigger className="w-full h-16 bg-slate-900 border-slate-800/50 text-white hover:bg-slate-950 [&_svg]:text-white [&_svg]:opacity-100 text-lg px-4 [&_svg]:size-5">
                 <SelectValue />
               </SelectTrigger>
@@ -263,7 +309,7 @@ export default function SettingsPage() {
             <label className="text-sm text-slate-400 font-medium">
               Default Asset
             </label>
-            <Select value={defaultAsset} onValueChange={setDefaultAsset}>
+            <Select value={defaultAsset} onValueChange={handleDefaultAssetChange}>
               <SelectTrigger className="w-full h-16 bg-slate-950 border-slate-800/50 text-white hover:bg-slate-950 [&_svg]:text-white [&_svg]:opacity-100 text-lg px-4 [&_svg]:size-5">
                 <SelectValue />
               </SelectTrigger>
@@ -300,7 +346,7 @@ export default function SettingsPage() {
             </div>
             <Switch
               checked={batchValidation}
-              onCheckedChange={setBatchValidation}
+              onCheckedChange={handleBatchValidationChange}
               className="data-[state=checked]:bg-emerald-500"
             />
           </div>
@@ -317,7 +363,7 @@ export default function SettingsPage() {
             </div>
             <Switch
               checked={completionNotifications}
-              onCheckedChange={setCompletionNotifications}
+              onCheckedChange={handleCompletionNotificationsChange}
               className="data-[state=checked]:bg-emerald-500"
             />
           </div>

--- a/contexts/BatchFlowContext.tsx
+++ b/contexts/BatchFlowContext.tsx
@@ -7,6 +7,7 @@ import { useNotifications } from "@/contexts/NotificationsContext";
 import { parsePaymentFile, analyzeParsedPayments } from "@/lib/stellar/parser";
 import { getBatchSummary } from "@/lib/stellar/summary";
 import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
+import { loadSettingsPreferences } from "@/lib/settings-prefs";
 import type {
   ParsedPaymentFile,
   BatchResult,
@@ -128,6 +129,14 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const { publicKey } = useWallet();
   const { pushBatchNotification } = useNotifications();
+
+  // Load default network from settings preferences on mount (#576)
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const prefs = loadSettingsPreferences();
+      setSelectedNetwork(prefs.defaultNetwork);
+    }
+  }, []);
 
   // Sync state to sessionStorage to prevent data loss on render crashes
   useEffect(() => {

--- a/lib/settings-prefs.ts
+++ b/lib/settings-prefs.ts
@@ -1,0 +1,103 @@
+export interface SettingsPreferences {
+  version: number;
+  defaultNetwork: "testnet" | "mainnet";
+  defaultAsset: "xlm" | "usdc" | "usdt";
+  batchValidation: boolean;
+  completionNotifications: boolean;
+}
+
+const STORAGE_KEY = "batchpay_settings_v1";
+const CURRENT_VERSION = 1;
+
+const DEFAULT_PREFERENCES: SettingsPreferences = {
+  version: CURRENT_VERSION,
+  defaultNetwork: "testnet",
+  defaultAsset: "xlm",
+  batchValidation: true,
+  completionNotifications: true,
+};
+
+/**
+ * Load settings preferences from localStorage with SSR guard and schema migration
+ */
+export function loadSettingsPreferences(): SettingsPreferences {
+  if (typeof window === "undefined") {
+    return DEFAULT_PREFERENCES;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_PREFERENCES;
+    }
+
+    const parsed = JSON.parse(stored);
+    
+    // Schema migration: if version is missing or outdated, migrate to current version
+    if (!parsed.version || parsed.version < CURRENT_VERSION) {
+      const migrated = migrateSettings(parsed);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(migrated));
+      return migrated;
+    }
+
+    // Validate and merge with defaults to handle missing fields
+    return {
+      ...DEFAULT_PREFERENCES,
+      ...parsed,
+      version: CURRENT_VERSION,
+    };
+  } catch (error) {
+    console.error("Failed to load settings preferences:", error);
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+/**
+ * Migrate settings from older versions to current version
+ */
+function migrateSettings(oldSettings: any): SettingsPreferences {
+  // Version 0 to 1 migration: add version field and ensure all fields exist
+  return {
+    version: CURRENT_VERSION,
+    defaultNetwork: oldSettings.defaultNetwork ?? DEFAULT_PREFERENCES.defaultNetwork,
+    defaultAsset: oldSettings.defaultAsset ?? DEFAULT_PREFERENCES.defaultAsset,
+    batchValidation: oldSettings.batchValidation ?? DEFAULT_PREFERENCES.batchValidation,
+    completionNotifications: oldSettings.completionNotifications ?? DEFAULT_PREFERENCES.completionNotifications,
+  };
+}
+
+/**
+ * Save settings preferences to localStorage
+ */
+export function saveSettingsPreferences(preferences: Partial<SettingsPreferences>): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    const current = loadSettingsPreferences();
+    const updated = {
+      ...current,
+      ...preferences,
+      version: CURRENT_VERSION,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch (error) {
+    console.error("Failed to save settings preferences:", error);
+  }
+}
+
+/**
+ * Reset settings preferences to defaults
+ */
+export function resetSettingsPreferences(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(DEFAULT_PREFERENCES));
+  } catch (error) {
+    console.error("Failed to reset settings preferences:", error);
+  }
+}

--- a/tests/settings-prefs.test.ts
+++ b/tests/settings-prefs.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  loadSettingsPreferences,
+  saveSettingsPreferences,
+  resetSettingsPreferences,
+  type SettingsPreferences,
+} from "@/lib/settings-prefs";
+
+const STORAGE_KEY = "batchpay_settings_v1";
+
+describe("settings-prefs", () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    if (typeof window !== "undefined") {
+      localStorage.clear();
+    }
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    if (typeof window !== "undefined") {
+      localStorage.clear();
+    }
+  });
+
+  describe("loadSettingsPreferences", () => {
+    it("should return default preferences when localStorage is empty", () => {
+      const prefs = loadSettingsPreferences();
+      expect(prefs).toEqual({
+        version: 1,
+        defaultNetwork: "testnet",
+        defaultAsset: "xlm",
+        batchValidation: true,
+        completionNotifications: true,
+      });
+    });
+
+    it("should return default preferences on SSR (window undefined)", () => {
+      // Mock window as undefined to simulate SSR
+      const originalWindow = global.window;
+      // @ts-expect-error - intentionally undefined for SSR test
+      delete global.window;
+
+      const prefs = loadSettingsPreferences();
+      expect(prefs).toEqual({
+        version: 1,
+        defaultNetwork: "testnet",
+        defaultAsset: "xlm",
+        batchValidation: true,
+        completionNotifications: true,
+      });
+
+      global.window = originalWindow;
+    });
+
+    it("should load saved preferences from localStorage", () => {
+      const savedPrefs: SettingsPreferences = {
+        version: 1,
+        defaultNetwork: "mainnet",
+        defaultAsset: "usdc",
+        batchValidation: false,
+        completionNotifications: false,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(savedPrefs));
+
+      const prefs = loadSettingsPreferences();
+      expect(prefs).toEqual(savedPrefs);
+    });
+
+    it("should migrate preferences from version 0 to version 1", () => {
+      const oldPrefs = {
+        defaultNetwork: "mainnet",
+        defaultAsset: "usdt",
+        batchValidation: false,
+        // Missing version field and completionNotifications
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(oldPrefs));
+
+      const prefs = loadSettingsPreferences();
+      expect(prefs.version).toBe(1);
+      expect(prefs.defaultNetwork).toBe("mainnet");
+      expect(prefs.defaultAsset).toBe("usdt");
+      expect(prefs.batchValidation).toBe(false);
+      expect(prefs.completionNotifications).toBe(true); // Default value
+    });
+
+    it("should handle corrupt localStorage data gracefully", () => {
+      localStorage.setItem(STORAGE_KEY, "invalid json");
+
+      const prefs = loadSettingsPreferences();
+      expect(prefs).toEqual({
+        version: 1,
+        defaultNetwork: "testnet",
+        defaultAsset: "xlm",
+        batchValidation: true,
+        completionNotifications: true,
+      });
+    });
+
+    it("should merge with defaults for missing fields", () => {
+      const partialPrefs = {
+        version: 1,
+        defaultNetwork: "mainnet",
+        // Missing other fields
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(partialPrefs));
+
+      const prefs = loadSettingsPreferences();
+      expect(prefs.version).toBe(1);
+      expect(prefs.defaultNetwork).toBe("mainnet");
+      expect(prefs.defaultAsset).toBe("xlm"); // Default
+      expect(prefs.batchValidation).toBe(true); // Default
+      expect(prefs.completionNotifications).toBe(true); // Default
+    });
+  });
+
+  describe("saveSettingsPreferences", () => {
+    it("should save preferences to localStorage", () => {
+      const prefs: Partial<SettingsPreferences> = {
+        defaultNetwork: "mainnet",
+        defaultAsset: "usdc",
+      };
+
+      saveSettingsPreferences(prefs);
+
+      const stored = localStorage.getItem(STORAGE_KEY);
+      expect(stored).toBeDefined();
+
+      const parsed = JSON.parse(stored!);
+      expect(parsed.defaultNetwork).toBe("mainnet");
+      expect(parsed.defaultAsset).toBe("usdc");
+      expect(parsed.version).toBe(1);
+    });
+
+    it("should merge with existing preferences", () => {
+      // Save initial preferences
+      saveSettingsPreferences({
+        defaultNetwork: "mainnet",
+        defaultAsset: "usdc",
+        batchValidation: false,
+      });
+
+      // Update only one field
+      saveSettingsPreferences({ defaultAsset: "usdt" });
+
+      const stored = localStorage.getItem(STORAGE_KEY);
+      const parsed = JSON.parse(stored!);
+      expect(parsed.defaultNetwork).toBe("mainnet"); // Preserved
+      expect(parsed.defaultAsset).toBe("usdt"); // Updated
+      expect(parsed.batchValidation).toBe(false); // Preserved
+    });
+
+    it("should not throw on SSR (window undefined)", () => {
+      const originalWindow = global.window;
+      // @ts-expect-error - intentionally undefined for SSR test
+      delete global.window;
+
+      expect(() => {
+        saveSettingsPreferences({ defaultNetwork: "mainnet" });
+      }).not.toThrow();
+
+      global.window = originalWindow;
+    });
+
+    it("should handle localStorage errors gracefully", () => {
+      // Mock localStorage.setItem to throw an error
+      const originalSetItem = localStorage.setItem;
+      localStorage.setItem = () => {
+        throw new Error("Storage quota exceeded");
+      };
+
+      expect(() => {
+        saveSettingsPreferences({ defaultNetwork: "mainnet" });
+      }).not.toThrow();
+
+      localStorage.setItem = originalSetItem;
+    });
+  });
+
+  describe("save/load round-trip", () => {
+    it("should preserve all preference fields through save/load cycle", () => {
+      const originalPrefs: SettingsPreferences = {
+        version: 1,
+        defaultNetwork: "mainnet",
+        defaultAsset: "usdc",
+        batchValidation: false,
+        completionNotifications: false,
+      };
+
+      saveSettingsPreferences(originalPrefs);
+      const loadedPrefs = loadSettingsPreferences();
+
+      expect(loadedPrefs).toEqual(originalPrefs);
+    });
+
+    it("should handle partial updates through save/load cycle", () => {
+      // Save initial state
+      const initialPrefs: SettingsPreferences = {
+        version: 1,
+        defaultNetwork: "testnet",
+        defaultAsset: "xlm",
+        batchValidation: true,
+        completionNotifications: true,
+      };
+      saveSettingsPreferences(initialPrefs);
+
+      // Update partial fields
+      saveSettingsPreferences({
+        defaultNetwork: "mainnet",
+        completionNotifications: false,
+      });
+
+      // Load and verify
+      const loadedPrefs = loadSettingsPreferences();
+      expect(loadedPrefs.defaultNetwork).toBe("mainnet");
+      expect(loadedPrefs.defaultAsset).toBe("xlm"); // Preserved
+      expect(loadedPrefs.batchValidation).toBe(true); // Preserved
+      expect(loadedPrefs.completionNotifications).toBe(false); // Updated
+    });
+  });
+
+  describe("resetSettingsPreferences", () => {
+    it("should reset preferences to defaults", () => {
+      // Save custom preferences
+      saveSettingsPreferences({
+        defaultNetwork: "mainnet",
+        defaultAsset: "usdc",
+        batchValidation: false,
+        completionNotifications: false,
+      });
+
+      // Reset
+      resetSettingsPreferences();
+
+      // Load and verify defaults
+      const prefs = loadSettingsPreferences();
+      expect(prefs).toEqual({
+        version: 1,
+        defaultNetwork: "testnet",
+        defaultAsset: "xlm",
+        batchValidation: true,
+        completionNotifications: true,
+      });
+    });
+
+    it("should not throw on SSR (window undefined)", () => {
+      const originalWindow = global.window;
+      // @ts-expect-error - intentionally undefined for SSR test
+      delete global.window;
+
+      expect(() => {
+        resetSettingsPreferences();
+      }).not.toThrow();
+
+      global.window = originalWindow;
+    });
+  });
+});


### PR DESCRIPTION
…xt (#576)

- Create SettingsPreferences type and localStorage utility (lib/settings-prefs.ts)
- Add SSR guard for localStorage access to prevent hydration errors
- Implement schema migration with version field for future compatibility
- Add debounced save (500ms) to localStorage on preference changes
- Update settings page to load preferences on mount and save on change
- Apply persisted defaultNetwork preference in BatchFlowContext
- Add comprehensive unit tests for save/load round-trip
- Ensure theme integration with next-themes remains unaffected

Settings now persist across page reloads via localStorage, with safe fallbacks for corrupt data and SSR environments.

closes #576 