### PR TITLE
ci(pipeline): add next build job to pull request CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,34 @@ jobs:
         run: bun run test
         env:
           CI: 'true'
+
+  build:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-
+
+      - name: Build Next.js application
+        run: bun run build
+        env:
+          CI: 'true'
+          NEXT_TELEMETRY_DISABLED: '1'
+          ALLOW_SERVER_SIGNING: 'false'
+          SECRET_BACKEND: env
+

--- a/CI_NEXT_BUILD_PIPELINE.md
+++ b/CI_NEXT_BUILD_PIPELINE.md
@@ -1,0 +1,59 @@
+# CI Next Build Pipeline
+
+This document covers the implementation of the Next.js `build` job added to the pull request CI pipeline in `.github/workflows/ci.yml`, resolving issue #578.
+
+## What Changed
+
+A new `build` job was added to `.github/workflows/ci.yml`. It runs in parallel with the existing `vitest` job on every pull request targeting `main` and on every push to `main`. The job executes `next build` — the definitive check that all App Router pages, server components, API routes, and TypeScript types compile into a shippable production bundle.
+
+Before this change, CI only ran the Vitest unit suite and a `tsc --noEmit` typecheck. Build-time errors such as incorrect dynamic imports, edge/Node.js runtime mismatches, and server components importing client-only modules could pass both checks and only surface as a failed deployment.
+
+## Acceptance Criteria
+
+### CI runs `next build` on pull requests targeting `main`
+
+The workflow triggers on `pull_request: branches: [main]`. The `build` job calls `bun run build`, which maps to `next build` in `package.json`. Any build error causes the job to exit non-zero, failing the check.
+
+### Build job uses frozen lockfile install consistent with the vitest job
+
+Both jobs install dependencies with `bun install --frozen-lockfile`. This guarantees the exact same resolved dependency tree in both jobs and prevents silent lockfile drift during CI.
+
+### Documented env stubs allow build without production secrets
+
+The following variables are stubbed under the `Build Next.js application` step so that `next build` can complete without real credentials:
+
+| Variable | Value | Why it is needed |
+|---|---|---|
+| `CI` | `true` | Tells Next.js to treat warnings as errors and suppress interactive prompts. |
+| `NEXT_TELEMETRY_DISABLED` | `1` | Stops anonymous telemetry from being sent to Vercel during the build. This is the documented official opt-out. |
+| `ALLOW_SERVER_SIGNING` | `false` | Disables the server-side Stellar signing path in `app/api/batch-submit/route.ts`. When set to anything other than `"true"`, the route returns early before it tries to read `STELLAR_SECRET_KEY`, so no real secret key is required. |
+| `SECRET_BACKEND` | `env` | Selects the `EnvSecretsProvider` fallback in `lib/secrets/index.ts`. This prevents the secrets factory from attempting an AWS Secrets Manager or GitHub API call during the build. |
+
+Network endpoint variables (`HORIZON_URL_TESTNET`, `SOROBAN_RPC_URL_TESTNET`, etc.) are intentionally not stubbed. `lib/stellar/network-config.ts` already falls back to hardcoded SDF public endpoints when these variables are absent, so no stub is required for a clean build.
+
+### Failed builds block merge via required GitHub check
+
+GitHub Actions does not enforce merge blocking automatically. To satisfy this criterion the repository owner must configure a required status check in branch protection:
+
+1. Go to **Repository Settings → Branches → Branch protection rules → Edit rule for `main`**.
+2. Enable **"Require status checks to pass before merging"**.
+3. In the search box, find and select the **`build`** check. This name matches the job key defined in `ci.yml`.
+4. Save the rule.
+
+After this is done, any PR whose `build` job fails will be blocked from merging until the build passes.
+
+## Cache Strategy
+
+The job caches `.next/cache` using `actions/cache@v4` with a key based on the hash of `bun.lock`:
+
+```
+key: ${{ runner.os }}-nextjs-${{ hashFiles('**/bun.lock') }}
+restore-keys: |
+  ${{ runner.os }}-nextjs-
+```
+
+This file is named `bun.lock` (not `bun.lockb`) because the project uses Bun 1.2+, which generates the text-based lockfile format by default. A cache hit restores intermediate SWC and TypeScript compilation artefacts so subsequent builds only recompile modules that changed, reducing build time from a full O(M) compilation to an incremental O(ΔM) pass over changed modules.
+
+## Files Changed
+
+- `.github/workflows/ci.yml` — added the `build` job


### PR DESCRIPTION
Closes #578

## PR Description

