### PR TITLE
Fix balance validation for liabilities and reserves

### DIFF
--- a/app/api/batch-build/route.ts
+++ b/app/api/batch-build/route.ts
@@ -51,6 +51,18 @@ interface RequestBody {
 }
 
 const MAX_OPS = 100;
+const STROOPS_PER_XLM = 10_000_000;
+
+async function fetchCurrentBaseReserveXlm(server: Horizon.Server): Promise<number | undefined> {
+  try {
+    const latestLedger = await server.ledgers().order("desc").limit(1).call();
+    const record = latestLedger.records[0] as { base_reserve_in_stroops?: number | string } | undefined;
+    if (!record?.base_reserve_in_stroops) return undefined;
+    return Number(record.base_reserve_in_stroops) / STROOPS_PER_XLM;
+  } catch {
+    return undefined;
+  }
+}
 
 export async function POST(request: NextRequest) {
   const rate = applyRateLimit(request, "batch-build");
@@ -119,7 +131,17 @@ export async function POST(request: NextRequest) {
     const balancesMap = buildBalancesMap(
       sourceAccount.balances as unknown as HorizonBalance[],
     );
-    const balanceCheck = validateBalances(payments, balancesMap, undefined, MAX_OPS);
+    const reserveSource = sourceAccount as unknown as {
+      subentry_count?: number | string;
+      num_sponsoring?: number | string;
+      num_sponsored?: number | string;
+    };
+    const balanceCheck = validateBalances(payments, balancesMap, undefined, MAX_OPS, {
+      baseReserveXlm: await fetchCurrentBaseReserveXlm(server),
+      subentryCount: Number(reserveSource.subentry_count ?? 0),
+      numSponsoring: Number(reserveSource.num_sponsoring ?? 0),
+      numSponsored: Number(reserveSource.num_sponsored ?? 0),
+    });
     if (!balanceCheck.all_sufficient) {
       const insufficient = balanceCheck.checks
         .filter((c) => !c.sufficient)

--- a/lib/stellar/types.ts
+++ b/lib/stellar/types.ts
@@ -149,6 +149,8 @@ export interface HorizonBalance {
   asset_type: "native" | "credit_alphanum4" | "credit_alphanum12";
   asset_code?: string;
   asset_issuer?: string;
+  buying_liabilities?: string;
+  selling_liabilities?: string;
 }
 
 export interface BalancesMap {

--- a/lib/stellar/validator.ts
+++ b/lib/stellar/validator.ts
@@ -15,6 +15,20 @@ import {
 } from "./types";
 import { parseStellarAmount, formatAmount } from "./utils";
 
+export interface BalanceValidationOptions {
+  baseReserveXlm?: number;
+  subentryCount?: number;
+  numSponsoring?: number;
+  numSponsored?: number;
+}
+
+const DEFAULT_BASE_RESERVE_XLM = 0.5;
+const FEE_PER_OPERATION_XLM = 0.00001; // stroops: 100 / 10^7
+
+function toNumberAmount(value: string): number {
+  return Number(parseStellarAmount(value).toString());
+}
+
 function isValidPublicKey(value: string): boolean {
   return StrKey.isValidEd25519PublicKey(value);
 }
@@ -256,7 +270,10 @@ export function buildBalancesMap(balances: HorizonBalance[]): BalancesMap {
       entry.asset_type === "native"
         ? "XLM"
         : `${entry.asset_code}:${entry.asset_issuer}`;
-    map[key] = Number(entry.balance);
+    const balance = parseStellarAmount(entry.balance);
+    const sellingLiabilities = parseStellarAmount(entry.selling_liabilities ?? "0");
+    const spendable = balance.minus(sellingLiabilities);
+    map[key] = Number((spendable.gt(0) ? spendable : parseStellarAmount("0")).toString());
   }
   return map;
 }
@@ -274,9 +291,8 @@ export function resolveAssetKey(asset: string): string {
  * aggregated so cumulative spend is checked.
  *
  * For XLM, reserves the following:
- * - Base reserve: 2 XLM (minimum account balance)
+ * - Minimum account reserve: (2 + subentries + sponsoring - sponsored) * baseReserve
  * - Transaction fees: ~0.00001 XLM per operation
- * - Subentry reserves: 0.5 XLM per trustline (if creating trustlines)
  *
  * @param instructions Payment instructions to validate
  * @param balancesMap Current account balances from Horizon
@@ -288,22 +304,18 @@ export function validateBalances(
   balancesMap: BalancesMap,
   estimatedOperations?: number,
   maxOperationsPerTransaction: number = 100,
+  options: BalanceValidationOptions = {},
 ): BalanceValidationResult {
   // Aggregate required amounts per asset
   const requiredByAsset: Record<string, number> = {};
   for (const instruction of instructions) {
     const key = resolveAssetKey(instruction.asset);
     requiredByAsset[key] =
-      (requiredByAsset[key] ?? 0) + Number(instruction.amount);
+      (requiredByAsset[key] ?? 0) + toNumberAmount(instruction.amount);
   }
 
   const checks = [];
   let allSufficient = true;
-
-  // Stellar constants
-  const BASE_RESERVE_XLM = 2; // minimum account balance
-  const FEE_PER_OPERATION_XLM = 0.00001; // stroops: 100 / 10^7
-  const SUBENTRY_RESERVE_XLM = 0.5; // per trustline
 
   // Calculate XLM reserves
   const finalOps = estimatedOperations !== undefined
@@ -311,7 +323,13 @@ export function validateBalances(
     : Math.max(instructions.length, 1);
 
   const transactionFees = finalOps * FEE_PER_OPERATION_XLM;
-  const xlmReserved = BASE_RESERVE_XLM + transactionFees;
+  const reserveEntries =
+    2 +
+    (options.subentryCount ?? 0) +
+    (options.numSponsoring ?? 0) -
+    (options.numSponsored ?? 0);
+  const minimumReserve = Math.max(0, reserveEntries) * (options.baseReserveXlm ?? DEFAULT_BASE_RESERVE_XLM);
+  const xlmReserved = minimumReserve + transactionFees;
 
   for (const [assetKey, required] of Object.entries(requiredByAsset)) {
     const available = balancesMap[assetKey] ?? 0; // missing trustline → zero

--- a/tests/balance-validation.test.ts
+++ b/tests/balance-validation.test.ts
@@ -26,6 +26,20 @@ describe('buildBalancesMap', () => {
     expect(map[`USDC:${validIssuer}`]).toBe(500);
   });
 
+  test('subtracts selling liabilities from spendable issued-asset balances', () => {
+    const map = buildBalancesMap([
+      {
+        asset_type: 'credit_alphanum4',
+        asset_code: 'USDC',
+        asset_issuer: validIssuer,
+        balance: '100.0000000',
+        selling_liabilities: '90.0000000',
+      },
+    ]);
+
+    expect(map[`USDC:${validIssuer}`]).toBe(10);
+  });
+
   test('returns empty map for empty balances', () => {
     const map = buildBalancesMap([]);
     expect(Object.keys(map)).toHaveLength(0);
@@ -73,6 +87,27 @@ describe('validateBalances', () => {
     expect(result.checks[0].required).toBe(999);
   });
 
+  test('issued-asset selling liabilities prevent overstating available funds', () => {
+    const balancesWithLiabilities = buildBalancesMap([
+      {
+        asset_type: 'credit_alphanum4',
+        asset_code: 'USDC',
+        asset_issuer: validIssuer,
+        balance: '100.0000000',
+        selling_liabilities: '90.0000000',
+      },
+    ]);
+    const payments: PaymentInstruction[] = [
+      { address: validAddress, amount: '20', asset: `USDC:${validIssuer}` },
+    ];
+
+    const result = validateBalances(payments, balancesWithLiabilities);
+
+    expect(result.all_sufficient).toBe(false);
+    expect(result.checks[0].available).toBe(10);
+    expect(result.checks[0].required).toBe(20);
+  });
+
   test('missing trustline treated as zero balance', () => {
     const payments: PaymentInstruction[] = [
       { address: validAddress, amount: '1', asset: `BTC:${validIssuer}` },
@@ -112,5 +147,21 @@ describe('validateBalances', () => {
     ];
     const result = validateBalances(payments, balancesMap);
     expect(result.all_sufficient).toBe(true);
+  });
+
+  test('XLM reserve reflects subentries and sponsorship instead of a fixed 2 XLM floor', () => {
+    const payments: PaymentInstruction[] = [
+      { address: validAddress, amount: '6', asset: 'XLM' },
+    ];
+    const result = validateBalances(payments, { XLM: 10 }, 1, 100, {
+      baseReserveXlm: 0.5,
+      subentryCount: 8,
+      numSponsoring: 2,
+      numSponsored: 1,
+    });
+
+    expect(result.all_sufficient).toBe(false);
+    expect(result.checks[0].xlm_reserved).toBeCloseTo(5.50001);
+    expect(result.checks[0].xlm_available_after_reserve).toBeCloseTo(4.49999);
   });
 });


### PR DESCRIPTION
## Summary
- subtract Horizon `selling_liabilities` when building spendable source balances
- calculate the native XLM reserve from account subentries/sponsorship plus the live ledger base reserve when building batches
- add regression coverage for the 100 USDC / 90 USDC liabilities scenario and dynamic XLM reserves

Fixes #713.

## Validation
- `npx vitest run tests/balance-validation.test.ts` passed: 15 tests
- `npm run typecheck` passed
- `git diff --check` passed

Note: initial `npm install` failed on this machine because `better-sqlite3@11.10.0` does not compile against local Node 26/V8; dependencies were installed with `npm install --ignore-scripts` for the targeted validator tests.