### PR TITLE
fix(batch-build): resolve omitted rows by rowIndex, not indexOf

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -154,8 +154,13 @@ export async function POST(request: NextRequest) {
       network === "testnet" ? Networks.TESTNET : Networks.PUBLIC;
 
     const xdrs: string[] = [];
-    // #396: collect indices of rows skipped due to per-row validation failure
+    // #396: collect indices of rows skipped due to per-row validation failure.
+    // #510: indices are the original 0-based positions in the request `payments`
+    // array (mirrored from the parser's `rowIndex`), so duplicate rows resolve
+    // to distinct positions instead of collapsing onto the first match.
     const omittedRows: number[] = [];
+    // #510: map each omitted index to its validation reason for actionable 422s.
+    const omittedReasons: Record<number, string> = {};
 
     for (let i = 0; i < batches.length; i++) {
       const batch = batches[i];
@@ -180,12 +185,21 @@ export async function POST(request: NextRequest) {
         networkPassphrase,
       }).addMemo(memo);
 
-      for (const payment of batch.payments) {
+      for (let pIdx = 0; pIdx < batch.payments.length; pIdx++) {
+        const payment = batch.payments[pIdx];
         const pv = validatePaymentInstruction(payment);
         if (!pv.valid) {
-          // #396: track omitted row indices instead of silently skipping
-          const originalIndex = payments.indexOf(payment);
+          // #510: prefer the parser-assigned rowIndex so duplicate rows (same
+          // address/amount/asset) map to the row that actually failed. indexOf
+          // returns the first value-equal match, misreporting which CSV line was
+          // skipped. Fall back to indexOf only for legacy payloads built without
+          // a rowIndex.
+          const originalIndex =
+            typeof payment.rowIndex === "number"
+              ? payment.rowIndex
+              : payments.indexOf(payment);
           omittedRows.push(originalIndex);
+          omittedReasons[originalIndex] = pv.error ?? "Failed per-row validation";
           continue;
         }
 
@@ -218,7 +232,10 @@ export async function POST(request: NextRequest) {
         NextResponse.json(
           {
             error: "Some payment rows failed per-row validation and were omitted.",
+            // #510: 0-based original row indices; duplicates resolve distinctly.
             omittedRows,
+            // #510: per-index reason so callers can surface exactly what to fix.
+            omittedReasons,
           },
           { status: 422 },
         ),

--- a/tests/batch-build.test.ts
+++ b/tests/batch-build.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for POST /api/batch-build omitted-row reporting (#510).
+ *
+ * When a row fails per-row validation while XDRs are built, the route must
+ * report the *original* row index (the parser's `rowIndex`) so duplicate rows
+ * — same address/amount/asset — resolve to distinct positions instead of
+ * collapsing onto the first value-equal match via `Array.indexOf`.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Account, Keypair } from "stellar-sdk";
+import type { PaymentInstruction } from "@/lib/stellar/types";
+
+const { mockLoadAccount } = vi.hoisted(() => ({
+  mockLoadAccount: vi.fn(),
+}));
+
+// Keep the real stellar-sdk (TransactionBuilder, Memo, Asset, …) and only
+// stub the Horizon network call.
+vi.mock("stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("stellar-sdk")>();
+  class MockServer {
+    loadAccount = mockLoadAccount;
+  }
+  return {
+    ...actual,
+    Horizon: { ...actual.Horizon, Server: MockServer },
+  };
+});
+
+vi.mock("@/lib/stellar/fee-service", () => ({
+  getRecommendedFee: vi.fn().mockResolvedValue(100),
+}));
+
+vi.mock("@/lib/api-rate-limit", () => ({
+  applyRateLimit: vi.fn(() => ({ blocked: false, response: undefined })),
+  setRateLimitHeaders: vi.fn((response: Response) => response),
+}));
+
+// Let top-level validation pass so execution reaches the per-row build loop,
+// then fail exactly the row whose memo is the poison marker. This isolates the
+// omission branch, which the shared top-level guard would otherwise 400 first.
+vi.mock("@/lib/stellar/validator", () => ({
+  validatePaymentInstructions: vi.fn(() => ({
+    valid: true,
+    errors: new Map(),
+    duplicateIndices: new Set(),
+  })),
+  validatePaymentInstruction: vi.fn((p: PaymentInstruction) =>
+    p.memo === "__BAD__"
+      ? { valid: false, error: "Invalid memo" }
+      : { valid: true },
+  ),
+  buildBalancesMap: vi.fn(() => ({})),
+  validateBalances: vi.fn(() => ({ all_sufficient: true, checks: [] })),
+}));
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/batch-build", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/batch-build — omitted rows (#510)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadAccount.mockImplementation((publicKey: string) =>
+      Promise.resolve(new Account(publicKey, "0")),
+    );
+  });
+
+  test("reports the failing row's original rowIndex, not its array position", async () => {
+    const { POST } = await import("@/app/api/batch-build/route");
+
+    const owner = Keypair.random().publicKey();
+    const recipient = Keypair.random().publicKey();
+
+    // Two value-equal duplicate rows. The second is invalid. Their rowIndex
+    // values deliberately differ from their array positions so a positional /
+    // indexOf resolution would report the wrong row.
+    const payments: PaymentInstruction[] = [
+      { address: recipient, amount: "1", asset: "XLM", rowIndex: 5 },
+      { address: recipient, amount: "1", asset: "XLM", memo: "__BAD__", rowIndex: 2 },
+    ];
+
+    const response = await POST(
+      makeRequest({ payments, network: "testnet", publicKey: owner }) as never,
+    );
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+
+    // rowIndex (2), not the array position (1), is reported.
+    expect(json.omittedRows).toEqual([2]);
+    expect(json.omittedRows).not.toContain(1);
+    expect(json.omittedReasons["2"]).toBe("Invalid memo");
+  });
+
+  test("duplicate rows resolve to distinct indices", async () => {
+    const { POST } = await import("@/app/api/batch-build/route");
+
+    const owner = Keypair.random().publicKey();
+    const recipient = Keypair.random().publicKey();
+
+    // Three identical rows; the last two both fail validation but carry
+    // distinct rowIndex values — they must not collapse to one index.
+    const payments: PaymentInstruction[] = [
+      { address: recipient, amount: "10", asset: "XLM", rowIndex: 0 },
+      { address: recipient, amount: "10", asset: "XLM", memo: "__BAD__", rowIndex: 1 },
+      { address: recipient, amount: "10", asset: "XLM", memo: "__BAD__", rowIndex: 2 },
+    ];
+
+    const response = await POST(
+      makeRequest({ payments, network: "testnet", publicKey: owner }) as never,
+    );
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+
+    expect(new Set(json.omittedRows)).toEqual(new Set([1, 2]));
+    expect(json.omittedRows).toHaveLength(2);
+  });
+
+  test("falls back to positional index for legacy payloads without rowIndex", async () => {
+    const { POST } = await import("@/app/api/batch-build/route");
+
+    const owner = Keypair.random().publicKey();
+    const recipient = Keypair.random().publicKey();
+
+    const payments: PaymentInstruction[] = [
+      { address: recipient, amount: "1", asset: "XLM" },
+      { address: recipient, amount: "1", asset: "XLM", memo: "__BAD__" },
+    ];
+
+    const response = await POST(
+      makeRequest({ payments, network: "testnet", publicKey: owner }) as never,
+    );
+
+    expect(response.status).toBe(422);
+    const json = await response.json();
+
+    // No rowIndex → fall back to the array position (1) via indexOf.
+    expect(json.omittedRows).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary

When a row failed per-row validation during XDR building, `app/api/batch-build/route.ts` recorded the skipped position with `payments.indexOf(payment)` (#396). `Array.indexOf` resolves objects by reference and values by equality, so duplicate rows (same address, amount, and asset) collapsed onto the first match — the reported `omittedRows` pointed at the wrong CSV line and users edited a row that was never skipped.

## Changes

- Prefer the parser-assigned `rowIndex` (0-based original position) when recording an omitted row, falling back to `indexOf` only for legacy payloads built without one.
- Return an additional `omittedReasons` map (keyed by index) in the 422 response so callers can surface exactly what failed for each row.
- Document that `omittedRows` are 0-based original row indices.

The parser already sets `rowIndex` on every upload path (`parseJSON` / `parseCSV`, #397), and `createBatches` preserves payment references, so the index flows through unchanged.

## Testing

New `tests/batch-build.test.ts` covers:
- the failing row's `rowIndex` is reported rather than its array position,
- duplicate rows resolve to distinct indices,
- the legacy positional fallback when `rowIndex` is absent.

`npx vitest run tests/batch-build.test.ts` — all pass. `npx tsc --noEmit` — clean.

## Acceptance criteria

- [x] `omittedRows` lists exact 0-based indices matching the original rows (documented).
- [x] Duplicate payment rows resolve to distinct indices in 422 responses.
- [x] `batch-build` integration test covers duplicate-row omission.
- [x] Parser sets `rowIndex` for all upload paths (already in place via #397).

closes #510
