### PR TITLE
fix(batch-worker): prevent duplicate workers with atomic job claiming

### DIFF
--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -32,16 +32,12 @@ import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
 import { safeJsonResponse } from "@/lib/safe-json";
 import { createIdempotentJob, IdempotencyConflictError, getJob } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
-import { processJobInBackground } from "@/lib/stellar/batch-worker";
 import { findSourceMismatch } from "@/lib/stellar/xdr-source";
 import type {
   JobState,
   PaymentInstruction,
   BatchJobNetwork,
 } from "@/lib/stellar/types";
-import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
-import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
-import { logger } from "@/lib/logger";
 import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
 import { logger } from "@/lib/logger";

--- a/docs/atomic-job-claiming.md
+++ b/docs/atomic-job-claiming.md
@@ -1,0 +1,97 @@
+# Atomic Job Claiming: Preventing Duplicate Background Workers
+
+This document details the architecture, design decisions, and complexity analysis for resolving the concurrent background worker execution race condition in Stellar BatchPay.
+
+## Problem Description
+
+`processJobInBackground` previously guarded against duplicate execution with a non-atomic read-then-write sequence:
+
+1. Read `job.status` via `getJob(jobId)`.
+2. Return early if status was not `queued` or `processing`.
+3. Call `updateJob` to set status to `processing` and begin submitting transactions.
+
+The gap between step 1 and step 3 is the race window. Two concurrent invocations triggered by a double POST, an idempotency race, or a retry while the original worker is running can both read `queued` before either has written `processing` to the database. Both workers then proceed past the guard, claim `processing` independently, and submit overlapping sets of Horizon transactions.
+
+The consequence is duplicate or failed Stellar transactions (`TX_BAD_SEQ`), inflated `completedBatches` counters, and incorrect job summaries.
+
+---
+
+## Solution Architecture
+
+The fix introduces a single atomic SQL `UPDATE` at the database layer that combines the status check and the status transition in one operation.
+
+### 1. Atomic Claim Handler (`lib/job-store.ts`)
+
+A new exported function `claimJobForProcessing(jobId: string): boolean` runs this statement:
+
+```sql
+UPDATE jobs
+SET status = 'processing',
+    updatedAt = ?,
+    version = version + 1
+WHERE jobId = ? AND (
+  status = 'queued' OR
+  (status = 'processing' AND updatedAt < ?)
+)
+```
+
+The function returns `result.changes > 0`. Because SQLite serializes all write operations, only one caller can ever have `changes === 1` for a given `jobId` at the same time. Any concurrent caller will find the status already changed and receive `changes === 0`, which maps to a `false` return value.
+
+The `WHERE` clause handles two cases:
+
+- `status = 'queued'`: normal first-time claim.
+- `status = 'processing' AND updatedAt < ?`: stale lease reclaim. If a worker crashed mid-job and left the job stranded in `processing`, a later invocation can reclaim it once the lease window expires.
+
+The lease duration is read from `process.env.IDEMPOTENCY_REPLAY_STALE_MS` and defaults to 30 000 ms. This matches the stale threshold already used by the idempotency replay logic in the route handler.
+
+`getDb` is also exported so the stale-claim test can manipulate `updatedAt` directly on the in-memory SQLite instance without requiring a separate helper.
+
+### 2. Guard Integration (`lib/stellar/batch-worker.ts`)
+
+The old non-atomic guard:
+
+```ts
+if (job.status !== "queued" && job.status !== "processing") {
+  return;
+}
+```
+
+is replaced with:
+
+```ts
+const claimed = claimJobForProcessing(jobId);
+if (!claimed) {
+  logger.warn({ requestId, jobId, status: job.status },
+    "Background worker: Duplicate worker run detected. Job is already claimed, processing, or completed. Exiting early.");
+  return;
+}
+```
+
+If `claimJobForProcessing` returns `false`, the worker exits immediately before any Horizon transaction is attempted. The `logger.warn` call records the duplicate attempt with the `jobId` so it is visible in structured logs.
+
+The `updateJob` calls that follow the claim (setting `totalBatches` and resetting `completedBatches`) remain in place. The claim only transitions the status; the batch metadata is still written by the existing `updateJob` calls once the worker has computed it.
+
+---
+
+## Complexity Analysis
+
+### Time Complexity
+
+- `claimJobForProcessing(jobId)`: **O(1)**. The `WHERE jobId = ?` clause hits the primary key index directly. SQLite locates, locks, and updates the row in constant time regardless of total table size.
+- Timestamp comparison in the stale-lease branch: **O(1)**. ISO string lexicographic comparison against a precomputed cutoff timestamp.
+
+### Space Complexity
+
+- `claimJobForProcessing(jobId)`: **O(1)**. No additional in-memory structures. The function creates two string values (`nowIso`, `staleTimeIso`) and reads a single integer (`result.changes`).
+
+---
+
+## Testing Strategy
+
+Three new tests were added to `tests/batch-worker.test.ts` under the describe block `processJobInBackground — concurrent processing guards (#508)`:
+
+1. **Atomic claiming under concurrency**: Creates a job then fires three parallel calls to `claimJobForProcessing` via `Promise.all`. Asserts that exactly one call returns `true` and the other two return `false`.
+
+2. **Stale lease reclaim**: Claims a job, verifies an immediate second claim is rejected, manually sets `updatedAt` to 40 seconds in the past via a direct SQL statement on the test database, then verifies a third claim succeeds.
+
+3. **End-to-end single submission**: Creates a job and fires two parallel `processJobInBackground` calls. Asserts that `mockSubmitTransaction` is called exactly once, confirming only one worker reaches the Horizon submission path.

