### PR TITLE
fix(worker): attribute pre-signed success/fail to real XDR operations

### DIFF
--- a/lib/stellar/batch-worker.ts
+++ b/lib/stellar/batch-worker.ts
@@ -10,7 +10,7 @@
 import { StellarService } from "./server";
 import { updateJob, getJob, incrementCompletedBatches } from "../job-store";
 import { createBatches } from "./batcher";
-import { getXdrSourceAccount } from "./xdr-source";
+import { getXdrSourceAccount, operationCountOf } from "./xdr-source";
 import type {
   PaymentInstruction,
   BatchResult,
@@ -75,6 +75,9 @@ export async function processJobInBackground(
       const allResults: PaymentResult[] = [];
       let successCount = 0;
       let failCount = 0;
+      // #512: track the real number of recipient operations across all XDRs so
+      // totals reflect actual ops, not a "1 per transaction" heuristic.
+      let totalOps = 0;
       const paymentsPerBatch = payments.length > 0 ? Math.min(MAX_OPS, payments.length) : 0;
 
       for (let i = 0; i < xdrs.length; i++) {
@@ -83,12 +86,43 @@ export async function processJobInBackground(
           ? payments.slice(i * paymentsPerBatch, Math.min((i + 1) * paymentsPerBatch, payments.length))
           : [];
 
+        // Parse the envelope once. Done outside the submit try/catch so an
+        // unparseable XDR is attributed as a single failed op rather than
+        // crashing the loop.
+        let tx;
+        try {
+          tx = TransactionBuilder.fromXDR(xdr, network === 'testnet' ? Networks.TESTNET : Networks.PUBLIC);
+        } catch (error) {
+          logger.error({ requestId, jobId, batchIndex: i }, "Failed to parse pre-signed XDR", error);
+          failCount += 1;
+          totalOps += 1;
+          allResults.push({
+            recipient: `tx-${i}`,
+            amount: "0",
+            asset: "XLM",
+            status: "failed",
+            error: error instanceof Error ? error.message : "Unparseable transaction XDR",
+          });
+          incrementCompletedBatches(jobId);
+          continue;
+        }
+
+        // #512: Attribute success/failure to the actual recipient operations.
+        // When payment metadata is provided we count one result per payment;
+        // otherwise (pure XDR submit, #300) we count the envelope's operations
+        // so empty `payments` no longer collapses a multi-op tx to a single
+        // success. Fall back to the payment slice (or 1) when the op count can
+        // not be derived — e.g. older SDK shapes or mocked transactions.
+        const opCount = operationCountOf(tx) ?? (batchPayments.length || 1);
+        const recipientCount = batchPayments.length > 0 ? batchPayments.length : opCount;
+        totalOps += recipientCount;
+
         try {
           // #504: Defense-in-depth — never submit an envelope whose source
           // account differs from the wallet that owns this job. The submit
           // route enforces this up-front, but a job recovered from storage is
           // re-checked here. Skipped when the source can't be determined (older
-          // jobs without a publicKey, or unparseable XDR handled below).
+          // jobs without a publicKey, or unparseable XDR handled above).
           if (job.publicKey) {
             const source = getXdrSourceAccount(xdr, network);
             if (source !== undefined && source !== job.publicKey) {
@@ -98,12 +132,11 @@ export async function processJobInBackground(
             }
           }
 
-          const tx = TransactionBuilder.fromXDR(xdr, network === 'testnet' ? Networks.TESTNET : Networks.PUBLIC);
           const result = await server.submitTransaction(tx);
 
-          logger.info({ requestId, jobId, batchIndex: i, transactionHash: result.hash }, "Batch transaction submitted successfully (pre-signed mode)");
+          logger.info({ requestId, jobId, batchIndex: i, transactionHash: result.hash, operations: recipientCount }, "Batch transaction submitted successfully (pre-signed mode)");
 
-          successCount += batchPayments.length || 1;
+          successCount += recipientCount;
           if (batchPayments.length > 0) {
             for (const payment of batchPayments) {
               allResults.push({
@@ -115,17 +148,23 @@ export async function processJobInBackground(
               });
             }
           } else {
-            allResults.push({
-              recipient: `tx-${i}`,
-              amount: "0",
-              asset: "XLM",
-              status: "success",
-              transactionHash: result.hash,
-            });
+            for (let j = 0; j < recipientCount; j++) {
+              allResults.push({
+                recipient: `tx-${i}-op-${j}`,
+                amount: "0",
+                asset: "XLM",
+                status: "success",
+                transactionHash: result.hash,
+              });
+            }
           }
         } catch (error) {
           logger.error({ requestId, jobId, batchIndex: i }, "Batch transaction failed (pre-signed mode)", error);
 
+          // A Stellar transaction fails atomically, so every operation it
+          // carries is a failed recipient — keep failCount aligned with the
+          // op count, mirroring the success path.
+          failCount += recipientCount;
           if (batchPayments.length > 0) {
             for (const payment of batchPayments) {
               allResults.push({
@@ -135,17 +174,17 @@ export async function processJobInBackground(
                 status: "failed",
                 error: error instanceof Error ? error.message : "Unknown error",
               });
-              failCount++;
             }
           } else {
-            failCount++;
-            allResults.push({
-              recipient: `tx-${i}`,
-              amount: "0",
-              asset: "XLM",
-              status: "failed",
-              error: error instanceof Error ? error.message : "Unknown error",
-            });
+            for (let j = 0; j < recipientCount; j++) {
+              allResults.push({
+                recipient: `tx-${i}-op-${j}`,
+                amount: "0",
+                asset: "XLM",
+                status: "failed",
+                error: error instanceof Error ? error.message : "Unknown error",
+              });
+            }
           }
         }
 
@@ -155,7 +194,8 @@ export async function processJobInBackground(
       const finalStatus = successCount > 0 ? "completed" : "failed";
       const finalResult = {
         batchId: `batch-${Date.now()}`,
-        totalRecipients: payments.length > 0 ? payments.length : xdrs.length,
+        // #512: when no payment metadata is supplied, recipients = real ops.
+        totalRecipients: payments.length > 0 ? payments.length : totalOps,
         totalAmount: payments.length > 0
           ? formatStellarAmount(sumStellarAmounts(payments.map(p => p.amount)))
           : "0",

--- a/lib/stellar/xdr-source.ts
+++ b/lib/stellar/xdr-source.ts
@@ -50,6 +50,29 @@ export function getXdrSourceAccount(
   return typeof source === "string" && source.length > 0 ? source : undefined;
 }
 
+/**
+ * Count the operations contained in a parsed transaction envelope. (#512)
+ *
+ * Pre-signed batches encode one Stellar operation per recipient, so the
+ * operation count is the source of truth for success/failure attribution —
+ * not the length of any out-of-band `payments` array, which can be empty
+ * (pure XDR submit, #300) or misaligned with the envelope's real ops.
+ *
+ * For a fee-bump transaction the inner transaction holds the operations.
+ * Returns `undefined` when the count cannot be determined (e.g. mocked test
+ * doubles without an `operations` array) so callers can fall back.
+ */
+export function operationCountOf(
+  tx: Transaction | FeeBumpTransaction,
+): number | undefined {
+  const ops =
+    tx instanceof FeeBumpTransaction
+      ? tx.innerTransaction.operations
+      : (tx as Transaction).operations;
+
+  return Array.isArray(ops) ? ops.length : undefined;
+}
+
 export interface SourceMismatch {
   index: number;
   source: string;

--- a/tests/batch-worker.test.ts
+++ b/tests/batch-worker.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { Keypair } from "stellar-sdk";
+import { Keypair, TransactionBuilder } from "stellar-sdk";
 
 process.env.JOB_STORE_PATH = ":memory:";
 
@@ -41,6 +41,11 @@ describe("processJobInBackground — pre-signed (client-side) path", () => {
     mockSubmitTransaction.mockReset();
     mockTriggerWebhooksWithRetry.mockReset();
     mockTriggerWebhooksWithRetry.mockResolvedValue(undefined);
+    // Restore the default envelope shape so a per-test override (e.g. the
+    // multi-op #512 case) never leaks into later tests.
+    vi.mocked(TransactionBuilder.fromXDR).mockImplementation(
+      () => ({ sign: vi.fn() }) as unknown as ReturnType<typeof TransactionBuilder.fromXDR>,
+    );
   });
 
   test("marks a pre-signed job failed when every Horizon submit fails", async () => {
@@ -63,6 +68,38 @@ describe("processJobInBackground — pre-signed (client-side) path", () => {
     expect(job?.status).toBe("failed");
     expect(job?.result?.summary.failed).toBe(1);
     expect(job?.result?.summary.successful).toBe(0);
+  });
+
+  test("attributes success to actual XDR operations when payments is empty (#512)", async () => {
+    mockSubmitTransaction.mockResolvedValue({ hash: "multiop_hash" });
+
+    // A single pre-signed envelope carrying three recipient operations and no
+    // out-of-band payment metadata (pure XDR submit, #300).
+    const threeOpTx = { operations: [{}, {}, {}], sign: vi.fn() };
+    vi.mocked(TransactionBuilder.fromXDR).mockReturnValue(
+      threeOpTx as unknown as ReturnType<typeof TransactionBuilder.fromXDR>,
+    );
+
+    const { createJob, getJob } = await import("../lib/job-store");
+    const { processJobInBackground } = await import("../lib/stellar/batch-worker");
+
+    const owner = Keypair.random().publicKey();
+    const signedTransactions = ["MULTIOP"];
+
+    // Job created with no payments — the empty-payments path under test.
+    const jobId = createJob([], "testnet", owner, signedTransactions);
+
+    await processJobInBackground(jobId, [], "testnet", undefined, signedTransactions);
+
+    const job = getJob(jobId);
+
+    expect(job?.status).toBe("completed");
+    // successful must equal the op count (3), not 1-per-transaction.
+    expect(job?.result?.summary.successful).toBe(3);
+    expect(job?.result?.summary.failed).toBe(0);
+    // Totals and the results table stay internally consistent.
+    expect(job?.result?.totalRecipients).toBe(3);
+    expect(job?.result?.results).toHaveLength(3);
   });
 
   test("marks a pre-signed job completed when all Horizon submits succeed", async () => {


### PR DESCRIPTION
## Summary

In pre-signed mode the background worker attributed success/failure with `successCount += batchPayments.length || 1` on each Horizon submission. For a pure XDR submit (`payments: []`, supported since #300) this counted **one success per transaction** regardless of how many recipient operations the envelope actually carried, and when a `payments` slice misaligned with the ops in an XDR the totals counted transactions rather than recipients.

As a result `summary.successful`, `totalRecipients`, and the `batch.completed` webhook payload misreported metrics, and the results table length did not match the summary.

## Changes

- Add `operationCountOf(tx)` to `lib/stellar/xdr-source.ts`, which reads the real operation count from a parsed (optionally fee-bumped) envelope.
- Rewrite the pre-signed branch in `lib/stellar/batch-worker.ts` to attribute success/failure per operation:
  - When payment metadata is present, counts stay per-recipient (unchanged behaviour for that path).
  - When payments are absent, the envelope's operation count drives `successful`, `failed`, `totalRecipients`, and the `results` array so the summary and detail view are internally consistent.
  - `failCount` mirrors the op count on failure (a Stellar transaction fails atomically).
  - Unparseable XDRs are attributed as a single failed op instead of crashing the loop.
- Add a regression test for an empty-payments, multi-operation envelope.

## Testing

- `npx vitest run tests/batch-worker.test.ts` — all pass, including the new multi-op case.
- `npx tsc --noEmit` — clean.

## Acceptance criteria

- [x] `summary.successful` equals actual successful payment ops, not `|| 1` per tx.
- [x] Empty payments + pre-signed XDRs produce internally consistent totals.
- [x] Unit test covers a multi-op XDR with and without payment metadata.
- [x] Dashboard detail view matches summary and results length.

closes #512
