### PR TITLE
docs: add batch worker webhook delivery guide (closes #501)

### DIFF
--- a/docs/batch-worker-webhooks.md
+++ b/docs/batch-worker-webhooks.md
@@ -1,0 +1,61 @@
+# Batch Worker Webhook Delivery
+
+## Overview
+
+The background batch worker (`lib/stellar/batch-worker.ts`) reliably emits webhook events for all batch outcomes: `batch.completed` on success and `batch.failed` on failure.
+
+## Event Lifecycle
+
+### Success Path
+
+When all operations in a batch succeed, the worker:
+
+1. Updates the job status to `completed` in the job store.
+2. Triggers a `batch.completed` webhook to all registered subscribers via `triggerWebhooksWithRetry`.
+
+### Failure Path
+
+When any operation fails or a top-level worker error occurs, the worker:
+
+1. Updates the job status to `failed` and records the error in the job store.
+2. Triggers a `batch.failed` webhook to all registered subscribers via `triggerWebhooksWithRetry`.
+
+### Catch Block
+
+The top-level `catch` block in `processJobInBackground` handles unrecoverable errors (e.g., invalid signing configuration, job store exceptions). It:
+
+1. Logs the error with structured logging.
+2. Marks the job as `failed`.
+3. Fires the `batch.failed` webhook with the error details.
+
+## Retry Semantics
+
+`triggerWebhooksWithRetry` provides exponential backoff (500ms base) and retries on 5xx / network errors up to 4 additional attempts. It also logs every delivery attempt to the `webhook_deliveries` table for auditing.
+
+## Webhook Payload Schema
+
+All worker-emitted webhooks include:
+
+```ts
+{
+  event: "batch.completed" | "batch.failed",
+  payload: {
+    jobId: string;
+    network: "testnet" | "mainnet";
+    batchId: string;
+    summary: { successful: number; failed: number };
+    error?: string; // included only on batch.failed
+  },
+  timestamp: string;
+}
+```
+
+## Subscriber Guidance
+
+Subscribers should treat `batch.failed` as a terminal state. The `summary.failed` and `payload.error` fields provide full context for reconciliation or alerting.
+
+## Related
+
+- #501 — catch block webhook delivery
+- #513 — batch.completed on success path
+- #338 — initial webhook implementation


### PR DESCRIPTION
Closes #501

The fix for #501 was implemented in commit eab5d35 but lacked documentation and proper issue tracking. This PR adds:
- Comprehensive documentation of webhook delivery behavior in the batch worker
- Clear explanation of success/failure paths and catch block handling
- Payload schema and retry semantics for webhook subscribers

## Changes
- Added `docs/batch-worker-webhooks.md` covering worker webhook events, lifecycle, and payload structure.

## Verification
- `triggerWebhooksWithRetry` import confirmed in `lib/stellar/batch-worker.ts` (line 24)
- `batch.completed` fired on success paths (lines 228, 336)
- `batch.failed` fired on failure paths including top-level catch (lines 235, 343, 356)
- Existing tests in `tests/batch-worker.test.ts` cover the catch-path webhook call