--- a/lib/job-store.ts
+++ b/lib/job-store.ts
@@ -73,7 +73,7 @@ const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
 let _db: Database.Database | null = null;
 
-function getDb(): Database.Database {
+export function getDb(): Database.Database {
   if (_db) return _db;
 
   // Ensure the data directory exists at runtime
@@ -335,6 +335,34 @@ export function incrementCompletedBatches(jobId: string): void {
       throw new Error(`incrementCompletedBatches: concurrent modification on job ${jobId}`);
     }
   }
+}
+
+const LEASE_MS = Number(process.env.IDEMPOTENCY_REPLAY_STALE_MS ?? 30000);
+
+/**
+ * Atomically claim a job for processing.
+ * Transitions a job from 'queued' to 'processing', or reclaims a stranded job
+ * whose status is 'processing' but updatedAt is older than the lease duration.
+ * Returns true if the claim was successful, false otherwise.
+ */
+export function claimJobForProcessing(jobId: string): boolean {
+  const db = getDb();
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const staleTimeIso = new Date(now.getTime() - LEASE_MS).toISOString();
+
+  const result = db.prepare(`
+    UPDATE jobs
+    SET status = 'processing',
+        updatedAt = ?,
+        version = version + 1
+    WHERE jobId = ? AND (
+      status = 'queued' OR
+      (status = 'processing' AND updatedAt < ?)
+    )
+  `).run(nowIso, jobId, staleTimeIso);
+
+  return result.changes > 0;
 }
 
 /**

--- a/lib/stellar/batch-worker.ts
+++ b/lib/stellar/batch-worker.ts
@@ -8,7 +8,7 @@
  */
 
 import { StellarService } from "./server";
-import { updateJob, getJob, incrementCompletedBatches } from "../job-store";
+import { updateJob, getJob, incrementCompletedBatches, claimJobForProcessing } from "../job-store";
 import { createBatches } from "./batcher";
 import { getXdrSourceAccount, operationCountOf } from "./xdr-source";
 import type {
@@ -45,9 +45,10 @@ export async function processJobInBackground(
       logger.warn({ requestId, jobId }, "Background worker: Job not found");
       return;
     }
-    // Reject second processJobInBackground if status is not queued or processing
-    if (job.status !== "queued" && job.status !== "processing") {
-      logger.warn({ requestId, jobId, status: job.status }, "Background worker: Job is already processed or completed. Exiting early.");
+    // Atomically claim the job. If claim fails, it means another worker is actively processing it or it is finished.
+    const claimed = claimJobForProcessing(jobId);
+    if (!claimed) {
+      logger.warn({ requestId, jobId, status: job.status }, "Background worker: Duplicate worker run detected. Job is already claimed, processing, or completed. Exiting early.");
       return;
     }
 

--- a/tests/batch-worker.test.ts
+++ b/tests/batch-worker.test.ts
@@ -224,3 +224,71 @@ describe("processJobInBackground — webhook delivery", () => {
     );
   });
 });
