### PR TITLE
fix: keeper script exits non-zero on failure so CI catches maintenance errors

### DIFF
--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -50,6 +50,21 @@ jobs:
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
             const issueNumber = context.issue?.number;
 
+            // Write job summary so the failure reason is visible in the Actions UI.
+            const summary = [
+              '## ❌ Keeper Bot Failure',
+              '',
+              `| Field | Value |`,
+              `| ----- | ----- |`,
+              `| Run | [${context.runId}](${runUrl}) |`,
+              `| Contract | \`${process.env.CONTRACT_ID || 'N/A'}\` |`,
+              `| Schedule | \`${context.event?.schedule || 'manual'}\` |`,
+              '',
+              'Check the **Run keeper bot** step logs for the full error.',
+            ].join('\n');
+            core.summary.addRaw(summary);
+            await core.summary.write();
+
             if (issueNumber) {
               await github.rest.issues.createComment({
                 owner,

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -179,6 +179,38 @@ export MAINTENANCE_LIMIT=10
 export KEEPER_STATE_PATH=/mnt/data/keeper-state.json
 ```
 
+### Keeper Bot Exit Codes
+
+The keeper script (`scripts/keeper.ts`) uses explicit exit codes so CI
+workflows correctly report success or failure.
+
+| Exit Code | Meaning |
+| --------- | ------- |
+| `0` | Keeper completed successfully — all recipients maintained, instance bumped, balance checked. |
+| `1` | Keeper encountered a fatal error (missing config, RPC failure, transaction error, etc.). The alert webhook fires **before** the non-zero exit. |
+
+**CI behaviour:**
+
+- GitHub Actions treats exit code `0` as success (green checkmark) and any
+  non-zero code as failure (red cross).
+- The `Report failure` step in `.github/workflows/keeper.yml` runs on
+  `if: failure()` and writes a job summary with the contract ID and run
+  metadata, then creates or comments on a GitHub issue.
+
+**Testing exit codes locally:**
+
+```bash
+# Success path (valid env)
+npx ts-node scripts/keeper.ts; echo "exit: $?"
+
+# Failure path (missing CONTRACT_ID)
+CONTRACT_ID= npx ts-node scripts/keeper.ts; echo "exit: $?"
+# → prints exit: 1
+```
+
+The `main` function is exported for programmatic testing via subprocess
+spawn.
+
 ---
 
 ## Smart Contract Deployment

--- a/scripts/keeper.ts
+++ b/scripts/keeper.ts
@@ -26,6 +26,8 @@ const CONTRACT_ID = process.env.CONTRACT_ID;
 const U32_MAX = 2 ** 32 - 1;
 const MAINTENANCE_LIMIT = readU32Env("MAINTENANCE_LIMIT", 10);
 const BUMP_THRESHOLD_DAYS = 7;
+const LEDGERS_PER_DAY = 17280; // ~5 s per ledger on Stellar
+const BUMP_THRESHOLD_LEDGERS = BUMP_THRESHOLD_DAYS * LEDGERS_PER_DAY;
 const ALERT_WEBHOOK_URL = process.env.ALERT_WEBHOOK_URL;
 const LOW_BALANCE_THRESHOLD = Number(process.env.LOW_BALANCE_THRESHOLD || "50"); // XLM
 
@@ -120,7 +122,7 @@ async function checkBalance(_server: SorobanRpc.Server, publicKey: string) {
 
 // ── Main loop ──────────────────────────────────────────────────────────────
 
-async function main() {
+export async function main() {
   // Fetch the keeper secret from the configured backend (#257).
   // Set SECRET_BACKEND=aws|github|env (default: env with a warning).
   const secrets = await createSecretsProvider();
@@ -164,10 +166,12 @@ async function main() {
     await checkBalance(server, keeperKeypair.publicKey());
 
     console.log("Keeper Bot finished successfully.");
+    process.exit(0);
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     console.error("Keeper execution failed:", errorMsg);
     await sendAlert(`Critical failure in Keeper Bot: ${errorMsg}`);
+    process.exit(1);
   }
 }
 
@@ -360,4 +364,4 @@ async function maintainRecipientWindow(
   return true;
 }
 
-main();
+main().catch(() => process.exit(1));


### PR DESCRIPTION
## Fix: Keeper script exits non-zero on failure so CI catches maintenance errors

### Problem

`scripts/keeper.ts` catches errors in `main()` using a `try/catch`, logs them, and sends Slack/webhook alerts, but never calls `process.exit(1)`. As a result, the script falls through after a failure and Node exits with status code `0`.

Because GitHub Actions interprets an exit code of `0` as success, keeper maintenance failures can silently pass CI, increasing the risk of Soroban contract storage expiring without operator awareness.

Additionally, `BUMP_THRESHOLD_LEDGERS` was referenced (line 135) but never defined, resulting in a `ReferenceError` at runtime.

### Changes

#### `scripts/keeper.ts`

- Added `LEDGERS_PER_DAY = 17280` and derived `BUMP_THRESHOLD_LEDGERS`, fixing the undefined variable bug.
- Added `process.exit(0)` on the success path and `process.exit(1)` in the `catch` block after the alert webhook is sent.
- Exported `main()` to enable programmatic testing via subprocess spawning.
- Replaced the bare `main()` invocation with `main().catch(() => process.exit(1))` as a safeguard against unhandled rejections.

#### `.github/workflows/keeper.yml`

- Enhanced the **Report failure** step to write a `$GITHUB_STEP_SUMMARY` table containing the run ID, contract ID, and schedule trigger, making failure context visible directly in the GitHub Actions UI.

#### `DEPLOYMENT.md`

- Added a **Keeper Bot Exit Codes** section documenting:
  - Exit code semantics
  - CI behavior
  - Local testing commands

### Acceptance Criteria

- Keeper exits with a non-zero status (`1`) when the maintenance loop throws.
- The CI workflow fails when the keeper script fails.
- Successful runs continue to exit with status `0`.
- The alert webhook is triggered before the process exits with a non-zero status.
- `BUMP_THRESHOLD_LEDGERS` is properly defined, eliminating the runtime `ReferenceError`.

### Testing

```bash
# Success path
CONTRACT_ID=C... KEEPER_SECRET=S... npx ts-node scripts/keeper.ts
echo "exit: $?"
# exit: 0

# Failure path (missing config)
CONTRACT_ID= npx ts-node scripts/keeper.ts
echo "exit: $?"
# exit: 1
```

Closes #535.