### PR TITLE
Add .env.example and CI validation for environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,165 @@
+# =============================================================================
+# Stellar BatchPay — Environment Variable Reference
+# =============================================================================
+# Copy this file to .env and fill in your values.
+# NEVER commit .env or any file containing real secrets to version control.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Wallet/Signing (server-only — never prefix with NEXT_PUBLIC_)
+# -----------------------------------------------------------------------------
+# Enables the API routes /api/batch-submit and /api/batch-retry to sign
+# transactions server-side using the secret below. Default is disabled (false).
+# ALLOW_SERVER_SIGNING=false
+
+# Secret key for the Stellar account that pays batches. Keep this private.
+# STELLAR_SECRET_KEY="S..."
+
+# Maximum retries when the server encounters tx_bad_seq errors.
+# STELLAR_BAD_SEQUENCE_RETRY_LIMIT=3
+
+# -----------------------------------------------------------------------------
+# Client-Side / Browser Variables (must use NEXT_PUBLIC_ prefix)
+# -----------------------------------------------------------------------------
+# Public site URL used in sitemap.xml and robots.txt.
+# NEXT_PUBLIC_SITE_URL="https://stellar-batch-pay.vercel.app"
+
+# Sentry DSN for browser error reporting (only active in production).
+# NEXT_PUBLIC_SENTRY_DSN="https://..."
+
+# Enable/disable Vercel Analytics.
+# NEXT_PUBLIC_ENABLE_ANALYTICS=false
+
+# -----------------------------------------------------------------------------
+# Horizon/RPC (server + client)
+# -----------------------------------------------------------------------------
+# Client bundles need the NEXT_PUBLIC_ prefix; the server-only versions are
+# used for backend operations. If either is set, the NEXT_PUBLIC_ one wins
+# on the client so the browser can target a different RPC than the server.
+# HORIZON_URL_MAINNET="https://horizon.stellar.org"
+# HORIZON_URL_TESTNET="https://horizon-testnet.stellar.org"
+# HORIZON_URL_FUTURENET="https://horizon-futurenet.stellar.org"
+# SOROBAN_RPC_URL_MAINNET="https://soroban-mainnet.stellar.org"
+# SOROBAN_RPC_URL_TESTNET="https://soroban-testnet.stellar.org"
+# SOROBAN_RPC_URL_FUTURENET="https://soroban-futurenet.stellar.org"
+# NEXT_PUBLIC_HORIZON_URL_MAINNET="https://horizon.stellar.org"
+# NEXT_PUBLIC_HORIZON_URL_TESTNET="https://horizon-testnet.stellar.org"
+# NEXT_PUBLIC_HORIZON_URL_FUTURENET="https://horizon-futurenet.stellar.org"
+# NEXT_PUBLIC_SOROBAN_RPC_URL_MAINNET="https://soroban-mainnet.stellar.org"
+# NEXT_PUBLIC_SOROBAN_RPC_URL_TESTNET="https://soroban-testnet.stellar.org"
+# NEXT_PUBLIC_SOROBAN_RPC_URL_FUTURENET="https://soroban-futurenet.stellar.org"
+
+# Network passphrase for the Soroban RPC URL above.
+# NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
+# -----------------------------------------------------------------------------
+# Persistence & Storage
+# -----------------------------------------------------------------------------
+# SQLite path for durable batch job state. Defaults to ./data/jobs.db.
+# JOB_STORE_PATH="./data/jobs.db"
+
+# SQLite path for API rate-limit counters. Defaults to ./data/rate-limit.db.
+# RATE_LIMIT_DB_PATH="./data/rate-limit.db"
+
+# -----------------------------------------------------------------------------
+# Rate limits
+# -----------------------------------------------------------------------------
+# JSON map of API keys to tiers. Example: {"abc123":"pro","def456":"enterprise"}
+# RATE_LIMIT_API_KEY_TIERS=
+
+# Per-endpoint free-tier limits. Prefix the endpoint key with RATE_LIMIT_.
+# Enterprise limits follow the same pattern with suffix _ENTERPRISE.
+# RATE_LIMIT_BATCH_BUILD_FREE=8
+# RATE_LIMIT_BATCH_BUILD_PRO=20
+# RATE_LIMIT_BATCH_BUILD_WINDOW_MS=60000
+# RATE_LIMIT_BATCH_SUBMIT_FREE=5
+# RATE_LIMIT_BATCH_SUBMIT_PRO=15
+# RATE_LIMIT_BATCH_SUBMIT_WINDOW_MS=60000
+# RATE_LIMIT_BATCH_SUBMIT_SIGNED_FREE=5
+# RATE_LIMIT_BATCH_SUBMIT_SIGNED_PRO=15
+# RATE_LIMIT_BATCH_SUBMIT_SIGNED_WINDOW_MS=60000
+# RATE_LIMIT_WEBHOOK_REGISTER_FREE=3
+# RATE_LIMIT_WEBHOOK_REGISTER_PRO=10
+# RATE_LIMIT_WEBHOOK_REGISTER_WINDOW_MS=60000
+# RATE_LIMIT_TX_STATUS_FREE=30
+# RATE_LIMIT_TX_STATUS_PRO=100
+# RATE_LIMIT_TX_STATUS_WINDOW_MS=60000
+# RATE_LIMIT_DASHBOARD_METRICS_FREE=20
+# RATE_LIMIT_DASHBOARD_METRICS_PRO=60
+# RATE_LIMIT_DASHBOARD_METRICS_WINDOW_MS=60000
+# RATE_LIMIT_BATCH_STATUS_FREE=60
+# RATE_LIMIT_BATCH_STATUS_PRO=200
+# RATE_LIMIT_BATCH_STATUS_WINDOW_MS=60000
+# RATE_LIMIT_BATCH_EVENTS_FREE=10
+# RATE_LIMIT_BATCH_EVENTS_PRO=30
+# RATE_LIMIT_BATCH_EVENTS_WINDOW_MS=60000
+# RATE_LIMIT_HEALTH_FREE=30
+# RATE_LIMIT_HEALTH_PRO=100
+# RATE_LIMIT_HEALTH_WINDOW_MS=60000
+
+# -----------------------------------------------------------------------------
+# Webhooks
+# -----------------------------------------------------------------------------
+# (No dedicated webhook env vars — webhook registrations are stored in SQLite
+# and managed via /api/webhooks/register. Outgoing deliveries use the stored
+# secret per registration.)
+
+# -----------------------------------------------------------------------------
+# Secret Backend (Keeper Bot)
+# -----------------------------------------------------------------------------
+# Backend for fetching the KEEPER_SECRET. Options: env | aws | github
+# SECRET_BACKEND=env
+
+# When SECRET_BACKEND=env the secret is read directly from the environment.
+# KEEPER_SECRET="S..."
+
+# When SECRET_BACKEND=aws, these are required:
+# AWS_REGION=us-east-1
+# AWS_ACCESS_KEY_ID="..."
+# AWS_SECRET_ACCESS_KEY="..."
+
+# When SECRET_BACKEND=github the secret is injected by GitHub Actions.
+# No additional env vars are needed.
+
+# -----------------------------------------------------------------------------
+# Keeper Bot
+# -----------------------------------------------------------------------------
+# Contract ID of the deployed batch-vesting Soroban contract (starts with C...).
+# CONTRACT_ID="C..."
+
+# Maintenance window size — number of schedule indices bumped per recipient per run.
+# MAINTENANCE_LIMIT=10
+
+# JSON path for persisting per-recipient pagination cursor between keeper runs.
+# KEEPER_STATE_PATH="./data/keeper-state.json"
+
+# Optional Slack/Discord webhook URL for keeper alert notifications.
+# ALERT_WEBHOOK_URL="https://hooks.slack.com/services/..."
+
+# Low XLM balance threshold that triggers a keeper alert.
+# LOW_BALANCE_THRESHOLD=50
+
+# -----------------------------------------------------------------------------
+# Idempotency & Retries
+# -----------------------------------------------------------------------------
+# Staleness threshold (ms) after which a queued/processing job is considered
+# stranded and replayed on an idempotent request.
+# IDEMPOTENCY_REPLAY_STALE_MS=30000
+
+# -----------------------------------------------------------------------------
+# Error Tracking
+# -----------------------------------------------------------------------------
+# Server-side Sentry DSN (requires @sentry/nextjs or similar integration).
+# SENTRY_DSN="https://..."
+
+# -----------------------------------------------------------------------------
+# General
+# -----------------------------------------------------------------------------
+# NODE_ENV=development
+# LOG_LEVEL=info
+
+# -----------------------------------------------------------------------------
+# End-to-End Tests (Playwright)
+# -----------------------------------------------------------------------------
+# Base URL for Playwright tests. Defaults to http://localhost:3000.
+# E2E_BASE_URL="http://localhost:3000"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,6 @@ jobs:
         run: bun run test
         env:
           CI: 'true'
