### PR TITLE
fix(contract): enforce MIN_UPGRADE_TIMELOCK in set_config

### DIFF
--- a/contracts/batch-vesting/src/lib.rs
+++ b/contracts/batch-vesting/src/lib.rs
@@ -18,6 +18,9 @@ const PAUSE_CLAIM: u32 = 1 << 1;
 const PAUSE_REVOKE: u32 = 1 << 2;
 
 const UPGRADE_TIMELOCK: u64 = 7 * 24 * 60 * 60; // 7 days in seconds
+/// #699: Hard-coded floor for upgrade_timelock. No admin can reduce the
+/// upgrade review window below this value, preventing immediate WASM swaps.
+const MIN_UPGRADE_TIMELOCK: u64 = 24 * 60 * 60; // 1 day in seconds
 
 #[contract]
 pub struct BatchVestingContract;
@@ -154,6 +157,8 @@ pub enum VestingError {
     InvalidInput = 18,
     /// #543: Provided fee asset is not the whitelisted token from contract config.
     InvalidToken = 19,
+    /// #699: upgrade_timelock is below MIN_UPGRADE_TIMELOCK.
+    TimelockTooShort = 20,
 }
 
 impl BatchVestingContract {
@@ -780,8 +785,15 @@ impl BatchVestingContract {
     ///
     /// #543: The `fee_asset` field sets the single whitelisted token for fee
     /// collection. Once set, fees can only be collected in this token.
+    ///
+    /// #699: `upgrade_timelock` must be at least MIN_UPGRADE_TIMELOCK (1 day).
+    /// This prevents an admin from reducing the upgrade review window to zero
+    /// and executing a WASM swap immediately after proposing it.
     pub fn set_config(env: Env, admin: Address, config: Config) {
         Self::require_current_admin(&env, &admin);
+        if config.upgrade_timelock < MIN_UPGRADE_TIMELOCK {
+            soroban_sdk::panic_with_error!(&env, VestingError::TimelockTooShort);
+        }
         Self::set_config_internal(&env, &config);
 
         env.events().publish(

--- a/contracts/batch-vesting/src/test.rs
+++ b/contracts/batch-vesting/src/test.rs
@@ -2163,7 +2163,7 @@ fn test_set_config() {
     let new_config = Config {
         max_batch_size: 50,
         max_schedules_per_recipient: 5,
-        upgrade_timelock: 100,
+        upgrade_timelock: MIN_UPGRADE_TIMELOCK, // #699: must be >= MIN_UPGRADE_TIMELOCK
         fee_asset: fee_token.clone(),
     };
 
@@ -2178,7 +2178,7 @@ fn test_set_config() {
     let event_data: (u32, u32, u64, Address) = last_event.2.try_into_val(&env).unwrap();
     assert_eq!(event_data.0, 50u32);
     assert_eq!(event_data.1, 5u32);
-    assert_eq!(event_data.2, 100u64);
+    assert_eq!(event_data.2, MIN_UPGRADE_TIMELOCK);
     assert_eq!(event_data.3, fee_token);
 }
 
@@ -2197,7 +2197,7 @@ fn test_config_enforcement() {
     client.set_config(&admin, &Config {
         max_batch_size: 2,
         max_schedules_per_recipient: 10,
-        upgrade_timelock: 100,
+        upgrade_timelock: MIN_UPGRADE_TIMELOCK, // #699: must be >= MIN_UPGRADE_TIMELOCK
         fee_asset: Address::generate(&env),
     });
 
@@ -3284,4 +3284,123 @@ fn test_zero_fees_with_whitelisted_asset() {
     // All tokens should be in the contract (no fees deducted)
     assert_eq!(token.balance(&sender), 900); // 1000 - 100 deposited
     assert_eq!(token.balance(&contract_id), 100); // Only the deposited amount
+}
+
+// ── Minimum upgrade timelock tests (#699) ────────────────────────────────────
+
+/// set_config must reject upgrade_timelock values below MIN_UPGRADE_TIMELOCK.
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #20)")]
+fn test_set_config_rejects_zero_upgrade_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    // upgrade_timelock = 0 is below MIN_UPGRADE_TIMELOCK → must panic with #20
+    client.set_config(&admin, &Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 0,
+        fee_asset: Address::generate(&env),
+    });
+}
+
+/// set_config must reject any upgrade_timelock below MIN_UPGRADE_TIMELOCK (1 day - 1 second).
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #20)")]
+fn test_set_config_rejects_timelock_below_minimum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    // One second below MIN_UPGRADE_TIMELOCK (1 day) → must panic with #20
+    client.set_config(&admin, &Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: MIN_UPGRADE_TIMELOCK - 1,
+        fee_asset: Address::generate(&env),
+    });
+}
+
+/// set_config must accept upgrade_timelock exactly equal to MIN_UPGRADE_TIMELOCK.
+#[test]
+fn test_set_config_accepts_minimum_upgrade_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    // Exactly MIN_UPGRADE_TIMELOCK should succeed
+    client.set_config(&admin, &Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: MIN_UPGRADE_TIMELOCK,
+        fee_asset: Address::generate(&env),
+    });
+}
+
+/// Even when upgrade_timelock is set to MIN_UPGRADE_TIMELOCK (1 day), execute_upgrade
+/// must not succeed before the timelock has elapsed.
+#[test]
+fn test_execute_upgrade_blocked_with_minimum_timelock() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    client.set_config(&admin, &Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: MIN_UPGRADE_TIMELOCK,
+        fee_asset: Address::generate(&env),
+    });
+
+    let new_wasm_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+    // Propose upgrade at t=1000
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.propose_upgrade(&admin, &new_wasm_hash);
+
+    // Execute one second before the timelock expires → must fail with TimelockNotExpired (#15)
+    env.ledger().with_mut(|li| li.timestamp = 1000 + MIN_UPGRADE_TIMELOCK - 1);
+    let result = client.try_execute_upgrade(&admin);
+    assert!(
+        result.is_err(),
+        "execute_upgrade should be blocked before MIN_UPGRADE_TIMELOCK elapses"
+    );
+}
+
+/// An admin who previously set upgrade_timelock = 0 (before the fix) cannot bypass
+/// the review window: even after lowering the timelock to zero and immediately
+/// proposing an upgrade, execution must be gated by MIN_UPGRADE_TIMELOCK.
+/// This test verifies that set_config itself is the enforcement point.
+#[test]
+fn test_set_config_with_zero_timelock_is_rejected_before_propose() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BatchVestingContract);
+    let client = BatchVestingContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    // Attempt to set timelock to 0 — should be rejected
+    let result = client.try_set_config(&admin, &Config {
+        max_batch_size: 100,
+        max_schedules_per_recipient: 10,
+        upgrade_timelock: 0,
+        fee_asset: Address::generate(&env),
+    });
+    assert!(
+        result.is_err(),
+        "set_config must reject upgrade_timelock = 0"
+    );
+
+    // The contract should not have a config yet (or still have the previous valid config)
+    // — propose_upgrade must therefore also fail or operate on the valid timelock
 }

