### PR TITLE
feat(demo): add route-scoped error boundary with session recovery

### DIFF
--- a/app/demo/error.tsx
+++ b/app/demo/error.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { Navbar } from "@/components/landing/navbar";
+import { Button } from "@/components/ui/button";
+
+interface DemoErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function DemoError({ error, reset }: DemoErrorProps) {
+  useEffect(() => {
+    // Log error digest in development only
+    if (process.env.NODE_ENV === "development") {
+      console.error("Demo error boundary caught error:", error);
+      if (error.digest) {
+        console.error("Error digest:", error.digest);
+      }
+    }
+  }, [error]);
+
+  const handleResetDemo = () => {
+    sessionStorage.removeItem("demo_batch_payments");
+    reset();
+  };
+
+  return (
+    <main id="main-content" className="min-h-screen bg-background text-foreground">
+      <Navbar />
+      <div className="max-w-2xl mx-auto px-4 py-16 flex flex-col items-center justify-center text-center">
+        <div
+          role="alert"
+          aria-live="assertive"
+          className="w-full bg-destructive/10 border border-destructive text-destructive rounded-lg p-6 mb-8 text-left"
+        >
+          <h2 className="text-xl font-bold mb-2">Demo Error</h2>
+          <p className="text-sm text-muted-foreground">
+            Something went wrong while running the demo. You can try again, reset the demo to start fresh, or return to the home page.
+          </p>
+          {process.env.NODE_ENV === "development" && (
+            <p className="text-xs font-mono bg-destructive/20 p-2 rounded mt-4 overflow-auto max-h-40">
+              {error.message || "An unexpected error occurred."}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-4 justify-center">
+          <Button
+            onClick={reset}
+            className="bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 text-white"
+          >
+            Try again
+          </Button>
+          <Button
+            onClick={handleResetDemo}
+            variant="outline"
+            className="border-destructive/50 text-destructive hover:bg-destructive/10"
+          >
+            Reset demo
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => {
+              window.location.href = "/";
+            }}
+          >
+            Return home
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/tests/demo-error.test.ts
+++ b/tests/demo-error.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const ERROR_BOUNDARY_FILE = path.join(process.cwd(), "app", "demo", "error.tsx");
+const SOURCE = readFileSync(ERROR_BOUNDARY_FILE, "utf8");
+
+describe("demo error boundary tests", () => {
+  test("declares use client at the very top", () => {
+    const trimmed = SOURCE.trim();
+    expect(trimmed.startsWith('"use client"') || trimmed.startsWith("'use client'")).toBe(true);
+  });
+
+  test("implements role alert for accessibility", () => {
+    expect(SOURCE).toMatch(/role="alert"/);
+  });
+
+  test("clears demo sessionStorage on reset action", () => {
+    expect(SOURCE).toMatch(/sessionStorage\.removeItem\("demo_batch_payments"\)/);
+  });
+
+  test("renders buttons for Try again, Reset demo, and Return home", () => {
+    expect(SOURCE).toMatch(/Try again/);
+    expect(SOURCE).toMatch(/Reset demo/);
+    expect(SOURCE).toMatch(/Return home/);
+  });
+
+  test("logs error to console in development only", () => {
+    expect(SOURCE).toMatch(/process\.env\.NODE_ENV === "development"/);
+    expect(SOURCE).toMatch(/console\.error\(/);
+  });
+});


### PR DESCRIPTION
Closes #565

## PR Description

The demo route at `app/demo/page.tsx` had no route-scoped error boundary. Any unhandled runtime error thrown by a client component, a hook, or a data parsing step would bubble all the way up to the root `app/error.tsx`. That root boundary knows nothing about the demo context, so it renders a generic fatal error screen that strips the marketing navbar, gives no session recovery option, and leaves the user with no way to clear the stale `demo_batch_payments` key from sessionStorage before trying again.

This matters because the demo flow is the primary onboarding path for new users evaluating wallet-signed batches. A user who hits an opaque crash screen during their first interaction is very likely to leave before ever connecting a wallet.

I fixed this by adding `app/demo/error.tsx` as a route-scoped client error boundary following the Next.js App Router error boundary conventions. The file exports a default component that receives the standard `error` and `reset` props. Because it lives at `app/demo/error.tsx`, Next.js automatically uses it as the error boundary for the entire `/demo` segment, so it intercepts all unhandled errors before they reach the root boundary.

The error UI keeps the marketing `<Navbar />` visible so the user never loses brand context. The message block carries `role="alert"` and `aria-live="assertive"` so screen readers announce the failure as soon as it appears, which matches the accessibility pattern already used by the inline error banner in `app/demo/page.tsx` and the field-level errors in the rest of the codebase.

There are three recovery buttons:

- **Try again** calls `reset()` directly. This triggers React to re-render the segment children without a full browser navigation, which is how Next.js error boundaries are meant to be used. If the underlying issue was transient (a failed fetch, a one-time parsing hiccup) the page recovers in place.

- **Reset demo** first calls `sessionStorage.removeItem("demo_batch_payments")` to clear the persisted payment state, then calls `reset()`. This is the important one for the failure mode described in the issue: when malformed session data causes a crash on mount, clicking "Try again" alone would just re-crash because the corrupt payload is still in storage. Clearing it first gives the user a genuinely clean slate.

- **Return home** sets `window.location.href = "/"` for users who just want out.

In development, the component logs the caught error and its digest to the console via `useEffect`. In production it logs nothing, which is consistent with how `app/error.tsx` and `app/dashboard/error.tsx` handle this.

The existing `BatchErrorBoundary` that wraps the payment flow inside `page.tsx` is unaffected. That boundary catches errors at the component level within the payment upload and preview sub-tree and handles inline restoration from sessionStorage. The new route-level boundary sits above it and only catches errors that escape `BatchErrorBoundary` or originate outside the payment sub-tree entirely. There is no double-wrapping conflict because they operate at different levels of the React tree.


## Changes Made

- Added `app/demo/error.tsx`: a new `"use client"` Next.js route-scoped error boundary for the `/demo` segment. It renders the marketing `<Navbar />`, an accessible `role="alert"` error block, and three recovery buttons: Try again (`reset()`), Reset demo (clears `demo_batch_payments` from sessionStorage then calls `reset()`), and Return home. Error details and digest are logged to the console in development only.

- Added `tests/demo-error.test.ts`: five static source-inspection tests that assert the boundary file has the `"use client"` directive at the top, carries `role="alert"` on the error block, calls `sessionStorage.removeItem("demo_batch_payments")` in the reset handler, renders all three recovery buttons, and gates console logging behind `process.env.NODE_ENV === "development"`. This follows the same static-assertion pattern used by `tests/demo-error-alert.test.ts` and `tests/demo-page-hooks.test.ts` in this codebase, which avoids needing jsdom or testing-library for client component tests.


## Testing

```bash
# Run only the new boundary tests
npx vitest run tests/demo-error.test.ts
```

Result:

```
✓ tests/demo-error.test.ts (5 tests) 13ms
  ✓ demo error boundary tests (5)
    ✓ declares use client at the very top
    ✓ implements role alert for accessibility
    ✓ clears demo sessionStorage on reset action
    ✓ renders buttons for Try again, Reset demo, and Return home
    ✓ logs error to console in development only

Test Files  1 passed (1)
     Tests  5 passed (5)
```

```bash
# TypeScript compiler check
npm run typecheck
```

Result: `app/demo/error.tsx` introduces zero new TypeScript errors. All pre-existing type errors in the codebase (`app/error.tsx` Sentry import, `scripts/keeper.ts` variable reference, route handler type mismatches) were present before this change and are out of scope.
