### PR TITLE
fix(vesting): enforce configured vesting contract ID and reject placeholder in dashboard submissions

### DIFF
--- a/app/dashboard/vesting/page.tsx
+++ b/app/dashboard/vesting/page.tsx
@@ -10,6 +10,7 @@ import { useWallet } from "@/contexts/WalletContext";
 import { toast } from "sonner";
 import type { PaymentInstruction } from "@/lib/stellar/types";
 import { buildDepositTransaction } from "@/lib/stellar/vesting";
+import { resolveVestingContractId } from "@/lib/stellar/vesting-config";
 import { parsePaymentFile } from "@/lib/stellar/parser";
 import { Networks, TransactionBuilder } from "stellar-sdk";
 import { t } from "@/lib/i18n";
@@ -153,7 +154,14 @@ export default function VestingPage() {
       const vestingStep = parseInt(vestingConfig.vestingStep);
       const cliffTime = startTime;
 
-      const contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+      let contractId: string;
+      try {
+        contractId = resolveVestingContractId(network);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Invalid vesting contract configuration";
+        toast.error(msg);
+        return;
+      }
 
       const unsignedXdr = await buildDepositTransaction(
         contractId,
@@ -237,6 +245,9 @@ export default function VestingPage() {
 
     try {
       setIsProcessing(true);
+      const network = expectedNetwork === "mainnet" ? "mainnet" : "testnet";
+      const contractId = resolveVestingContractId(network);
+
       const claimRes = await fetch("/api/vesting-claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -245,7 +256,7 @@ export default function VestingPage() {
           network: expectedNetwork,
           recipient: schedule.recipient,
           amount: schedule.claimableAmount,
-          contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+          contractId,
         }),
       });
 
@@ -274,6 +285,9 @@ export default function VestingPage() {
 
     try {
       setIsProcessing(true);
+      const network = expectedNetwork === "mainnet" ? "mainnet" : "testnet";
+      const contractId = resolveVestingContractId(network);
+
       const revokeRes = await fetch("/api/vesting-revoke", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -281,7 +295,7 @@ export default function VestingPage() {
           publicKey,
           network: expectedNetwork,
           recipients: schedules.map((s) => s.recipient),
-          contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+          contractId,
         }),
       });
 

--- a/lib/stellar/vesting-config.ts
+++ b/lib/stellar/vesting-config.ts
@@ -1,0 +1,45 @@
+import { StrKey } from "stellar-sdk";
+import type { Network } from "./types";
+
+function pickEnv(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (value && value.trim().length > 0) return value.trim();
+  }
+  return undefined;
+}
+
+const PLACEHOLDER_VESTING_CONTRACT_IDS = new Set([
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+]);
+
+function isPlaceholderVestingContractId(value: string): boolean {
+  return PLACEHOLDER_VESTING_CONTRACT_IDS.has(value);
+}
+
+export function resolveVestingContractId(network: Network): string {
+  const configuredValue = pickEnv(
+    `NEXT_PUBLIC_CONTRACT_ID_${network.toUpperCase()}`,
+    `CONTRACT_ID_${network.toUpperCase()}`,
+    "NEXT_PUBLIC_CONTRACT_ID",
+    "CONTRACT_ID",
+  );
+
+  if (!configuredValue) {
+    throw new Error(
+      `Vesting contract is not configured for ${network}. Set NEXT_PUBLIC_CONTRACT_ID_${network.toUpperCase()}, CONTRACT_ID_${network.toUpperCase()}, NEXT_PUBLIC_CONTRACT_ID, or CONTRACT_ID.`,
+    );
+  }
+
+  if (isPlaceholderVestingContractId(configuredValue)) {
+    throw new Error(
+      `Configured vesting contract ID for ${network} is a placeholder value. Set NEXT_PUBLIC_CONTRACT_ID_${network.toUpperCase()}, CONTRACT_ID_${network.toUpperCase()}, NEXT_PUBLIC_CONTRACT_ID, or CONTRACT_ID to your deployed contract address.`,
+    );
+  }
+
+  if (!StrKey.isValidContract(configuredValue)) {
+    throw new Error(`Invalid vesting contract ID for ${network}: ${configuredValue}`);
+  }
+
+  return configuredValue;
+}

