### PR TITLE
fix: O(N²) sort in revoke_batch, settings network sync, demo WalletContext, fee op count

### DIFF
--- a/app/api/batch-submit-signed/route.ts
+++ b/app/api/batch-submit-signed/route.ts
@@ -20,7 +20,7 @@ import {
     isBadSequenceError,
     isInsufficientFeeError,
 } from "@/lib/stellar/submit-errors";
-import { getXdrSourceAccount } from "@/lib/stellar/xdr-source";
+import { getXdrSourceAccount, operationCountOf } from "@/lib/stellar/xdr-source";
 
 interface RequestBody {
     signedXdr: string;
@@ -131,7 +131,8 @@ export async function POST(request: NextRequest) {
             if (isInsufficientFeeError(submissionError)) {
                 const feeStats = await getFeeStats(server);
                 const currentBaseFee = Number(feeStats.last_ledger_base_fee || "100");
-                const estimatedFee = (currentBaseFee * 300).toString(); // 300 ops is typical batch size
+                const opCount = operationCountOf(transaction) ?? 1;
+                const estimatedFee = (currentBaseFee * opCount).toString();
 
                 return setRateLimitHeaders(safeJsonResponse(
                     {
@@ -140,8 +141,9 @@ export async function POST(request: NextRequest) {
                         code: "insufficient_fee",
                         action: "increase_fee",
                         currentNetworkFee: currentBaseFee,
+                        operationCount: opCount,
                         estimatedRequiredFee: estimatedFee,
-                        guidance: `Network base fee is ${currentBaseFee} stroops. Consider retrying with a fee of at least ${estimatedFee} stroops.`,
+                        guidance: `Network base fee is ${currentBaseFee} stroops × ${opCount} operation(s). Consider retrying with a fee of at least ${estimatedFee} stroops.`,
                     },
                     { status: 400 },
                 ), rate);

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -33,11 +33,11 @@ import {
 } from "@/lib/settings-prefs";
 
 export default function SettingsPage() {
-  const { publicKey, connect, disconnect, isConnecting } = useWallet();
+  const { publicKey, connect, disconnect, isConnecting, expectedNetwork, selectNetwork } = useWallet();
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
 
-  const [defaultNetwork, setDefaultNetwork] = useState<string>("testnet");
+  const [defaultNetwork, setDefaultNetwork] = useState<string>(expectedNetwork);
   const [defaultAsset, setDefaultAsset] = useState<string>("xlm");
   const [batchValidation, setBatchValidation] = useState(true);
   const [completionNotifications, setCompletionNotifications] = useState(true);
@@ -52,6 +52,11 @@ export default function SettingsPage() {
     setBatchValidation(prefs.batchValidation);
     setCompletionNotifications(prefs.completionNotifications);
   }, []);
+
+  // Keep defaultNetwork in sync with active wallet network (#528)
+  useEffect(() => {
+    setDefaultNetwork(expectedNetwork);
+  }, [expectedNetwork]);
 
   // Debounced save to localStorage
   const debouncedSave = useCallback(
@@ -69,9 +74,11 @@ export default function SettingsPage() {
 
   // Update handlers to save preferences
   const handleDefaultNetworkChange = useCallback((value: string) => {
-    setDefaultNetwork(value);
-    debouncedSave({ defaultNetwork: value as "testnet" | "mainnet" });
-  }, [debouncedSave]);
+    const net = value as "testnet" | "mainnet";
+    setDefaultNetwork(net);
+    selectNetwork(net);
+    debouncedSave({ defaultNetwork: net });
+  }, [debouncedSave, selectNetwork]);
 
   const handleDefaultAssetChange = useCallback((value: string) => {
     setDefaultAsset(value);
@@ -206,7 +213,7 @@ export default function SettingsPage() {
 
             <div className="flex items-center justify-between">
               <span className="text-slate-400">Network</span>
-              <span className="text-white font-medium">Testnet</span>
+              <span className="text-white font-medium capitalize">{expectedNetwork}</span>
             </div>
 
             {publicKey && (

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -7,7 +7,7 @@ import { FileUpload } from "@/components/file-upload";
 import { BatchSummary } from "@/components/batch-summary";
 import { ResultsDisplay } from "@/components/results-display";
 import { ConnectWalletButton } from "@/components/connect-wallet-button";
-import { useFreighter } from "@/hooks/use-freighter";
+import { useWallet } from "@/contexts/WalletContext";
 import { useToast } from "@/components/ui/use-toast";
 import { parseInput, parseFileStream, validatePaymentInstructions } from "@/lib/stellar";
 import type { StreamValidationResult } from "@/lib/stellar/parser";
@@ -50,7 +50,7 @@ export default function Home() {
   });
 
   const { saveResult } = useBatchHistory();
-  const { publicKey, signTx } = useFreighter();
+  const { publicKey, signTx } = useWallet();
 
   const handleFileSelect = async (file: File, format: "json" | "csv") => {
     try {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -93,7 +93,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <WalletProvider expectedNetwork="testnet">
+          <WalletProvider expectedNetwork={(process.env.NEXT_PUBLIC_STELLAR_NETWORK as "testnet" | "mainnet") ?? "testnet"}>
             <QueryProvider>
               <AddressBookProvider>
                 {children}

--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -1160,6 +1160,12 @@ impl BatchVestingContract {
 
     /// Revoke unvested schedules for multiple (recipient, index) pairs atomically.
     /// Reverts the entire transaction if any revocation fails.
+    ///
+    /// Requests MUST be provided pre-sorted in strictly descending order of
+    /// `index` within each recipient (same requirement as `batch_revoke`).
+    /// This keeps on-chain instruction counts O(N) and within Soroban resource
+    /// limits for batches up to MAX_BATCH_SIZE (100). Unsorted input is
+    /// rejected immediately with VestingError::InvalidInput. (#544)
     pub fn revoke_batch(env: Env, caller: Address, requests: Vec<RevokeRequest>) {
         Self::panic_if_operation_paused(&env, PAUSE_REVOKE);
         caller.require_auth();
@@ -1170,34 +1176,26 @@ impl BatchVestingContract {
             return;
         }
 
+        // O(N) validation: require strictly descending index per recipient so
+        // swap-with-last removal does not corrupt pending indices. Sorting is
+        // pushed to the caller (off-chain). (#544 / #308)
+        if n > 1 {
+            let mut last_index: Map<Address, u32> = Map::new(&env);
+            for i in 0..n {
+                let curr = requests.get(i).unwrap();
+                if let Some(prev_index) = last_index.get(curr.recipient.clone()) {
+                    if curr.index >= prev_index {
+                        soroban_sdk::panic_with_error!(&env, VestingError::InvalidInput);
+                    }
+                }
+                last_index.set(curr.recipient.clone(), curr.index);
+            }
+        }
+
         let current_time = env.ledger().timestamp();
 
-        // Build a process_order array and sort in DESCENDING order of index
-        // to prevent swap-with-last removal from corrupting pending indices.
-        let mut process_order: Vec<u32> = Vec::new(&env);
         for k in 0..n {
-            process_order.push_back(k);
-        }
-        for i in 1..n {
-            let key = process_order.get(i).unwrap();
-            let key_idx = requests.get(key).unwrap().index;
-            let mut j = i;
-            while j > 0 {
-                let prev = process_order.get(j - 1).unwrap();
-                let prev_idx = requests.get(prev).unwrap().index;
-                if prev_idx < key_idx {
-                    process_order.set(j, prev);
-                    j -= 1;
-                } else {
-                    break;
-                }
-            }
-            process_order.set(j, key);
-        }
-
-        for k in 0..n {
-            let pos = process_order.get(k).unwrap();
-            let request = requests.get(pos).unwrap();
+            let request = requests.get(k).unwrap();
             let recipient = &request.recipient;
             let index = request.index;
 


### PR DESCRIPTION
## Summary

- **#544** — `revoke_batch` in `contracts/batch-vesting/src/lib.rs` replaced an O(N²) insertion sort with an O(N) pre-sorted validation pass (identical strategy to `batch_revoke` from #308). Unsorted input is rejected with `VestingError::InvalidInput`. Callers must sort descending per recipient off-chain before calling.
- **#528** — Settings page (`app/dashboard/settings/page.tsx`) now initialises `defaultNetwork` from `WalletContext.expectedNetwork` and stays in sync when the header network changes. Changing the network in Settings calls `selectNetwork`, so both surfaces stay consistent. The hardcoded `"Testnet"` label in the wallet card is replaced with the live `expectedNetwork` value. `app/layout.tsx` now reads `NEXT_PUBLIC_STELLAR_NETWORK` instead of hardcoding `"testnet"`.
- **#526** — `app/demo/page.tsx` now uses `useWallet` from `WalletContext` instead of importing `useFreighter` directly, aligning demo network and signing state with the rest of the dashboard.
- **#542** — `app/api/batch-submit-signed/route.ts` replaces the hardcoded `baseFee * 300` fee estimate with `operationCountOf(transaction) * baseFee`, reading the actual operation count from the submitted XDR. The response now includes an `operationCount` field.

## Test plan

- [ ] Submit a 1-op signed transaction with insufficient fee → verify `estimatedRequiredFee` equals `baseFee × 1`, not `× 300`
- [ ] Submit a 100-op signed transaction with insufficient fee → verify `estimatedRequiredFee` equals `baseFee × 100`
- [ ] Call `revoke_batch` with 80+ pre-sorted requests → verify completes within resource limits
- [ ] Call `revoke_batch` with unsorted requests → verify panics with `InvalidInput`
- [ ] Switch to mainnet in the header, open Settings → verify Default Network and wallet card both show Mainnet
- [ ] Change network in Settings → verify header/wallet context updates
- [ ] Open `/demo`, connect wallet, select mainnet in demo → verify signing uses the same network context as the dashboard

Closes #544, Closes #528, Closes #526, Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
