### PR TITLE
fix: keep dashboard metrics null on error to avoid masking with zeros

### DIFF
--- a/hooks/use-dashboard-metrics.ts
+++ b/hooks/use-dashboard-metrics.ts
@@ -52,13 +52,17 @@ export function useDashboardMetrics(
     staleTime: 30 * 1000,
   });
 
+  const showZeroDefaults = !publicKey;
+
   return {
-    metrics: metrics ?? {
-      totalPayments: 0,
-      totalAmountSent: "0 XLM",
-      successRate: "0.0%",
-      activeBatches: 0,
-    },
+    metrics: showZeroDefaults
+      ? {
+          totalPayments: 0,
+          totalAmountSent: "0 XLM",
+          successRate: "0.0%",
+          activeBatches: 0,
+        }
+      : (metrics ?? null),
     loading: isLoading,
     error: error ? (error instanceof Error ? error.message : "Unknown error") : null,
     refetch,

--- a/tests/dashboard-metrics.test.ts
+++ b/tests/dashboard-metrics.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { useDashboardMetrics } from "../hooks/use-dashboard-metrics";
+import { useQuery } from "@tanstack/react-query";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+describe("Issue #461: useDashboardMetrics behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns zero defaults when wallet is disconnected (publicKey is null)", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    const result = useDashboardMetrics(null, "testnet");
+
+    expect(result.metrics).toEqual({
+      totalPayments: 0,
+      totalAmountSent: "0 XLM",
+      successRate: "0.0%",
+      activeBatches: 0,
+    });
+    expect(result.loading).toBe(false);
+    expect(result.error).toBeNull();
+  });
+
+  test("keeps metrics null on error when wallet is connected", () => {
+    const mockError = new Error("Horizon server error");
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+      refetch: vi.fn(),
+    } as any);
+
+    const result = useDashboardMetrics("GDQERHRWJY...", "testnet");
+
+    expect(result.metrics).toBeNull();
+    expect(result.loading).toBe(false);
+    expect(result.error).toBe("Horizon server error");
+  });
+
+  test("keeps metrics null when loading and no cached data", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    const result = useDashboardMetrics("GDQERHRWJY...", "testnet");
+
+    expect(result.metrics).toBeNull();
+    expect(result.loading).toBe(true);
+    expect(result.error).toBeNull();
+  });
+
+  test("returns fetched data when successful", () => {
+    const mockData = {
+      totalPayments: 42,
+      totalAmountSent: "1500 XLM",
+      successRate: "98.5%",
+      activeBatches: 2,
+    };
+
+    vi.mocked(useQuery).mockReturnValue({
+      data: mockData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    const result = useDashboardMetrics("GDQERHRWJY...", "testnet");
+
+    expect(result.metrics).toEqual(mockData);
+    expect(result.loading).toBe(false);
+    expect(result.error).toBeNull();
+  });
+});


### PR DESCRIPTION
### Problem
The `useDashboardMetrics` hook catch block fell back to hardcoded zero metrics (`totalPayments: 0`, `successRate: "0.0%"`, etc.) when an error occurred or during loading. This masked Horizon outages, invalid keys, and 500 responses as "no activity" (i.e., "you have no payments yet") instead of indicating that metrics are currently unavailable.

### Solution
- Modified `useDashboardMetrics` to only return zero-default metrics when the wallet is disconnected (`!publicKey`).
- If the wallet is connected and an error occurs, or if the hook is loading, the `metrics` object is kept as `null`.
- The `OverviewMetrics` component already correctly handles `error` and `loading` states. Specifically, on error, it renders a destructive `Alert` box with a retry button rather than rendering the metric cards with misleading zeros.

### Changes
1. **`hooks/use-dashboard-metrics.ts`**: Updated the return value of the hook to differentiate between a disconnected wallet and an error/loading state.
2. **`tests/dashboard-metrics.test.ts`**: Added a comprehensive suite of unit tests verifying the hook's behavior under all four scenarios (wallet disconnected, loading, error, and success).

Closes #461 