--- a/contracts/batch-vesting/test_snapshots/test/test_config_enforcement.1.json
+++ b/contracts/batch-vesting/test_snapshots/test/test_config_enforcement.1.json
@@ -67,7 +67,7 @@
                         "symbol": "upgrade_timelock"
                       },
                       "val": {
-                        "u64": 100
+                        "u64": 86400
                       }
                     }
                   ]
@@ -229,7 +229,7 @@
                         "symbol": "upgrade_timelock"
                       },
                       "val": {
-                        "u64": 100
+                        "u64": 86400
                       }
                     }
                   ]

--- a/contracts/batch-vesting/test_snapshots/test/test_execute_upgrade_blocked_with_minimum_timelock.1.json
+++ b/contracts/batch-vesting/test_snapshots/test/test_execute_upgrade_blocked_with_minimum_timelock.1.json
@@ -51,7 +51,7 @@
                         "symbol": "max_batch_size"
                       },
                       "val": {
-                        "u32": 50
+                        "u32": 100
                       }
                     },
                     {
@@ -59,7 +59,7 @@
                         "symbol": "max_schedules_per_recipient"
                       },
                       "val": {
-                        "u32": 5
+                        "u32": 10
                       }
                     },
                     {
@@ -78,12 +78,35 @@
           "sub_invocations": []
         }
       ]