--- a/tests/vesting-contract-config.test.ts
+++ b/tests/vesting-contract-config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { resolveVestingContractId } from "../lib/stellar/vesting-config";
+
+const VALID_CONTRACT_ID = "CAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQMCJ";
+const PLACEHOLDER_CONTRACT_ID = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+const ENV_KEYS = [
+  "NEXT_PUBLIC_CONTRACT_ID_TESTNET",
+  "NEXT_PUBLIC_CONTRACT_ID_MAINNET",
+  "NEXT_PUBLIC_CONTRACT_ID_FUTURENET",
+  "NEXT_PUBLIC_CONTRACT_ID",
+  "CONTRACT_ID_TESTNET",
+  "CONTRACT_ID_MAINNET",
+  "CONTRACT_ID_FUTURENET",
+  "CONTRACT_ID",
+];
+
+let snapshot: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  snapshot = {};
+  for (const key of ENV_KEYS) {
+    snapshot[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("resolveVestingContractId", () => {
+  test("prefers network-specific contract IDs over the generic fallback", () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = "C123";
+    process.env.NEXT_PUBLIC_CONTRACT_ID_TESTNET = VALID_CONTRACT_ID;
+
+    expect(resolveVestingContractId("testnet")).toBe(VALID_CONTRACT_ID);
+  });
+
+  test("falls back to the generic public contract ID when no network-specific value is set", () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID = VALID_CONTRACT_ID;
+
+    expect(resolveVestingContractId("mainnet")).toBe(VALID_CONTRACT_ID);
+  });
+
+  test("throws an actionable error when the contract is missing or invalid", () => {
+    expect(() => resolveVestingContractId("testnet")).toThrow(
+      "Vesting contract is not configured for testnet. Set NEXT_PUBLIC_CONTRACT_ID_TESTNET, CONTRACT_ID_TESTNET, NEXT_PUBLIC_CONTRACT_ID, or CONTRACT_ID.",
+    );
+
+    process.env.NEXT_PUBLIC_CONTRACT_ID_TESTNET = "not-a-contract";
+
+    expect(() => resolveVestingContractId("testnet")).toThrow(
+      "Invalid vesting contract ID for testnet",
+    );
+  });
+
+  test("throws an actionable error when the configured contract ID is the placeholder value", () => {
+    process.env.NEXT_PUBLIC_CONTRACT_ID_TESTNET = PLACEHOLDER_CONTRACT_ID;
+
+    expect(() => resolveVestingContractId("testnet")).toThrow(
+      "Configured vesting contract ID for testnet is a placeholder value.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes the vesting dashboard so it resolves the contract ID from configuration instead of relying on a hard-coded placeholder address. It also adds validation to block submission whenever the vesting contract configuration is missing, invalid, or still set to the placeholder value, preventing transactions from being sent to an incorrect or non-existent contract.

## Why
Previously, the vesting dashboard used a placeholder contract ID directly in `page.tsx`. If the real environment configuration was never set (or was set incorrectly), the app would silently attempt to interact with the wrong contract, only failing at the wallet signature step or, worse, succeeding against an unintended address. This PR closes that gap by centralizing contract resolution and validating it before any wallet interaction is triggered.

## What Changed

**`vesting-config.ts`**
- Added `resolveVestingContractId(network)` to centralize contract ID resolution.
- Resolution order:
  1. `NEXT_PUBLIC_CONTRACT_ID_<NETWORK>`
  2. `CONTRACT_ID_<NETWORK>`
  3. `NEXT_PUBLIC_CONTRACT_ID`
  4. `CONTRACT_ID`
- Throws clear, actionable errors for:
  - Missing configuration
  - Invalid contract IDs
  - Placeholder contract IDs left unconfigured

**`page.tsx`**
- Replaced the hard-coded placeholder contract ID with a call to `resolveVestingContractId(network)`.
- Ensures the deposit, claim, and revoke flows all consistently target the correctly configured contract.
- Surfaces a toast error to the user *before* a wallet signature is requested if the configuration is invalid, avoiding unnecessary wallet prompts for a doomed transaction.

**`vesting-contract-config.test.ts`**
- Added regression tests covering:
  - Rejection of placeholder contract IDs
  - Network-specific resolution and fallback to generic env vars
  - Handling of missing and invalid configuration

## Testing
- `npx vitest run tests/vesting-contract-config.test.ts` ✅
- `npx vitest run vesting-contract-config.test.ts tests/vesting.test.ts` ✅

## Notes for Reviewers
This change is backward-compatible for any environment that already has `CONTRACT_ID` or `NEXT_PUBLIC_CONTRACT_ID` set correctly. Environments relying on the old placeholder will now fail fast with a clear error instead of silently using an incorrect address.

Closes #715