### PR TITLE
fix: report successful payment totals separately by asset

### DIFF
--- a/lib/receipt-generator.ts
+++ b/lib/receipt-generator.ts
@@ -15,9 +15,40 @@ export function generateReceiptHtml(batchResult: BatchResult): string {
   const successfulPayments = batchResult.results.filter(r => r.status === "success");
   const failedPayments = batchResult.results.filter(r => r.status === "failed");
 
-  const totalAmount = formatStellarAmount(
-    sumStellarAmounts(batchResult.results.map(r => r.amount || "0"))
-  );
+  const assetGroups: Record<string, string[]> = {};
+  for (const payment of successfulPayments) {
+    const asset = payment.asset || "XLM";
+    if (!assetGroups[asset]) {
+      assetGroups[asset] = [];
+    }
+    assetGroups[asset].push(payment.amount || "0");
+  }
+
+  const successfulTotals = Object.entries(assetGroups).map(([asset, amounts]) => ({
+    asset,
+    total: formatStellarAmount(sumStellarAmounts(amounts)),
+  }));
+
+  let totalAmountHtml = "";
+  let totalAmountLabel = "";
+
+  if (successfulTotals.length === 0) {
+    totalAmountHtml = `<div class="number">0.0000000</div>`;
+    totalAmountLabel = `<div class="label">Total Amount (XLM)</div>`;
+  } else if (successfulTotals.length === 1) {
+    const { asset, total } = successfulTotals[0];
+    if (asset.includes(':')) {
+      totalAmountHtml = `<div class="number" style="font-size: 14px; line-height: 1.3; padding-top: 5px;">${total} ${asset}</div>`;
+      totalAmountLabel = `<div class="label">Total Amount</div>`;
+    } else {
+      totalAmountHtml = `<div class="number">${total}</div>`;
+      totalAmountLabel = `<div class="label">Total Amount (${asset})</div>`;
+    }
+  } else {
+    totalAmountHtml = `<div class="number" style="font-size: 14px; line-height: 1.3; padding-top: 5px;">${successfulTotals.map(t => `${t.total} ${t.asset}`).join('<br/>')}</div>`;
+    totalAmountLabel = `<div class="label">Total Amount</div>`;
+  }
+
 
   return `
 <!DOCTYPE html>
@@ -74,8 +105,8 @@ export function generateReceiptHtml(batchResult: BatchResult): string {
           <div class="label">Failed</div>
         </div>
         <div class="summary-box">
-          <div class="number">${totalAmount}</div>
-          <div class="label">Total Amount (XLM)</div>
+          ${totalAmountHtml}
+          ${totalAmountLabel}
         </div>
       </div>
     </div>
@@ -166,9 +197,24 @@ export function generateReceiptHtml(batchResult: BatchResult): string {
 
 export function generateReceiptText(batchResult: BatchResult): string {
   const successfulPayments = batchResult.results.filter(r => r.status === "success");
-  const totalAmount = formatStellarAmount(
-    sumStellarAmounts(batchResult.results.map(r => r.amount || "0"))
-  );
+
+  const assetGroups: Record<string, string[]> = {};
+  for (const payment of successfulPayments) {
+    const asset = payment.asset || "XLM";
+    if (!assetGroups[asset]) {
+      assetGroups[asset] = [];
+    }
+    assetGroups[asset].push(payment.amount || "0");
+  }
+
+  const successfulTotals = Object.entries(assetGroups).map(([asset, amounts]) => ({
+    asset,
+    total: formatStellarAmount(sumStellarAmounts(amounts)),
+  }));
+
+  const totalAmountText = successfulTotals.length > 0
+    ? successfulTotals.map(t => `${t.total} ${t.asset}`).join(", ")
+    : "0.0000000 XLM";
 
   let text = `Stellar BatchPay - Batch Payment Receipt\n`;
   text += `${"=".repeat(50)}\n\n`;
@@ -181,7 +227,7 @@ export function generateReceiptText(batchResult: BatchResult): string {
   text += `Total Recipients: ${batchResult.totalRecipients}\n`;
   text += `Successful: ${batchResult.summary.successful}\n`;
   text += `Failed: ${batchResult.summary.failed}\n`;
-  text += `Total Amount: ${totalAmount} XLM\n\n`;
+  text += `Total Amount: ${totalAmountText}\n\n`;
 
   text += `PAYMENT DETAILS\n`;
   text += `${"-".repeat(30)}\n`;

--- a/tests/receipt-generator.test.ts
+++ b/tests/receipt-generator.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from 'vitest';
+import { generateReceiptHtml, generateReceiptText } from '../lib/receipt-generator';
+import type { BatchResult } from '../lib/stellar/types';
+
+describe('Receipt Generator - Totals by Asset', () => {
+  const mockBatchResult: BatchResult = {
+    batchId: 'mock-batch-123',
+    totalRecipients: 3,
+    totalAmount: '35.0000000', // old sum of all (10 + 5 + 20)
+    totalTransactions: 2,
+    network: 'testnet',
+    timestamp: '2026-07-23T15:00:00Z',
+    results: [
+      {
+        recipient: 'GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER',
+        amount: '10.0000000',
+        asset: 'XLM',
+        status: 'success',
+        transactionHash: 'hash1',
+      },
+      {
+        recipient: 'GBJCHUKZMTFSLOMNC7P4TS4VJJBTCYL3AEYZ7R37ZJNHYQM7MDEBC67',
+        amount: '5.0000000',
+        asset: 'XLM',
+        status: 'failed',
+        error: 'Insufficient funds',
+      },
+      {
+        recipient: 'GBL7D47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER',
+        amount: '20.0000000',
+        asset: 'USDC:GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER',
+        status: 'success',
+        transactionHash: 'hash2',
+      },
+    ],
+    summary: {
+      successful: 2,
+      failed: 1,
+    },
+  };
+
+  test('generateReceiptHtml calculates totals correctly for successful payments only, grouped by asset', () => {
+    const html = generateReceiptHtml(mockBatchResult);
+    
+    // Total should NOT include the failed 5 XLM payment (total XLM should be 10.0000000, USDC should be 20.0000000)
+    expect(html).toContain('10.0000000 XLM');
+    expect(html).toContain('20.0000000 USDC:GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER');
+    expect(html).not.toContain('35.0000000');
+    expect(html).not.toContain('15.0000000 XLM');
+  });
+
+  test('generateReceiptText calculates totals correctly for successful payments only, grouped by asset', () => {
+    const text = generateReceiptText(mockBatchResult);
+
+    expect(text).toContain('Total Amount: 10.0000000 XLM, 20.0000000 USDC:GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER');
+    expect(text).not.toContain('35.0000000');
+    expect(text).not.toContain('15.0000000 XLM');
+  });
+});


### PR DESCRIPTION

Closes : #703

## Changes Made

### Receipt Generator Component

#### [receipt-generator.ts](file:///c:/Users/TOSHIBA/Desktop/Stellar-Batch-Pay/lib/receipt-generator.ts)
- Modified `generateReceiptHtml` to filter all payment results by `status === "success"` before calculating totals.
- Grouped successful payment amounts by their respective asset string (e.g. `XLM`, `USDC:GBBD...`).
- Summed and formatted payments per-asset.
- Updated HTML layout to dynamically show:
  - Total Amount (ASSET) for single-asset receipts at the original `24px` size.
  - A multi-line list of all successful totals at `14px` size for multiple assets (or if asset names are long/contain issuers).
- Updated `generateReceiptText` to format totals in the same success-filtered, asset-grouped manner, printing multiple asset totals separated by commas.

## Verification & Testing

### Automated Tests
- Created a new test file: [receipt-generator.test.ts](file:///c:/Users/TOSHIBA/Desktop/Stellar-Batch-Pay/tests/receipt-generator.test.ts)
- Configured test cases for:
  - HTML receipt totals matching only successful payments, grouped by asset.
  - Text receipt totals matching only successful payments, grouped by asset.
- Ran tests successfully using:
  ```bash
  npx vitest run tests/receipt-generator.test.ts
  ```
  Both tests passed successfully.