-    ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "propose_upgrade",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
   ],
   "ledger": {
     "protocol_version": 22,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 87399,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -212,7 +235,7 @@
                         "symbol": "max_batch_size"
                       },
                       "val": {
-                        "u32": 50
+                        "u32": 100
                       }
                     },
                     {
@@ -220,7 +243,7 @@
                         "symbol": "max_schedules_per_recipient"
                       },
                       "val": {
-                        "u32": 5
+                        "u32": 10
                       }
                     },
                     {
@@ -229,6 +252,62 @@
                       },
                       "val": {
                         "u64": 86400
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "UpgradeProposal"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "UpgradeProposal"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "execute_at"
+                      },
+                      "val": {
+                        "u64": 87400
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "new_wasm_hash"
+                      },
+                      "val": {
+                        "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
                       }
                     }
                   ]
@@ -311,6 +390,39 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
                 "nonce": 5541220902715666415
               }
             },
@@ -361,39 +473,5 @@
       ]
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "ConfigUpdated"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 50
-                },
-                {
-                  "u32": 5
-                },
-                {
-                  "u64": 86400
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    }
-  ]
+  "events": []
 }

--- a/contracts/batch-vesting/test_snapshots/test/test_set_config_accepts_minimum_upgrade_timelock.1.json
+++ b/contracts/batch-vesting/test_snapshots/test/test_set_config_accepts_minimum_upgrade_timelock.1.json
@@ -51,7 +51,7 @@
                         "symbol": "max_batch_size"
                       },
                       "val": {
-                        "u32": 50
+                        "u32": 100
                       }
                     },
                     {
@@ -59,7 +59,7 @@
                         "symbol": "max_schedules_per_recipient"
                       },
                       "val": {
-                        "u32": 5
+                        "u32": 10
                       }
                     },
                     {
@@ -212,7 +212,7 @@
                         "symbol": "max_batch_size"
                       },
                       "val": {
-                        "u32": 50
+                        "u32": 100
                       }
                     },
                     {
@@ -220,7 +220,7 @@
                         "symbol": "max_schedules_per_recipient"
                       },
                       "val": {
-                        "u32": 5
+                        "u32": 10
                       }
                     },
                     {
@@ -377,10 +377,10 @@
             "data": {
               "vec": [
                 {
-                  "u32": 50
+                  "u32": 100
                 },
                 {
-                  "u32": 5
+                  "u32": 10
                 },
                 {
                   "u64": 86400

--- a/contracts/batch-vesting/test_snapshots/test/test_set_config_rejects_timelock_below_minimum.1.json
+++ b/contracts/batch-vesting/test_snapshots/test/test_set_config_rejects_timelock_below_minimum.1.json
@@ -24,61 +24,7 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_config",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "fee_asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_batch_size"
-                      },
-                      "val": {
-                        "u32": 50
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_schedules_per_recipient"
-                      },
-                      "val": {
-                        "u32": 5
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "upgrade_timelock"
-                      },
-                      "val": {
-                        "u64": 86400
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ]
+    []
   ],
   "ledger": {
     "protocol_version": 22,
@@ -172,78 +118,6 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Config"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Config"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "fee_asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_batch_size"
-                      },
-                      "val": {
-                        "u32": 50
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_schedules_per_recipient"
-                      },
-                      "val": {
-                        "u32": 5
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "upgrade_timelock"
-                      },
-                      "val": {
-                        "u64": 86400
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -307,39 +181,6 @@
       ],
       [
         {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -361,39 +202,5 @@
       ]
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "ConfigUpdated"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 50
-                },
-                {
-                  "u32": 5
-                },
-                {
-                  "u64": 86400
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    }
-  ]
+  "events": []
 }

--- a/contracts/batch-vesting/test_snapshots/test/test_set_config_rejects_zero_upgrade_timelock.1.json
+++ b/contracts/batch-vesting/test_snapshots/test/test_set_config_rejects_zero_upgrade_timelock.1.json
@@ -24,61 +24,7 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_config",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "fee_asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_batch_size"
-                      },
-                      "val": {
-                        "u32": 50
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_schedules_per_recipient"
-                      },
-                      "val": {
-                        "u32": 5
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "upgrade_timelock"
-                      },
-                      "val": {
-                        "u64": 86400
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ]
+    []
   ],
   "ledger": {
     "protocol_version": 22,
@@ -172,78 +118,6 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Config"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Config"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "fee_asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_batch_size"
-                      },
-                      "val": {
-                        "u32": 50
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_schedules_per_recipient"
-                      },
-                      "val": {
-                        "u32": 5
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "upgrade_timelock"
-                      },
-                      "val": {
-                        "u64": 86400
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -307,39 +181,6 @@
       ],
       [
         {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -361,39 +202,5 @@
       ]
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "ConfigUpdated"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 50
-                },
-                {
-                  "u32": 5
-                },
-                {
-                  "u64": 86400
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    }
-  ]
+  "events": []
 }

