### PR TITLE
fix(rate-limit): validate Bearer token against apiKeyTierMap before b…

### DIFF
--- a/lib/api-rate-limit.ts
+++ b/lib/api-rate-limit.ts
@@ -45,7 +45,7 @@ function getDb(): Database.Database {
       tier TEXT NOT NULL,
       endpoint TEXT NOT NULL,
       remaining INTEGER NOT NULL,
-      limit INTEGER NOT NULL,
+      "limit" INTEGER NOT NULL,
       resetAt INTEGER NOT NULL,
       windowMs INTEGER NOT NULL,
       updatedAt TEXT NOT NULL
@@ -106,7 +106,7 @@ const endpointLimits: Record<EndpointKey, EndpointLimit> = {
   "health": tunedLimit("health", DEFAULT_LIMITS["health"]),
 };
 
-const apiKeyTierMap: Record<string, Tier> = (() => {
+export const apiKeyTierMap: Record<string, Tier> = (() => {
   const raw = process.env.RATE_LIMIT_API_KEY_TIERS;
   if (!raw) return {};
 
@@ -133,7 +133,7 @@ function hashIdentifier(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
-function resolveTier(request: NextRequest): Tier {
+function getValidatedApiKey(request: NextRequest): { key: string; tier: Tier } | null {
   const auth = request.headers.get("authorization");
   let keyValue: string | undefined;
 
@@ -148,23 +148,30 @@ function resolveTier(request: NextRequest): Tier {
 
   if (keyValue) {
     if (apiKeyTierMap[keyValue]) {
-      return apiKeyTierMap[keyValue];
+      return { key: keyValue, tier: apiKeyTierMap[keyValue] };
     }
 
     const hashed = hashIdentifier(keyValue);
     if (apiKeyTierMap[hashed]) {
-      return apiKeyTierMap[hashed];
+      return { key: keyValue, tier: apiKeyTierMap[hashed] };
     }
   }
 
+  return null;
+}
+
+function resolveTier(request: NextRequest): Tier {
+  const validated = getValidatedApiKey(request);
+  if (validated) {
+    return validated.tier;
+  }
   return "free";
 }
 
 function resolveIdentifier(request: NextRequest): string {
-  const auth = request.headers.get("authorization");
-  if (auth?.startsWith("Bearer ")) {
-    const token = auth.slice(7).trim();
-    return `auth:${hashIdentifier(token)}`;
+  const validated = getValidatedApiKey(request);
+  if (validated) {
+    return `auth:${hashIdentifier(validated.key)}`;
   }
 
   const forwarded = request.headers.get("x-forwarded-for");
@@ -204,7 +211,7 @@ export function applyRateLimit(request: NextRequest, endpoint: EndpointKey): {
       const remaining = limit - 1;
       db.prepare(`
         INSERT OR REPLACE INTO rate_buckets
-        (key, tier, endpoint, remaining, limit, resetAt, windowMs, updatedAt)
+        (key, tier, endpoint, remaining, "limit", resetAt, windowMs, updatedAt)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `).run(key, tier, endpoint, remaining, limit, resetAtMs, policy.windowMs, new Date().toISOString());
       return { newWindow: true, resetAtMs, remaining };

--- a/tests/api-rate-limit-bearer-validation.test.ts
+++ b/tests/api-rate-limit-bearer-validation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import path from "path";
+
+describe("Bearer Token Rate Limit Validation", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Use an in-memory or isolated DB path for tests to avoid state bleed
+    process.env.RATE_LIMIT_DB_PATH = path.join(
+      process.cwd(),
+      "data",
+      `test-rate-limit-${Math.random().toString(36).slice(2)}.db`
+    );
+  });
+
+  test("rotating unknown Bearer tokens from the same IP share the same IP bucket and are rate limited", async () => {
+    const { applyRateLimit, getEndpointLimits } = await import("../lib/api-rate-limit");
+    const limit = getEndpointLimits()["batch-submit"].free; // limit = 5
+
+    const ip = "203.0.113.42";
+
+    // Exhaust quota (5 requests) with rotating unknown tokens
+    for (let i = 1; i <= limit; i++) {
+      const req = new NextRequest("http://localhost/api/batch-submit", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer random-token-${i}`,
+          "x-forwarded-for": ip,
+        },
+      });
+      const res = applyRateLimit(req, "batch-submit");
+      expect(res.blocked).toBe(false);
+      expect(res.remaining).toBe(limit - i);
+    }
+
+    // 6th request with a brand new unknown token MUST be blocked because IP quota is exhausted
+    const blockedReq = new NextRequest("http://localhost/api/batch-submit", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer random-token-6`,
+        "x-forwarded-for": ip,
+      },
+    });
+    const blockedRes = applyRateLimit(blockedReq, "batch-submit");
+    expect(blockedRes.blocked).toBe(true);
+    expect(blockedRes.remaining).toBe(0);
+    expect(blockedRes.response?.status).toBe(429);
+  });
+
+  test("valid Bearer tokens in apiKeyTierMap receive their own distinct bucket and tier limit", async () => {
+    const { applyRateLimit, apiKeyTierMap, getEndpointLimits } = await import("../lib/api-rate-limit");
+    const proLimit = getEndpointLimits()["batch-submit"].pro; // pro limit = 15
+
+    const validToken = "secret-pro-token-999";
+    apiKeyTierMap[validToken] = "pro";
+
+    const req = new NextRequest("http://localhost/api/batch-submit", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${validToken}`,
+        "x-forwarded-for": "203.0.113.42",
+      },
+    });
+
+    const res = applyRateLimit(req, "batch-submit");
+    expect(res.blocked).toBe(false);
+    expect(res.limit).toBe(proLimit);
+    expect(res.remaining).toBe(proLimit - 1);
+  });
+
+  test("unvalidated tokens without IP header fall back to ip:unknown bucket and get blocked", async () => {
+    const { applyRateLimit, getEndpointLimits } = await import("../lib/api-rate-limit");
+    const limit = getEndpointLimits()["batch-submit"].free;
+
+    for (let i = 1; i <= limit; i++) {
+      const req = new NextRequest("http://localhost/api/batch-submit", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer no-ip-token-${i}`,
+        },
+      });
+      const res = applyRateLimit(req, "batch-submit");
+      expect(res.blocked).toBe(false);
+    }
+
+    const blockedReq = new NextRequest("http://localhost/api/batch-submit", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer no-ip-token-overflow`,
+      },
+    });
+    const blockedRes = applyRateLimit(blockedReq, "batch-submit");
+    expect(blockedRes.blocked).toBe(true);
+  });
+});


### PR DESCRIPTION
### Summary
Fixes a high-severity security vulnerability in `lib/api-rate-limit.ts` where unvalidated `Authorization: Bearer` tokens were used directly to create separate `auth:<hash>` rate-limiting bucket keys. This allowed an attacker to bypass rate limits indefinitely by rotating random tokens on every request.

closes: #700 
---

### Problem Being Solved
Previously, `resolveIdentifier` extracted any string from `Authorization: Bearer <token>` and hashed it to construct an `auth:<hash>` rate limit identity without first validating if `<token>` (or its hash) was registered in `apiKeyTierMap`. While `resolveTier` fell back to `"free"`, `resolveIdentifier` generated a brand-new bucket per unique token value. As a result, sending repeated requests with rotating unknown Bearer tokens granted callers an endless stream of fresh free-tier quotas.

---

### Implemented Solution
1. **Unified Token & Key Validation (`getValidatedApiKey`)**: Introduced `getValidatedApiKey(request)` helper in `lib/api-rate-limit.ts` that checks both `Authorization: Bearer <token>` and `x-api-key` headers against `apiKeyTierMap` (by direct key match or SHA256 hash match).
2. **Shared Validation in `resolveTier` and `resolveIdentifier`**:
   - `resolveTier` uses `getValidatedApiKey(request)` to determine the caller's tier (`pro`, `enterprise`, or `free`).
   - `resolveIdentifier` only assigns an `auth:<hash>` identity bucket key if `getValidatedApiKey` returns a validated key.
3. **Fallback to IP Identification for Unknown/Unvalidated Tokens**: When an unvalidated or unknown Bearer token is sent, `resolveIdentifier` ignores the token and falls back to IP-based identification (`x-forwarded-for`, `cf-connecting-ip`, or `ip:unknown`). Rotating unknown tokens sent from the same IP now share the exact same rate limit bucket and get properly blocked with `429 Too Many Requests` once the IP quota is exhausted.
4. **Export `apiKeyTierMap` & Quote SQL Reserved Keyword**: Exported `apiKeyTierMap` for runtime/test configuration and quoted the `"limit"` column in SQLite queries to avoid syntax errors.

---

### Files and Components Changed
- **[lib/api-rate-limit.ts](file:///Users/atec/Desktop/DRIP/Stellar-Batch-Pay/lib/api-rate-limit.ts)**:
  - Added `getValidatedApiKey(request)` helper function.
  - Updated `resolveTier` and `resolveIdentifier` to validate tokens before assigning `auth:<hash>` buckets.
  - Exported `apiKeyTierMap`.
  - Quoted SQL column `"limit"` in SQLite schema creation and `INSERT OR REPLACE` query.
- **[tests/api-rate-limit-bearer-validation.test.ts](file:///Users/atec/Desktop/DRIP/Stellar-Batch-Pay/tests/api-rate-limit-bearer-validation.test.ts)**:
  - Added unit test suite covering unknown token rotation IP bucketing, valid key tier assignments, and IP fallback.

---

### Technical Decisions Made
- **Fallback to IP-based Bucketing**: Rather than throwing a 401/403 for unauthenticated callers (which might break public endpoints that accept unauthenticated traffic at free tier rate limits), unvalidated Bearer tokens fall back to IP-derived buckets (`ip:<hash(IP)>`). This enforces rate limits strictly per IP while retaining backward compatibility for public endpoints.
- **Consistently Hashed Identifiers**: Both `x-forwarded-for` and `cf-connecting-ip` use `hashIdentifier` to anonymize and normalize IP bucket keys.

---

### New Features or Behaviour Introduced
- Unrecognized Bearer tokens no longer receive unique rate-limit quotas.
- Rotating unknown tokens from the same IP hit the single IP-level rate-limit bucket.
- Valid API keys registered in `apiKeyTierMap` retain their tier quotas and distinct authentication identity buckets.

---

### Tests Added or Updated
- `tests/api-rate-limit-bearer-validation.test.ts` (3 new integration tests):
  - `rotating unknown Bearer tokens from the same IP share the same IP bucket and are rate limited`
  - `valid Bearer tokens in apiKeyTierMap receive their own distinct bucket and tier limit`
  - `unvalidated tokens without IP header fall back to ip:unknown bucket and get blocked`

---

### Validation Steps Performed
1. **TypeScript Type Check**: `npx tsc --noEmit` passed with 0 errors.
2. **Unit & Integration Tests**: `vitest` ran 51 test files (504 tests) — all passed.
3. **Production Build**: `npm run build` completed static page generation and route compilation cleanly.

---

### Limitations, Assumptions, or Follow-up Work
- `apiKeyTierMap` is populated at startup via `RATE_LIMIT_API_KEY_TIERS` JSON env var or dynamically modified via `apiKeyTierMap` exports.
- Future work could add automated key rotation or database-backed API key management if dynamic key provisioning is required.
