### PR TITLE
fix: preserve row validation for malformed amounts

### DIFF
--- a/contexts/BatchFlowContext.tsx
+++ b/contexts/BatchFlowContext.tsx
@@ -381,7 +381,6 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
       setStep(2);
     } catch (error) {
       console.error("Failed to parse file:", error);
-      setValidationResult(null);
       setSummary(null);
       setValidationError(
         error instanceof Error ? error.message : "Failed to parse payment file",
@@ -402,8 +401,20 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
     setValidationResult(parsed);
     setValidationError("");
 
-    const batchSummary = getBatchSummary(manualPayments);
-    setSummary(batchSummary);
+    try {
+      const batchSummary = getBatchSummary(manualPayments);
+      setSummary(batchSummary);
+    } catch (error) {
+      console.error("Failed to summarize manual batch:", error);
+      setSummary(null);
+      setValidationError(
+        error instanceof Error ? error.message : "Failed to summarize payment batch",
+      );
+      toast.error(
+        error instanceof Error ? error.message : "Failed to summarize payment batch",
+      );
+      return;
+    }
 
     toast.success("Manual batch validated successfully");
     setStep(2);

--- a/lib/stellar/summary.ts
+++ b/lib/stellar/summary.ts
@@ -10,12 +10,11 @@ export function getBatchSummary(instructions: PaymentInstruction[]) {
   const assetCount = new Map<string, number>();
 
   for (const instruction of instructions) {
-    totalAmount = totalAmount.plus(instruction.amount);
-    assetCount.set(instruction.asset, (assetCount.get(instruction.asset) || 0) + 1);
-
     const validation = validatePaymentInstruction(instruction);
     if (validation.valid) {
       validCount++;
+      totalAmount = totalAmount.plus(instruction.amount);
+      assetCount.set(instruction.asset, (assetCount.get(instruction.asset) || 0) + 1);
     } else {
       invalidCount++;
     }

--- a/tests/batcher.test.ts
+++ b/tests/batcher.test.ts
@@ -9,6 +9,7 @@ import {
   estimateBatchTransactionSize,
   getBatchSummary,
 } from '../lib/stellar/batcher';
+import { analyzeParsedPayments, parsePaymentFile } from '../lib/stellar/parser';
 import { parseAsset } from '../lib/stellar/utils';
 
 const firstAddress = Keypair.random().publicKey();
@@ -255,5 +256,51 @@ describe('Batch Summary', () => {
     ];
     const summary = getBatchSummary(payments);
     expect(summary.totalAmount).toBe('30.75');
+  });
+
+  test('preserves valid summary data when an amount is malformed', () => {
+    const payments = [
+      {
+        address: firstAddress,
+        amount: '10',
+        asset: 'XLM',
+      },
+      {
+        address: secondAddress,
+        amount: 'not-a-number',
+        asset: 'XLM',
+      },
+    ];
+
+    const summary = getBatchSummary(payments);
+
+    expect(summary.recipientCount).toBe(2);
+    expect(summary.validCount).toBe(1);
+    expect(summary.invalidCount).toBe(1);
+    expect(summary.totalAmount).toBe('10');
+    expect(summary.assetBreakdown['XLM']).toBe(1);
+  });
+
+  test('preserves upload row validation for malformed amounts', () => {
+    const csv = `address,amount,asset
+${firstAddress},10,XLM
+${secondAddress},not-a-number,XLM`;
+    const parsed = parsePaymentFile(csv, 'csv');
+    const summary = getBatchSummary(parsed.rows.map((row) => row.instruction));
+
+    expect(parsed.rows[1].valid).toBe(false);
+    expect(parsed.rows[1].error).toContain('positive number');
+    expect(summary.totalAmount).toBe('10');
+  });
+
+  test('summarizes manual entries without throwing on malformed amounts', () => {
+    const parsed = analyzeParsedPayments([
+      { address: firstAddress, amount: '10', asset: 'XLM' },
+      { address: secondAddress, amount: 'not-a-number', asset: 'XLM' },
+    ]);
+
+    expect(() => getBatchSummary(parsed.rows.map((row) => row.instruction))).not.toThrow();
+    expect(parsed.rows[1].valid).toBe(false);
+    expect(parsed.rows[1].error).toContain('positive number');
   });
 });


### PR DESCRIPTION
## Summary

Closes : #702


`getBatchSummary` attempted to add every amount with `big.js` before validating the payment instruction. Values such as `"not-a-number"` caused summary generation to throw before the parser’s row-level validation could be displayed.

This also caused:

- File uploads to clear their existing validation results.
- Users to see only a generic parse error.
- Manual entry to throw an uncaught exception.

## Changes

- Validate each payment instruction before performing amount arithmetic.
- Sum only amounts from valid instructions.
- Include only valid instructions in the asset breakdown.
- Preserve parsed validation results when file summary generation fails.
- Handle manual summary failures without allowing an uncaught exception.
- Add regression coverage for malformed amounts through upload and manual-entry paths.

## Testing

- `npm test`
  - 50 test files passed
  - 501 tests passed
- `npm run build`
  - Passed successfully
- `npm run lint`
  - Blocked by the existing ESLint 8 and `eslint-config-next` 16 configuration incompatibility before source files were checked.