### PR TITLE
feat : Fetch Full Batch Results for Historical Receipt Downloads

### DIFF
--- a/components/dashboard/HistoryExportCenter.tsx
+++ b/components/dashboard/HistoryExportCenter.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { CalendarRange, Download, FileText, Wallet, Receipt } from "lucide-react";
+import { CalendarRange, Download, FileText, Loader2, Wallet, Receipt } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useWallet } from "@/contexts/WalletContext";
 import { useBatchHistory } from "@/hooks/use-batch-history";
+import { fetchFullBatchResult } from "@/lib/batch-history-adapter";
 import {
   filterClaimExportRowsByDateRange,
   toClaimExportCsv,
@@ -85,6 +86,7 @@ export function HistoryExportCenter() {
   const { history, loading } = useBatchHistory(publicKey);
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
   const scopedRows = useMemo(() => toClaimExportRows(history, publicKey), [history, publicKey]);
   const filteredRows = useMemo(
@@ -128,21 +130,47 @@ export function HistoryExportCenter() {
     toast.success("Print dialog opened for PDF export.");
   };
 
-  const handleDownloadBatchReceipt = (batch: BatchResult) => {
+  const resolveFullBatchResult = async (batch: BatchResult): Promise<BatchResult | null> => {
+    if (!publicKey) {
+      toast.error("Connect a wallet to download batch receipts.");
+      return null;
+    }
+
+    // History rows are summary-only (no per-payment results), so fetch the
+    // full, owner-scoped job detail before generating a receipt/CSV.
+    const full = await fetchFullBatchResult(batch.batchId, publicKey);
+    if (!full) {
+      toast.error("Could not load payment details for this batch.");
+      return null;
+    }
+    return full;
+  };
+
+  const handleDownloadBatchReceipt = async (batch: BatchResult) => {
+    setDownloadingId(batch.batchId);
     try {
-      downloadReceipt(batch);
+      const full = await resolveFullBatchResult(batch);
+      if (!full) return;
+      downloadReceipt(full);
       toast.success("Receipt downloaded successfully.");
     } catch (error) {
       toast.error("Failed to generate receipt.");
+    } finally {
+      setDownloadingId(null);
     }
   };
 
-  const handleDownloadBatchCsv = (batch: BatchResult) => {
+  const handleDownloadBatchCsv = async (batch: BatchResult) => {
+    setDownloadingId(batch.batchId);
     try {
-      downloadReceiptCsv(batch);
+      const full = await resolveFullBatchResult(batch);
+      if (!full) return;
+      downloadReceiptCsv(full);
       toast.success("CSV downloaded successfully.");
     } catch (error) {
       toast.error("Failed to generate CSV.");
+    } finally {
+      setDownloadingId(null);
     }
   };
 
@@ -257,18 +285,28 @@ export function HistoryExportCenter() {
                       variant="ghost"
                       size="sm"
                       onClick={() => handleDownloadBatchReceipt(batch)}
+                      disabled={downloadingId === batch.batchId}
                       className="text-[#00D98B] hover:text-[#00D98B]/80 h-8 px-2"
                     >
-                      <FileText className="h-3.5 w-3.5 mr-1" />
+                      {downloadingId === batch.batchId ? (
+                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                      ) : (
+                        <FileText className="h-3.5 w-3.5 mr-1" />
+                      )}
                       Receipt
                     </Button>
                     <Button
                       variant="ghost"
                       size="sm"
                       onClick={() => handleDownloadBatchCsv(batch)}
+                      disabled={downloadingId === batch.batchId}
                       className="text-gray-400 hover:text-white h-8 px-2"
                     >
-                      <Download className="h-3.5 w-3.5 mr-1" />
+                      {downloadingId === batch.batchId ? (
+                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                      ) : (
+                        <Download className="h-3.5 w-3.5 mr-1" />
+                      )}
                       CSV
                     </Button>
                   </div>

--- a/lib/batch-history-adapter.ts
+++ b/lib/batch-history-adapter.ts
@@ -80,6 +80,34 @@ export async function fetchBatchHistory(
 }
 
 /**
+ * Fetch the full, owner-scoped result for a single job — including the
+ * per-payment results array (recipients, amounts, statuses, tx hashes).
+ *
+ * The list returned by fetchBatchHistory/getBatchHistory only carries a
+ * summary (see `results: []` above), so receipt/CSV downloads must call
+ * this before generating a file for a specific historical batch.
+ */
+export async function fetchFullBatchResult(
+  jobId: string,
+  publicKey: string
+): Promise<BatchResult | null> {
+  const params = new URLSearchParams({ publicKey });
+  const response = await fetch(`/api/batch-status/${encodeURIComponent(jobId)}?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch batch details: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  if (data.status !== "completed" || !data.result) {
+    return null;
+  }
+
+  return data.result as BatchResult;
+}
+
+/**
  * Get cached batch history from localStorage.
  * Returns null if cache is invalid, expired, or version mismatch.
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,9 +1645,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1663,9 +1660,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1683,9 +1677,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1701,9 +1692,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1721,9 +1709,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1739,9 +1724,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1759,9 +1741,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1778,9 +1757,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1796,9 +1772,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1822,9 +1795,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1846,9 +1816,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1872,9 +1839,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1896,9 +1860,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1922,9 +1883,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1947,9 +1905,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1971,9 +1926,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2252,9 +2204,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2270,9 +2219,6 @@
       "integrity": "sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2290,9 +2236,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,9 +2251,6 @@
       "integrity": "sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3949,9 +3889,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3969,9 +3906,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3989,9 +3923,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4009,9 +3940,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4029,9 +3957,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4049,9 +3974,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4358,9 +4280,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4373,9 +4292,6 @@
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4390,9 +4306,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4405,9 +4318,6 @@
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4422,9 +4332,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4437,9 +4344,6 @@
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4454,9 +4358,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4469,9 +4370,6 @@
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4486,9 +4384,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4501,9 +4396,6 @@
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4518,9 +4410,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4534,9 +4423,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4549,9 +4435,6 @@
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5430,9 +5313,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5450,9 +5330,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5470,9 +5347,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5490,9 +5364,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6179,9 +6050,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6196,9 +6064,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6213,9 +6078,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6230,9 +6092,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6247,9 +6106,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6264,9 +6120,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6281,9 +6134,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6298,9 +6148,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6315,9 +6162,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6332,9 +6176,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10708,9 +10549,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10732,9 +10570,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10756,9 +10591,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10780,9 +10612,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
Closes #704 

Summary of the fix:

lib/batch-history-adapter.ts: added fetchFullBatchResult(jobId, publicKey), fetching the owner-scoped /api/batch-status/:jobId endpoint for full per-payment detail.
components/dashboard/HistoryExportCenter.tsx: receipt/CSV download handlers now fetch full batch detail before generating the file, with a per-row loading spinner and error toasts for the unconnected-wallet/fetch-failure cases._