--- a/contracts/batch-vesting/test_snapshots/test/test_set_config_with_zero_timelock_is_rejected_before_propose.1.json
+++ b/contracts/batch-vesting/test_snapshots/test/test_set_config_with_zero_timelock_is_rejected_before_propose.1.json
@@ -24,61 +24,7 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_config",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "fee_asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_batch_size"
-                      },
-                      "val": {
-                        "u32": 50
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_schedules_per_recipient"
-                      },
-                      "val": {
-                        "u32": 5
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "upgrade_timelock"
-                      },
-                      "val": {
-                        "u64": 86400
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ]
+    []
   ],
   "ledger": {
     "protocol_version": 22,
@@ -172,78 +118,6 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "Config"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "Config"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "fee_asset"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_batch_size"
-                      },
-                      "val": {
-                        "u32": 50
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "max_schedules_per_recipient"
-                      },
-                      "val": {
-                        "u32": 5
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "upgrade_timelock"
-                      },
-                      "val": {
-                        "u64": 86400
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          518400
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -307,39 +181,6 @@
       ],
       [
         {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
           "contract_code": {
             "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
           }
@@ -361,39 +202,5 @@
       ]
     ]
   },
-  "events": [
-    {
-      "event": {
-        "ext": "v0",
-        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
-        "type_": "contract",
-        "body": {
-          "v0": {
-            "topics": [
-              {
-                "symbol": "ConfigUpdated"
-              }
-            ],
-            "data": {
-              "vec": [
-                {
-                  "u32": 50
-                },
-                {
-                  "u32": 5
-                },
-                {
-                  "u64": 86400
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                }
-              ]
-            }
-          }
-        }
-      },
-      "failed_call": false
-    }
-  ]
+  "events": []
 }


### PR DESCRIPTION
## Summary

Fixes a high-severity issue where `set_config` accepted `upgrade_timelock: 0`, allowing an admin to propose and execute a WASM upgrade in the same block with no review window.

Closes #699

---

## Problem

`set_config` wrote any supplied `Config` directly to storage with no minimum-value check on `upgrade_timelock`. With `upgrade_timelock == 0`, `propose_upgrade` set `execute_at = timestamp()`, and `execute_upgrade`'s `timestamp() < execute_at` check never triggered — so a compromised or malicious admin could swap the WASM immediately with no delay for anyone to react.

## Changes

### `contracts/batch-vesting/src/lib.rs`
- Added `MIN_UPGRADE_TIMELOCK: u64 = 24 * 60 * 60` (1 day) — a hard-coded floor that no admin can bypass
- Added `VestingError::TimelockTooShort = 20` error variant
- Added guard at the top of `set_config`: panics with `TimelockTooShort` when `config.upgrade_timelock < MIN_UPGRADE_TIMELOCK`

### `contracts/batch-vesting/src/test.rs`
- **5 new tests:**
  - `test_set_config_rejects_zero_upgrade_timelock` — zero is rejected with error `#20`
  - `test_set_config_rejects_timelock_below_minimum` — `MIN_UPGRADE_TIMELOCK - 1` is rejected
  - `test_set_config_accepts_minimum_upgrade_timelock` — exactly `MIN_UPGRADE_TIMELOCK` succeeds
  - `test_execute_upgrade_blocked_with_minimum_timelock` — execute fails before delay elapses even at floor value
  - `test_set_config_with_zero_timelock_is_rejected_before_propose` — validates rejection via `try_set_config`
- **2 existing tests updated:** `test_set_config` and `test_config_enforcement` previously used `upgrade_timelock: 100` for unrelated reasons — updated to `MIN_UPGRADE_TIMELOCK`

## Testing

All 70 Rust contract tests pass:
```
test result: ok. 70 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

All 512 TypeScript/JS unit tests pass (unrelated to this change, verified clean).