### PR TITLE
Fix/presigned batch persist payments

### DIFF
--- a/app/api/batch-retry/route.ts
+++ b/app/api/batch-retry/route.ts
@@ -36,7 +36,6 @@ export async function POST(request: NextRequest) {
         // Extract or derive idempotency key for duplicate retry protection (#550)
         const idempotencyKey = request.headers.get("Idempotency-Key") 
             ?? createHash("sha256").update(`${jobId}-${publicKey}`).digest("hex");
-        console.log("[RETRY] jobId:", jobId, "| publicKey:", publicKey, "| header:", request.headers.get("Idempotency-Key"), "| idempotencyKey:", idempotencyKey, "| ALL_HEADERS:", JSON.stringify([...request.headers.entries()]));
 
         if (!jobId || typeof jobId !== "string") {
             logger.warn({ requestId }, "Missing jobId in retry request");

--- a/app/api/batch-retry/route.ts
+++ b/app/api/batch-retry/route.ts
@@ -25,14 +25,18 @@ function hashRequestBody(body: { jobId: string; publicKey: string }): string {
 
 export async function POST(request: NextRequest) {
     const requestId = request.headers.get("x-request-id");
+    // jobId must be declared in the outer scope so the catch block
+    // can reference it for logging (#515 scoping fix).
+    let jobId: string | undefined;
     try {
         const body = (await request.json()) as { jobId?: string; publicKey?: string };
-        const jobId = body.jobId;
+        jobId = body.jobId;
         const publicKey = body.publicKey;
 
         // Extract or derive idempotency key for duplicate retry protection (#550)
         const idempotencyKey = request.headers.get("Idempotency-Key") 
             ?? createHash("sha256").update(`${jobId}-${publicKey}`).digest("hex");
+        console.log("[RETRY] jobId:", jobId, "| publicKey:", publicKey, "| header:", request.headers.get("Idempotency-Key"), "| idempotencyKey:", idempotencyKey, "| ALL_HEADERS:", JSON.stringify([...request.headers.entries()]));
 
         if (!jobId || typeof jobId !== "string") {
             logger.warn({ requestId }, "Missing jobId in retry request");

--- a/app/api/batch-retry/route.ts
+++ b/app/api/batch-retry/route.ts
@@ -109,12 +109,16 @@ export async function POST(request: NextRequest) {
             );
         }
 
+        // #515: Pre-signed batches with preserved payment metadata can be
+        // retried just like server-signed batches. Only block retry when
+        // there are genuinely no stored payments.
         if (!job.payments || job.payments.length === 0) {
-            logger.warn({ requestId, jobId }, "Retry not available for pre-signed batches");
+            logger.warn({ requestId, jobId }, "Retry not available — no payment metadata preserved");
             return NextResponse.json(
                 {
                     error:
-                        "Retry is not available for pre-signed batches without preserved payment metadata.",
+                        "Retry is not available for this batch because no payment metadata was preserved. " +
+                        "Re-submit the original payments with signedTransactions to enable retry support.",
                 },
                 { status: 400 },
             );

--- a/app/api/batch-submit/route.ts
+++ b/app/api/batch-submit/route.ts
@@ -32,16 +32,13 @@ import { MAX_UPLOAD_ROWS } from "@/lib/stellar/parser";
 import { safeJsonResponse } from "@/lib/safe-json";
 import { createIdempotentJob, IdempotencyConflictError, getJob } from "@/lib/job-store";
 import { processJobInBackground } from "@/lib/stellar/batch-worker";
-import { processJobInBackground } from "@/lib/stellar/batch-worker";
-import { findSourceMismatch } from "@/lib/stellar/xdr-source";
+import { findSourceMismatch, operationCountOf, networkPassphraseFor } from "@/lib/stellar/xdr-source";
+import { TransactionBuilder } from "stellar-sdk";
 import type {
   JobState,
   PaymentInstruction,
   BatchJobNetwork,
 } from "@/lib/stellar/types";
-import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
-import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
-import { logger } from "@/lib/logger";
 import { applyRateLimit, setRateLimitHeaders } from "@/lib/api-rate-limit";
 import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
 import { logger } from "@/lib/logger";
@@ -182,6 +179,41 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      // #515: When payments are provided alongside signed XDRs, validate that
+      // the payment count aligns with the total operations across all XDRs.
+      // This ensures recipient-level metadata stays consistent with what the
+      // network will execute.
+      if (payments && payments.length > 0) {
+        let totalOps = 0;
+        for (const xdr of signedTransactions) {
+          let tx;
+          try {
+            tx = TransactionBuilder.fromXDR(xdr, networkPassphraseFor(network));
+          } catch {
+            // If an XDR can't be parsed, skip op counting — the worker will
+            // handle it. Don't fail the whole batch for one unparseable XDR.
+            continue;
+          }
+          const count = operationCountOf(tx);
+          totalOps += count ?? 1;
+        }
+
+        if (payments.length !== totalOps) {
+          logger.warn(
+            { requestId, paymentCount: payments.length, totalOps },
+            "Payment count does not match total operations across signed XDRs",
+          );
+          return NextResponse.json(
+            {
+              error:
+                `Payment count (${payments.length}) does not match total operations across signed XDRs (${totalOps}). ` +
+                "When providing both payments and signedTransactions, the payment array must have one entry per operation.",
+            },
+            { status: 400 },
+          );
+        }
+      }
+
       // #504: A pre-signed envelope must be signed by the wallet the job is
       // attributed to. Reject any XDR whose source account (or fee-bump inner
       // source) differs from publicKey before creating the job, so a client
@@ -201,16 +233,21 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      // #515: Persist payments alongside signedTransactions so job history
+      // shows real recipient addresses and retry/export flows have metadata.
+      const storedPayments = payments ?? [];
+
       const outcome = createIdempotentJob<BatchSubmitAcceptedResponse>({
         idempotencyKey,
         requestHash,
-        payments: [],
+        payments: storedPayments,
         network,
         publicKey,
         signedTransactions,
         buildResponseBody: (jobId) => ({
           jobId,
           status: "queued",
+          totalPayments: storedPayments.length > 0 ? storedPayments.length : undefined,
           totalTransactions: signedTransactions.length,
           message:
             "Pre-signed batch queued for processing. Poll /api/batch-status/" +
@@ -221,7 +258,7 @@ export async function POST(request: NextRequest) {
 
       if (outcome.replayed) {
         const workerRestarted = resumeStrandedReplay(outcome.jobId, () => {
-          void processJobInBackground(outcome.jobId, [], network, undefined, signedTransactions, requestId || undefined);
+          void processJobInBackground(outcome.jobId, storedPayments, network, undefined, signedTransactions, requestId || undefined);
         });
         logger.info({ requestId, jobId: outcome.jobId, publicKey, network, replayed: true, workerRestarted }, "Batch submit job replayed (pre-signed mode)");
         return setRateLimitHeaders(safeJsonResponse(
@@ -230,7 +267,7 @@ export async function POST(request: NextRequest) {
         ), rate);
       }
 
-      void processJobInBackground(outcome.jobId, [], network, undefined, signedTransactions, requestId || undefined);
+      void processJobInBackground(outcome.jobId, storedPayments, network, undefined, signedTransactions, requestId || undefined);
 
       logger.info({ requestId, jobId: outcome.jobId, publicKey, network, replayed: false }, "Batch submit job queued and background worker triggered (pre-signed mode)");
       return setRateLimitHeaders(safeJsonResponse(

--- a/lib/stellar/batch-worker.ts
+++ b/lib/stellar/batch-worker.ts
@@ -61,6 +61,13 @@ export async function processJobInBackground(
       }
     }
 
+    // #515: If payments not provided or empty, try to recover from job state.
+    // This ensures that restart-recovered pre-signed jobs still have recipient
+    // metadata for history, retry, and export flows.
+    if ((!payments || payments.length === 0) && job.payments && job.payments.length > 0) {
+      payments = job.payments;
+    }
+
     // Create server instance for fee fetching
     const server = new Horizon.Server(horizonUrl(network));
 

--- a/tests/batch-retry.test.ts
+++ b/tests/batch-retry.test.ts
@@ -159,4 +159,37 @@ describe("POST /api/batch-retry (#388)", () => {
         const body2 = await res2.json();
         expect(body2.jobId).toBe(firstJobId);
     });
+
+    test("retries a pre-signed batch with stored payment metadata (#515)", async () => {
+        // Create a pre-signed job that also has payment metadata
+        const preSignedPayments: PaymentInstruction[] = [
+            { address: RECIPIENT_OK, amount: "10.0000000", asset: "XLM", rowIndex: 0 },
+            { address: RECIPIENT_BAD, amount: "5.0000000", asset: "XLM", rowIndex: 1 },
+        ];
+        const preSignedJobId = createJob(preSignedPayments, "testnet", OWNER, ["AAAA", "BBBB"]);
+        updateJob(preSignedJobId, { status: "completed", result: completedResult });
+
+        const res = await POST(makeRequest({ jobId: preSignedJobId, publicKey: OWNER }) as never);
+        expect(res.status).toBe(202);
+
+        const body = await res.json();
+        expect(body.jobId).toBeDefined();
+        expect(body.failedPayments).toBe(1);
+
+        const retryJob = getJob(body.jobId, OWNER);
+        expect(retryJob).toBeDefined();
+        expect(retryJob?.payments).toHaveLength(1);
+        expect(retryJob?.payments[0].address).toBe(RECIPIENT_BAD);
+    });
+
+    test("still blocks retry for pre-signed batches without payment metadata (#515)", async () => {
+        // Create a pre-signed job with empty payments (no metadata preserved)
+        const emptyPaymentsJobId = createJob([], "testnet", OWNER, ["AAAA"]);
+        updateJob(emptyPaymentsJobId, { status: "completed", result: completedResult });
+
+        const res = await POST(makeRequest({ jobId: emptyPaymentsJobId, publicKey: OWNER }) as never);
+        expect(res.status).toBe(400);
+        const body = await res.json();
+        expect(body.error).toMatch(/no payment metadata preserved/i);
+    });
 });

--- a/tests/batch-submit.test.ts
+++ b/tests/batch-submit.test.ts
@@ -21,9 +21,10 @@ const { mockCreateIdempotentJob } = vi.hoisted(() => ({
   mockCreateIdempotentJob: vi.fn(),
 }));
 
-const { mockGetJob, jobStates } = vi.hoisted(() => ({
+const { mockGetJob, jobStates, jobPayments } = vi.hoisted(() => ({
   mockGetJob: vi.fn(),
   jobStates: new Map<string, { status: string; updatedAt: string }>(),
+  jobPayments: new Map<string, unknown[]>(),
 }));
 
 vi.mock("@/lib/stellar/batch-worker", () => ({
@@ -65,6 +66,9 @@ vi.mock("@/lib/job-store", async () => {
       jobId,
       responseBody,
     });
+        // #515: Store payments alongside the job so tests can verify persistence
+    const storedPayments = (args as any).payments ?? [];
+    jobPayments.set(jobId, storedPayments);
     // Mirror the durable store: a fresh job starts "queued" with a current timestamp.
     jobStates.set(jobId, { status: "queued", updatedAt: new Date().toISOString() });
 
@@ -324,6 +328,54 @@ describe("POST /api/batch-submit pre-signed source verification (#504)", () => {
     expect(json.error).toMatch(/source account does not match/i);
     // Rejected before the job is ever created or a worker started.
     expect(mockCreateIdempotentJob).not.toHaveBeenCalled();
+    expect(mockProcessJobInBackground).not.toHaveBeenCalled();
+  });
+
+  test("accepts payments alongside signedTransactions and passes them to createIdempotentJob (#515)", async () => {
+    const payments = [
+      { address: OWNER_PUBLIC_KEY, amount: "10", asset: "XLM" },
+      { address: OTHER_PUBLIC_KEY, amount: "5", asset: "XLM" },
+    ];
+    // Use a real signed XDR so the op-count validation passes (1 op per XDR,
+    // but we have 2 payments... so we use 2 single-op XDRs to match).
+    const body = {
+      network: "testnet" as const,
+      publicKey: OWNER_PUBLIC_KEY,
+      signedTransactions: [buildSignedXdr(OWNER_KEYPAIR), buildSignedXdr(OWNER_KEYPAIR)],
+      payments,
+    };
+
+    const response = await POST(makeRequest(body, "payments-with-xdrs-key") as never);
+    expect(response.status).toBe(202);
+
+    // Verify payments were passed to createIdempotentJob
+    const lastCall = mockCreateIdempotentJob.mock.calls.at(-1)!;
+    const args = lastCall[0];
+    expect(args.payments).toEqual(payments);
+    expect(args.payments).not.toEqual([]);
+  });
+
+  test("rejects payments count mismatch with XDR operations (#515)", async () => {
+    const payments = [{ address: OWNER_PUBLIC_KEY, amount: "10", asset: "XLM" }];
+    // One signed XDR but only one payment — a single-op XDR should match one payment.
+    // Use a real signed XDR so operationCountOf returns a count.
+    const signedXdr = buildSignedXdr(OWNER_KEYPAIR);
+
+    // Pass 2 payments vs 1 operation in the XDR
+    const body = {
+      network: "testnet" as const,
+      publicKey: OWNER_PUBLIC_KEY,
+      signedTransactions: [signedXdr],
+      payments: [
+        { address: OWNER_PUBLIC_KEY, amount: "10", asset: "XLM" },
+        { address: OTHER_PUBLIC_KEY, amount: "5", asset: "XLM" },
+      ],
+    };
+
+    const response = await POST(makeRequest(body, "mismatch-ops-key") as never);
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toMatch(/Payment count/i);
     expect(mockProcessJobInBackground).not.toHaveBeenCalled();
   });
 

--- a/tests/batch-worker.test.ts
+++ b/tests/batch-worker.test.ts
@@ -165,6 +165,34 @@ describe("processJobInBackground — pre-signed (client-side) path", () => {
     expect(mockSubmitTransaction).toHaveBeenCalledOnce();
   });
 
+  test("recovers payments from job state when not passed as argument (#515)", async () => {
+    mockSubmitTransaction.mockResolvedValue({ hash: "recovered_payments_hash" });
+
+    const { createJob, getJob } = await import("../lib/job-store");
+    const { processJobInBackground } = await import("../lib/stellar/batch-worker");
+
+    const owner = Keypair.random().publicKey();
+    const recipient1 = Keypair.random().publicKey();
+    const recipient2 = Keypair.random().publicKey();
+    const payments = [
+      { address: recipient1, amount: "1", asset: "XLM" },
+      { address: recipient2, amount: "2", asset: "XLM" },
+    ];
+    const signedTransactions = ["RECOVER"];
+
+    const jobId = createJob(payments, "testnet", owner, signedTransactions);
+
+    // Do NOT pass payments — worker must recover them from job state (#515)
+    await processJobInBackground(jobId, [], "testnet", undefined, signedTransactions);
+
+    const job = getJob(jobId);
+    expect(job?.status).toBe("completed");
+    // Results should contain real recipient addresses, not synthetic placeholders
+    expect(job?.result?.results[0].recipient).toBe(recipient1);
+    expect(job?.result?.results[1].recipient).toBe(recipient2);
+    expect(mockSubmitTransaction).toHaveBeenCalledOnce();
+  });
+
   test("exits early and does nothing when job is already completed", async () => {
     mockSubmitTransaction.mockResolvedValue({ hash: "should_not_be_called" });
 


### PR DESCRIPTION
## Fix #515: Pre-signed batch-submit persists payments alongside signed XDRs

Pre-signed batch-submit was storing `payments: []` even when clients provided payment metadata alongside signed transactions, causing empty recipient history and blocked retry.

### Changes

- **Accept optional `payments` alongside `signedTransactions`** in batch-submit API; validate op count alignment when both are provided
- **Persist stored payments in the job**; worker recovers from job state on restart for real recipient addresses
- **Enable retry for pre-signed batches** that have payment metadata; clean error without it
- **Updated tests** for payment persistence, op-count validation, and retry

### Files Modified

| File | Change |
|------|--------|
| `app/api/batch-submit/route.ts` | Accept & persist payments alongside signed XDRs; validate op count alignment |
| `app/api/batch-retry/route.ts` | Enable retry for pre-signed batches with metadata; fix `jobId` catch-block scoping |
| `lib/stellar/batch-worker.ts` | Recover payments from job state on restart (mirrors signedTransactions recovery) |
| `tests/batch-submit.test.ts` | New tests for payment persistence & op-count mismatch rejection |
| `tests/batch-retry.test.ts` | New tests for pre-signed retry (with & without payment metadata) |
| `tests/batch-worker.test.ts` | New test for payment recovery from job state |

### How to verify

1. Build XDRs via `/api/batch-build`, then submit with both `signedTransactions` and `payments` to `/api/batch-submit`
2. Job history should show real recipient addresses instead of `tx-0` placeholders
3. `/api/batch-retry` should return 202 for jobs with stored payment metadata

Closes #515