+
+      - name: Validate environment configuration
+        run: bun run validate:env

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,13 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files
-.env*
+.env
+.env.local
+.env.production
+.env*.local
+
+# keep template in repo
+!.env.example
 
 # vercel
 .vercel

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,6 +15,14 @@ Instructions for deploying the Stellar bulk payment system to production.
 
 ## Environment Setup
 
+A complete list of supported variables with defaults and descriptions is
+included in [`.env.example`](./.env.example). Copy it to `.env` and fill in
+your values.
+
+```bash
+cp .env.example .env
+```
+
 ### Required Environment Variables
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -279,6 +279,16 @@ For a detailed guide on architecture, local development setup, and contract deve
 bun install
 ```
 
+### Environment Variables
+
+Copy the example environment file and configure it for your setup:
+
+```bash
+cp .env.example .env
+```
+
+See `.env.example` for all available variables, including client-side (`NEXT_PUBLIC_*`) and server-only options.
+
 ### Using the Web Interface
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test": "vitest run tests/",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "playwright test smoke.spec.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "validate:env": "bun scripts/validate-env.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -1,0 +1,82 @@
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+const ROOT = process.cwd();
+let failed = false;
+
+function fail(message: string): void {
+  console.error(`FAIL: ${message}`);
+  failed = true;
+}
+
+function ok(message: string): void {
+  console.log(`OK: ${message}`);
+}
+
+function warn(message: string): void {
+  console.warn(`WARN: ${message}`);
+}
+
+const examplePath = `${ROOT}/.env.example`;
+
+if (!existsSync(examplePath)) {
+  fail(".env.example is missing");
+} else {
+  const content = readFileSync(examplePath, "utf8");
+  ok(".env.example exists");
+
+  const requiredSections = [
+    "Wallet/Signing",
+    "Storage",
+    "Rate limits",
+    "Horizon/RPC",
+    "Webhooks",
+    "Keeper",
+  ];
+
+  for (const section of requiredSections) {
+    if (!content.includes(section)) {
+      fail(`.env.example is missing section: ${section}`);
+    } else {
+      ok(`.env.example contains section: ${section}`);
+    }
+  }
+
+  if (/STELLAR_SECRET_KEY\s*=\s*S[A-Z2-7]{55}/.test(content)) {
+    fail(".env.example contains a value that looks like a real secret key");
+  }
+
+  if (/ALLOW_SERVER_SIGNING\s*=\s*true/.test(content)) {
+    fail(".env.example sets ALLOW_SERVER_SIGNING=true without a strong warning");
+  }
+}
+
+try {
+  const tracked = execSync("git ls-files .env .env.local .env.production .env*.local", {
+    cwd: ROOT,
+    encoding: "utf8",
+  }).trim();
+  if (tracked) {
+    fail(`tracked env files: ${tracked}`);
+  } else {
+    ok("no sensitive .env files tracked by git");
+  }
+} catch {
+  ok("no sensitive .env files tracked by git");
+}
+
+try {
+  const untracked = execSync("git ls-files --others --exclude-standard .env .env.local .env.production .env*.local", {
+    cwd: ROOT,
+    encoding: "utf8",
+  }).trim();
+  if (untracked) {
+    warn(`untracked env files present (should not be committed): ${untracked.split(/\s+/).join(", ")}`);
+  }
+} catch {
+  // no untracked env files
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
closes #459

## What I did
- Added `.env.example` with commented sections covering all discovered environment variables: Wallet/Signing, Storage, Rate limits, Horizon/RPC, Webhooks, Keeper, and more
- Added `scripts/validate-env.ts` that checks for the presence of `.env.example`, ensures required sections exist, warns if secrets appear committed, and verifies no sensitive `.env` files are tracked by git
- Updated `.github/workflows/ci.yml` to run `bun run validate:env` after tests on every build
- Updated `README.md` with a link to `.env.example` in the Installation section
- Updated `DEPLOYMENT.md` to reference `.env.example` as the canonical env var reference
- Adjusted `.gitignore` to allow `.env.example` while still ignoring real `.env`, `.env.local`, `.env.production`, and `.env*.local`

## Why
New contributors and deployers previously had to grep the codebase to discover required configuration. This increases misconfiguration risk, especially around `NEXT_PUBLIC_` vs server-only variables and accidental production server signing.

## CI
All existing CI jobs should pass unchanged. The new `validate-env` step is designed to pass for a clean repository state.

closes #459