### PR TITLE
fix(dashboard): render live payment volume, gate mock behind previewMode

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { RecentBatchesTable } from "@/components/dashboard/RecentBatchesTable";
 import { OverviewMetrics } from "@/components/dashboard/overview-metrics";
-import { PaymentVolumeChart } from "@/components/dashboard/PaymentVolumeChart";
+import {
+  PaymentVolumeChart,
+  type PaymentVolumePoint,
+} from "@/components/dashboard/PaymentVolumeChart";
 import { QuickActions } from "@/components/dashboard/QuickActions";
 import { DeveloperResources } from "@/components/dashboard/developer-resources";
 import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-empty";
@@ -11,11 +15,31 @@ import { useDashboardMetrics } from "@/hooks/use-dashboard-metrics";
 import { Badge } from "@/components/ui/badge";
 import { t } from "@/lib/i18n";
 
+type Range = "7d" | "30d" | "90d";
+
 export default function DashboardPage() {
   const { publicKey, network, expectedNetwork } = useWallet();
   const dashboardNetwork = (network ?? expectedNetwork) === "mainnet" ? "mainnet" : "testnet";
-  const { metrics, loading, error } = useDashboardMetrics(publicKey, dashboardNetwork);
+  const [range, setRange] = useState<Range>("7d");
+  // #518: request the same range the chart shows so the main dashboard renders
+  // the wallet's real volume, sharing the analytics page's metrics source.
+  const { metrics, loading, error } = useDashboardMetrics(publicKey, dashboardNetwork, range);
   const hasNoData = Boolean(publicKey && !loading && !error && metrics && metrics.totalPayments === 0);
+
+  // #518: map the API time-series into the chart's per-range shape. Undefined
+  // when the API has no series yet, which lets the chart show its empty state
+  // instead of fictional sample volume.
+  const chartData = useMemo(() => {
+    if (!metrics?.timeSeries) return undefined;
+    const points: PaymentVolumePoint[] = metrics.timeSeries.map((p) => ({
+      date: new Date(p.date).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+      }),
+      amount: p.amount,
+    }));
+    return { [range]: points } as Partial<Record<Range, PaymentVolumePoint[]>>;
+  }, [metrics?.timeSeries, range]);
 
   return (
     <div className="space-y-8">
@@ -51,7 +75,13 @@ export default function DashboardPage() {
               <QuickActions />
             </div>
             <div className="lg:col-span-2">
-              <PaymentVolumeChart />
+              {/* #518: previewMode is intentionally omitted (defaults false) so
+                  a connected wallet never sees mock volume. */}
+              <PaymentVolumeChart
+                initialRange={range}
+                onRangeChange={setRange}
+                data={chartData}
+              />
             </div>
           </div>
 

--- a/components/dashboard/PaymentVolumeChart.tsx
+++ b/components/dashboard/PaymentVolumeChart.tsx
@@ -14,7 +14,9 @@ import {
   YAxis,
 } from "recharts";
 
-// Sample data for the last 7 days
+// Sample data — only rendered in `previewMode` (marketing / unconnected
+// screenshots). #518: never shown to a connected wallet, which must always see
+// API-driven volume or an honest empty state.
 const data7Days = [
   { date: "Jan 15", amount: 12500 },
   { date: "Jan 16", amount: 15800 },
@@ -73,30 +75,58 @@ export interface PaymentVolumeChartProps {
     "30d"?: PaymentVolumePoint[];
     "90d"?: PaymentVolumePoint[];
   };
+  /**
+   * #518: opt-in to the built-in sample arrays for marketing screenshots or
+   * the unconnected-wallet preview. Defaults to `false` so a connected
+   * wallet with no history sees an honest empty state instead of fictional
+   * volume that looks like real financial data.
+   */
+  previewMode?: boolean;
+}
+
+/**
+ * Choose the series the chart renders for a given range. (#518)
+ *
+ * Priority: live data for the range → sample arrays only when `previewMode`
+ * is set → otherwise an empty series so the chart shows an honest empty state
+ * rather than mock volume. Kept as a pure, exported function so the
+ * connected-wallet guarantee (mock never leaks) is unit-testable without a DOM.
+ */
+export function selectVolumeSeries(
+  timeRange: TimeRange,
+  data: PaymentVolumeChartProps["data"],
+  previewMode: boolean,
+): PaymentVolumePoint[] {
+  const live = data?.[timeRange];
+  if (live && live.length > 0) return live;
+
+  if (!previewMode) return [];
+
+  switch (timeRange) {
+    case "30d":
+      return data30Days;
+    case "90d":
+      return data90Days;
+    case "7d":
+    default:
+      return data7Days;
+  }
 }
 
 export function PaymentVolumeChart({
   onRangeChange,
   initialRange = "7d",
   data,
+  previewMode = false,
 }: PaymentVolumeChartProps = {}) {
   const [timeRange, setTimeRange] = useState<TimeRange>(initialRange);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  const getData = () => {
-    const live = data?.[timeRange];
-    if (live && live.length > 0) return live;
-    switch (timeRange) {
-      case "7d":
-        return data7Days;
-      case "30d":
-        return data30Days;
-      case "90d":
-        return data90Days;
-      default:
-        return data7Days;
-    }
-  };
+  const chartData = selectVolumeSeries(timeRange, data, previewMode);
+  const isEmpty = chartData.length === 0;
+  // The fallback sample arrays are showing — flag it so the data is never
+  // mistaken for real volume.
+  const showingSample = previewMode && !(data?.[timeRange]?.length);
 
   const getLabel = () => {
     switch (timeRange) {
@@ -115,7 +145,14 @@ export function PaymentVolumeChart({
     <Card className="h-full border-[#1F2937] bg-[#121827]">
       <CardContent className="p-4">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold text-white">Payment Volume</h2>
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-bold text-white">Payment Volume</h2>
+            {showingSample && (
+              <span className="rounded bg-[#1F2937] px-2 py-0.5 text-[10px] uppercase tracking-wide text-gray-400">
+                Sample data
+              </span>
+            )}
+          </div>
           <div className="relative">
             <Button
               variant="outline"
@@ -150,9 +187,17 @@ export function PaymentVolumeChart({
         </div>
 
         <div className="h-48">
+          {isEmpty ? (
+            <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+              <p className="text-sm font-medium text-gray-300">No payment volume yet</p>
+              <p className="text-xs text-gray-500">
+                Send a batch payment to start tracking your volume here.
+              </p>
+            </div>
+          ) : (
           <ResponsiveContainer width="100%" height="100%">
             <AreaChart
-              data={getData()}
+              data={chartData}
               margin={{ top: 5, right: 5, left: -20, bottom: 0 }}
             >
               <defs>
@@ -204,6 +249,7 @@ export function PaymentVolumeChart({
               />
             </AreaChart>
           </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/tests/payment-volume-chart.test.ts
+++ b/tests/payment-volume-chart.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression tests for the dashboard Payment Volume series selection (#518).
+ *
+ * The main dashboard must render the connected wallet's real volume — never
+ * the built-in marketing sample arrays — and fall back to an honest empty
+ * state when there is no history yet.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  selectVolumeSeries,
+  type PaymentVolumePoint,
+} from "@/components/dashboard/PaymentVolumeChart";
+
+const live: PaymentVolumePoint[] = [
+  { date: "Jun 1", amount: 100 },
+  { date: "Jun 2", amount: 250 },
+];
+
+describe("selectVolumeSeries (#518)", () => {
+  test("returns live data when provided for the range", () => {
+    const result = selectVolumeSeries("7d", { "7d": live }, false);
+    expect(result).toEqual(live);
+  });
+
+  test("returns an empty series (not sample data) when no live data and not previewing", () => {
+    expect(selectVolumeSeries("7d", undefined, false)).toEqual([]);
+    expect(selectVolumeSeries("30d", { "7d": live }, false)).toEqual([]);
+    expect(selectVolumeSeries("7d", { "7d": [] }, false)).toEqual([]);
+  });
+
+  test("never returns sample arrays once previewMode is off, even with empty live data", () => {
+    for (const range of ["7d", "30d", "90d"] as const) {
+      expect(selectVolumeSeries(range, { [range]: [] }, false)).toHaveLength(0);
+    }
+  });
+
+  test("falls back to sample arrays only in previewMode", () => {
+    const result = selectVolumeSeries("7d", undefined, true);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("live data wins over sample data even in previewMode", () => {
+    const result = selectVolumeSeries("7d", { "7d": live }, true);
+    expect(result).toEqual(live);
+  });
+});


### PR DESCRIPTION
## Summary

`PaymentVolumeChart` shipped hardcoded sample arrays, and the main dashboard (`app/dashboard/page.tsx`) rendered it with no props — so connected wallets saw fictional January demo volume that looked like real financial data. The analytics page (#359) already rendered the live `/api/dashboard-metrics` series; the primary dashboard did not.

## Changes

- `app/dashboard/page.tsx` now requests the metrics time-series for the selected range and feeds it to the chart, sharing the analytics page's data source. Range state drives both the query and the chart.
- `PaymentVolumeChart` gains a `previewMode` prop (default `false`). The built-in sample arrays are only used in preview mode (marketing / unconnected screenshots); otherwise the chart shows an honest empty state. Sample data is labelled when shown, so it can never be mistaken for real volume on a connected wallet.
- Series selection is extracted into the pure, exported `selectVolumeSeries` helper so the "mock never leaks" guarantee is unit-testable without a DOM.

## Testing

`tests/payment-volume-chart.test.ts` covers live data, empty fallback, the preview-only sample path, and live-wins-over-sample. `npx vitest run tests/payment-volume-chart.test.ts` — all pass. `npx tsc --noEmit` — clean.

## Acceptance criteria

- [x] Connected users see API-driven volume on the main dashboard chart.
- [x] Mock series are never shown when a `publicKey` is present (dashboard passes `previewMode` off).
- [x] Empty wallet/history shows an honest empty chart state.
- [x] Dashboard and analytics charts use the same metrics source for a given range.

closes #518