CI was only running the Vitest unit suite and a `tsc --noEmit` typecheck on every pull request. Neither of those is sufficient to guarantee a working production build. `next build` is the definitive check that all App Router pages, server components, API routes, and TypeScript types compose into a bundle that Next.js can actually compile and ship. Build-time failures such as a server component importing a client-only module, an edge/Node.js runtime mismatch, or an incorrect dynamic import could pass both Vitest and the typecheck and only surface when the deployment fails.

To fix this I added a `build` job to `.github/workflows/ci.yml`. The job runs in parallel with the existing `vitest` job so it does not extend the overall CI wall-clock time. On every pull request targeting `main`, and on every push to `main`, this job checks out the repository, installs dependencies with `bun install --frozen-lockfile`, restores the `.next/cache` directory from the GitHub Actions cache, and then runs `bun run build`.

The `--frozen-lockfile` flag is the same one already used by the `vitest` job, so both jobs resolve an identical dependency graph and there is no risk of one job silently installing a different version of a package than the other.

The cache is keyed on `hashFiles('**/bun.lock')`. The project uses Bun 1.2+, which generates `bun.lock` (the text-based format) rather than the legacy binary `bun.lockb`, so the glob targets the correct file. When a cache hit occurs, Next.js reuses the intermediate SWC and TypeScript compilation artefacts from the previous build and only recompiles modules that changed, which cuts build time significantly on branches where only a small number of files were modified.

Because `next build` calls into several application modules that read environment variables, I provided a minimal set of stubs in the step's `env` block so the build can succeed in CI without real credentials:

- `CI=true` tells Next.js to treat warnings as errors and suppress interactive output.
- `NEXT_TELEMETRY_DISABLED=1` stops anonymous telemetry from being sent to Vercel during the build. This is the documented official opt-out from the Next.js telemetry docs.
- `ALLOW_SERVER_SIGNING=false` disables the server-side Stellar signing path in `app/api/batch-submit/route.ts`. When this variable is anything other than `"true"`, the route returns a 403 before it tries to read `STELLAR_SECRET_KEY`, so no real secret key is needed at build time.
- `SECRET_BACKEND=env` selects the `EnvSecretsProvider` fallback in `lib/secrets/index.ts` and prevents the secrets factory from attempting an AWS Secrets Manager or GitHub API call during the build.

I intentionally did not stub `HORIZON_URL_TESTNET`, `SOROBAN_RPC_URL_TESTNET`, or any of the other network endpoint variables. The `lib/stellar/network-config.ts` module already falls back to hardcoded SDF public endpoints when those variables are absent, so no stub is required and adding one would be noise.

To fully satisfy the "failed builds block merge" acceptance criterion, the repository owner needs to add the `build` job as a required status check in the branch protection rule for `main`. The job name `build` is the identifier GitHub surfaces in the status checks list. The steps for doing this are documented in `CI_NEXT_BUILD_PIPELINE.md`.


## Changes Made

- `.github/workflows/ci.yml`: Added a new `build` job that runs `bun run build` on every pull request targeting `main` and every push to `main`.
- `.github/workflows/ci.yml`: The `build` job installs dependencies with `bun install --frozen-lockfile`, consistent with the existing `vitest` job.
- `.github/workflows/ci.yml`: Configured `actions/cache@v4` to cache `.next/cache` keyed on the hash of `bun.lock` for incremental build speed.
- `.github/workflows/ci.yml`: Added env stubs (`CI`, `NEXT_TELEMETRY_DISABLED`, `ALLOW_SERVER_SIGNING`, `SECRET_BACKEND`) so the build runs without production credentials.
- `.github/workflows/ci.yml`: Removed the hallucinated `STELLAR_NETWORK` env stub that was initially included but does not correspond to any variable read by the codebase.
- `CI_NEXT_BUILD_PIPELINE.md`: Created to document the full acceptance criteria for issue #578, including why each env stub is needed, what the cache key targets, and the manual step required to enforce merge blocking via GitHub branch protection.


## Testing

The build job configuration was verified by:

1. Reading every `process.env` access in `app/` and `lib/` to confirm which variables are read at build time and which have safe defaults.
2. Grepping the entire codebase for `STELLAR_NETWORK` to confirm it is not used anywhere, which led to removing it from the stub list.
3. Confirming the lockfile on disk is `bun.lock` (not `bun.lockb`) to ensure `hashFiles('**/bun.lock')` resolves correctly.
4. Cross-referencing the Next.js telemetry documentation and GitHub Actions caching documentation to confirm each configuration option is accurate.

The job itself will be fully exercised on the first CI run after this PR is merged or when a reviewer triggers it on the branch.