+
+describe("processJobInBackground — concurrent processing guards (#508)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockSubmitTransaction.mockReset();
+    mockTriggerWebhooksWithRetry.mockReset();
+    mockTriggerWebhooksWithRetry.mockResolvedValue(undefined);
+  });
+
+  test("only one worker can claim a queued job atomically", async () => {
+    const { createJob, claimJobForProcessing } = await import("../lib/job-store");
+    const owner = Keypair.random().publicKey();
+    const recipient = Keypair.random().publicKey();
+    const payments = [{ address: recipient, amount: "1", asset: "XLM" }];
+
+    const jobId = createJob(payments, "testnet", owner, ["AAAA"]);
+
+    const claims = await Promise.all([
+      claimJobForProcessing(jobId),
+      claimJobForProcessing(jobId),
+      claimJobForProcessing(jobId),
+    ]);
+
+    const successCount = claims.filter(Boolean).length;
+    expect(successCount).toBe(1);
+  });
+
+  test("reclaims a stale processing job after lease timeout", async () => {
+    const { createJob, claimJobForProcessing, getDb } = await import("../lib/job-store");
+    const owner = Keypair.random().publicKey();
+    const recipient = Keypair.random().publicKey();
+    const payments = [{ address: recipient, amount: "1", asset: "XLM" }];
+
+    const jobId = createJob(payments, "testnet", owner, ["AAAA"]);
+
+    const firstClaim = claimJobForProcessing(jobId);
+    expect(firstClaim).toBe(true);
+
+    const secondClaimImmediately = claimJobForProcessing(jobId);
+    expect(secondClaimImmediately).toBe(false);
+
+    const staleTime = new Date(Date.now() - 40000).toISOString();
+    getDb().prepare("UPDATE jobs SET updatedAt = ? WHERE jobId = ?").run(staleTime, jobId);
+
+    const thirdClaimStale = claimJobForProcessing(jobId);
+    expect(thirdClaimStale).toBe(true);
+  });
+
+  test("concurrent processJobInBackground calls produce a single Horizon submission set", async () => {
+    mockSubmitTransaction.mockResolvedValue({ hash: "abc123" });
+
+    const { createJob } = await import("../lib/job-store");
+    const { processJobInBackground } = await import("../lib/stellar/batch-worker");
+
+    const owner = Keypair.random().publicKey();
+    const recipient = Keypair.random().publicKey();
+    const payments = [{ address: recipient, amount: "1", asset: "XLM" }];
+
+    const jobId = createJob(payments, "testnet", owner, ["AAAA"]);
+
+    await Promise.all([
+      processJobInBackground(jobId, payments, "testnet"),
+      processJobInBackground(jobId, payments, "testnet"),
+    ]);
+
+    expect(mockSubmitTransaction).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #508

## PR Description

### What was broken

`processJobInBackground` was using a non-atomic read-then-write pattern to decide whether to run. It called `getJob(jobId)` to read the current status, checked whether the status was `queued` or `processing`, and only after that would call `updateJob` to transition the status to `processing`. The problem is that there is a real window of time between that read and that write. If two invocations arrive concurrently, which happens on a double POST, an idempotency race, or a retry while the original worker is still in-flight, both calls can read `queued` before either has written `processing` to the database. Both then pass the guard and proceed to submit Horizon transactions.

The result is that the same jobId ends up with two workers submitting overlapping transaction sets to Stellar. This triggers `TX_BAD_SEQ` errors on Horizon because both workers hold the same sequence number from the same source account, inflates `completedBatches` beyond `totalBatches`, and produces an incorrect job summary where successful and failed counts do not add up to the actual number of payments.

The existing `updateJob` optimistic lock (`WHERE version = ?`) was not solving this because it only serialized field-level writes after the initial status transition, not the initial claim itself.

### How it is fixed

I added a new function `claimJobForProcessing(jobId: string): boolean` in `lib/job-store.ts`. It runs a single SQL `UPDATE` statement:

```sql
UPDATE jobs
SET status = 'processing',
    updatedAt = ?,
    version = version + 1
WHERE jobId = ? AND (
  status = 'queued' OR
  (status = 'processing' AND updatedAt < ?)
)
```

Because SQLite serializes all write operations and `better-sqlite3` is synchronous, only one caller can ever have `result.changes === 1` for a given `jobId`. Any concurrent caller that arrives even a microsecond later will find the status already transitioned and get `result.changes === 0`, which maps to a `false` return. There is no gap between the check and the write because both happen inside a single statement.

In `processJobInBackground`, the old manual status check is replaced with this call. If the claim returns `false`, the worker logs a `warn`-level message with the `jobId` and returns immediately, before any Horizon submission is attempted. This satisfies the requirement that duplicate-worker attempts are logged at `warn` with `jobId`.

The `WHERE` clause also handles stranded jobs: if a worker crashed and left the status stuck at `processing` with a stale `updatedAt`, a new invocation can reclaim the job after the lease window passes. The lease duration is read from `process.env.IDEMPOTENCY_REPLAY_STALE_MS` and defaults to 30 000 ms, matching the stale threshold already used in the route handler for idempotency replay.

I also exported `getDb` from `lib/job-store.ts` so the stale-claim test can manipulate `updatedAt` directly on the in-memory SQLite instance without needing a separate test helper function.

I fixed a pre-existing duplicate import error in `app/api/batch-submit/route.ts` where `processJobInBackground`, `applyRateLimit`, `setRateLimitHeaders`, `canonicalizeIdempotencyPayload`, and `logger` were all imported twice. This was causing a parse error that blocked `tests/batch-submit.test.ts` from running entirely.

The documentation for this fix is written to `docs/atomic-job-claiming.md`, covering the problem statement, the SQL strategy, time and space complexity, and the testing approach.

### Why this approach

A single `UPDATE ... WHERE status = 'queued' OR (status = 'processing' AND updatedAt < ?)` is the correct atomic primitive for this problem. It does not require an external lock, a Redis instance, or an in-memory mutex. The existing SQLite setup already has WAL mode and a 5 000 ms `busy_timeout` configured, which is enough to handle contention between server processes as well. The `version` field is incremented by the claim so the existing `updateJob` optimistic locking path continues to work correctly after the claim without any additional changes.


## Changes Made

- `lib/job-store.ts`: Added `claimJobForProcessing(jobId)` that atomically transitions a job from `queued` to `processing` using a single SQL `UPDATE`. Added `LEASE_MS` constant for the stale-lease window. Exported `getDb` to support the test setup.
- `lib/stellar/batch-worker.ts`: Replaced the non-atomic `job.status` check with a call to `claimJobForProcessing`. Added a `logger.warn` log with `jobId` when a duplicate worker is detected and rejected. Updated import to include `claimJobForProcessing`.
- `app/api/batch-submit/route.ts`: Removed duplicate import statements for `processJobInBackground`, `applyRateLimit`, `setRateLimitHeaders`, `canonicalizeIdempotencyPayload`, and `logger` that were causing a parse error and blocking the test suite.
- `tests/batch-worker.test.ts`: Added a new `describe` block `processJobInBackground — concurrent processing guards (#508)` with three tests: atomic claiming where only one of three parallel claims succeeds, stale lease reclaim after manually aging `updatedAt`, and end-to-end verification that concurrent `processJobInBackground` calls produce exactly one Horizon submission.
- `docs/atomic-job-claiming.md`: New documentation file covering the problem, the SQL solution, complexity analysis (O(1) time and space), and the testing strategy.


## Testing

Run the directly affected test files:

```bash
npx vitest run tests/batch-worker.test.ts tests/batch-submit.test.ts
```

Result: 22 tests passed, 0 failed.

Breakdown:
- `tests/batch-worker.test.ts` — 11 tests passed (8 pre-existing + 3 new for #508)
- `tests/batch-submit.test.ts` — 11 tests passed (previously blocked by duplicate import parse error, now all passing)