### PR TITLE
fix: wire vesting claim/revoke through Soroban client builders

### DIFF
--- a/app/dashboard/vesting/page.tsx
+++ b/app/dashboard/vesting/page.tsx
@@ -9,7 +9,12 @@ import { DashboardWalletEmpty } from "@/components/dashboard/dashboard-wallet-em
 import { useWallet } from "@/contexts/WalletContext";
 import { toast } from "sonner";
 import type { PaymentInstruction } from "@/lib/stellar/types";
-import { buildDepositTransaction } from "@/lib/stellar/vesting";
+import {
+  buildBatchRevokeTransaction,
+  buildClaimTransaction,
+  buildDepositTransaction,
+  buildRevokeTransaction,
+} from "@/lib/stellar/vesting";
 import { resolveVestingContractId } from "@/lib/stellar/vesting-config";
 import { parsePaymentFile } from "@/lib/stellar/parser";
 import { Networks, TransactionBuilder } from "stellar-sdk";
@@ -17,6 +22,8 @@ import { t } from "@/lib/i18n";
 
 interface VestingSchedule {
   id: string;
+  /** On-chain schedule index for this recipient (per-recipient, not batch row). */
+  index: number;
   recipient: string;
   amount: string;
   asset: string;
@@ -81,13 +88,19 @@ export default function VestingPage() {
 
       const schedules: VestingSchedule[] = [];
       const recipients = new Set<string>();
+      // Per-recipient on-chain indices (push_vesting appends; unique recipients
+      // each start at 0 within a fresh batch).
+      const recipientNextIndex = new Map<string, number>();
       let totalAmount = "0";
 
       for (let i = 0; i < parsedFile.validPayments.length; i++) {
         const payment = parsedFile.validPayments[i];
         recipients.add(payment.address);
+        const index = recipientNextIndex.get(payment.address) ?? 0;
+        recipientNextIndex.set(payment.address, index + 1);
         schedules.push({
           id: `${i}`,
+          index,
           recipient: payment.address,
           amount: payment.amount,
           asset: payment.asset || "XLM",
@@ -123,6 +136,47 @@ export default function VestingPage() {
     } finally {
       setIsUploading(false);
     }
+  };
+
+  /**
+   * Sign an assembled Soroban XDR with the connected wallet and submit it
+   * via RPC, polling briefly for confirmation. Returns the transaction hash.
+   */
+  const signAndSubmitXdr = async (
+    unsignedXdr: string,
+    network: "testnet" | "mainnet",
+  ): Promise<{ hash: string; confirmed: boolean }> => {
+    const signedXdr = await signTx(unsignedXdr, network);
+
+    const { rpc: SorobanRpc } = await import("stellar-sdk");
+    const rpcUrl =
+      network === "testnet"
+        ? "https://soroban-testnet.stellar.org"
+        : "https://soroban-mainnet.stellar.org";
+    const server = new SorobanRpc.Server(rpcUrl, { allowHttp: false });
+
+    const networkPassphrase =
+      network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+    const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+    const sendResult = await server.sendTransaction(tx);
+
+    if (sendResult.status !== "PENDING" && sendResult.status !== "DUPLICATE") {
+      throw new Error(`Transaction submission failed: ${sendResult.status}`);
+    }
+
+    const hash = sendResult.hash;
+    for (let i = 0; i < 30; i++) {
+      await new Promise((r) => setTimeout(r, 2000));
+      const getResult = await server.getTransaction(hash);
+      if (getResult.status === "SUCCESS") {
+        return { hash, confirmed: true };
+      }
+      if (getResult.status === "FAILED") {
+        throw new Error("Transaction failed on-chain");
+      }
+    }
+
+    return { hash, confirmed: false };
   };
 
   const handleSubmitBatch = async () => {
@@ -174,60 +228,25 @@ export default function VestingPage() {
         publicKey,
       );
 
-      const signedXdr = await signTx(unsignedXdr, network);
+      const { hash: txHash, confirmed } = await signAndSubmitXdr(unsignedXdr, network);
 
-      const { rpc: SorobanRpc } = await import("stellar-sdk");
-      const rpcUrl = network === "testnet"
-        ? "https://soroban-testnet.stellar.org"
-        : "https://soroban-mainnet.stellar.org";
-      const server = new SorobanRpc.Server(rpcUrl, { allowHttp: false });
-
-      const networkPassphrase =
-        network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-      const tx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
-      const sendResult = await server.sendTransaction(tx);
-
-      if (sendResult.status === "PENDING" || sendResult.status === "DUPLICATE") {
-        const hash = sendResult.hash;
-
-        // Poll for confirmation
-        let txConfirmed = false;
-        let txHash = hash;
-        for (let i = 0; i < 30; i++) {
-          await new Promise((r) => setTimeout(r, 2000));
-          const getResult = await server.getTransaction(hash);
-          if (getResult.status === "SUCCESS") {
-            txConfirmed = true;
-            txHash = getResult.envelopeXdr
-              ? hash
-              : hash;
-            break;
-          }
-          if (getResult.status === "FAILED") {
-            throw new Error("Transaction failed on-chain");
-          }
-        }
-
-        if (!txConfirmed) {
-          toast.warning("Transaction submitted but not yet confirmed. Check history for updates.");
-        }
-
-        const submittedBatch: VestingBatch = {
-          ...currentBatch,
-          status: "submitted",
-          schedules: currentBatch.schedules.map((s) => ({
-            ...s,
-            status: "vesting" as const,
-            transactionHash: txHash,
-          })),
-        };
-        setBatches([...batches, submittedBatch]);
-        setCurrentBatch(null);
-        toast.success(t("vesting.submittedSuccess"));
-        setActiveTab("manage");
-      } else {
-        throw new Error(`Transaction submission failed: ${sendResult.status}`);
+      if (!confirmed) {
+        toast.warning("Transaction submitted but not yet confirmed. Check history for updates.");
       }
+
+      const submittedBatch: VestingBatch = {
+        ...currentBatch,
+        status: "submitted",
+        schedules: currentBatch.schedules.map((s) => ({
+          ...s,
+          status: "vesting" as const,
+          transactionHash: txHash,
+        })),
+      };
+      setBatches([...batches, submittedBatch]);
+      setCurrentBatch(null);
+      toast.success(t("vesting.submittedSuccess"));
+      setActiveTab("manage");
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Submission failed";
       toast.error(msg);
@@ -248,34 +267,60 @@ export default function VestingPage() {
       const network = expectedNetwork === "mainnet" ? "mainnet" : "testnet";
       const contractId = resolveVestingContractId(network);
 
-      const claimRes = await fetch("/api/vesting-claim", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          publicKey,
-          network: expectedNetwork,
-          recipient: schedule.recipient,
-          amount: schedule.claimableAmount,
-          contractId,
-        }),
-      });
+      // claim(recipient, index, amount) — index is required by the contract ABI.
+      const unsignedXdr = await buildClaimTransaction(
+        contractId,
+        schedule.recipient,
+        schedule.index,
+        schedule.claimableAmount,
+        network,
+        publicKey,
+        schedule.asset,
+      );
 
-      if (claimRes.ok) {
-        toast.success("Claim submitted successfully");
+      const { hash: txHash, confirmed } = await signAndSubmitXdr(unsignedXdr, network);
+
+      setBatches((prev) =>
+        prev.map((batch) => ({
+          ...batch,
+          schedules: batch.schedules.map((s) =>
+            s.id === schedule.id && s.recipient === schedule.recipient
+              ? {
+                  ...s,
+                  claimedAmount: (
+                    parseFloat(s.claimedAmount) + parseFloat(s.claimableAmount)
+                  ).toString(),
+                  claimableAmount: "0",
+                  status: "completed" as const,
+                  transactionHash: txHash,
+                }
+              : s,
+          ),
+        })),
+      );
+
+      if (!confirmed) {
+        toast.warning("Claim submitted but not yet confirmed. Check history for updates.");
       } else {
-        throw new Error("Failed to claim vesting");
+        toast.success("Claim submitted successfully");
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Claim failed";
       toast.error(msg);
+      console.error(err);
     } finally {
       setIsProcessing(false);
     }
   };
 
-  const handleRevoke = async (schedules: VestingSchedule[]) => {
+  const handleRevoke = async (schedules: VestingSchedule[], batchId: string) => {
     if (!publicKey) {
       toast.error(t("common.walletNotConnected"));
+      return;
+    }
+
+    if (schedules.length === 0) {
+      toast.error("No schedules to revoke");
       return;
     }
 
@@ -288,25 +333,40 @@ export default function VestingPage() {
       const network = expectedNetwork === "mainnet" ? "mainnet" : "testnet";
       const contractId = resolveVestingContractId(network);
 
-      const revokeRes = await fetch("/api/vesting-revoke", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          publicKey,
-          network: expectedNetwork,
-          recipients: schedules.map((s) => s.recipient),
-          contractId,
-        }),
-      });
+      // revoke(caller, recipient, index) or batch_revoke(caller, requests)
+      // — both require exact schedule indices, not just recipient addresses.
+      const unsignedXdr =
+        schedules.length === 1
+          ? await buildRevokeTransaction(
+              contractId,
+              schedules[0].recipient,
+              schedules[0].index,
+              network,
+              publicKey,
+            )
+          : await buildBatchRevokeTransaction(
+              contractId,
+              schedules.map((s) => ({
+                recipient: s.recipient,
+                index: s.index,
+              })),
+              network,
+              publicKey,
+            );
 
-      if (revokeRes.ok) {
-        toast.success("Vesting schedules revoked successfully");
+      const { confirmed } = await signAndSubmitXdr(unsignedXdr, network);
+
+      setBatches((prev) => prev.filter((b) => b.id !== batchId));
+
+      if (!confirmed) {
+        toast.warning("Revoke submitted but not yet confirmed. Check history for updates.");
       } else {
-        throw new Error("Failed to revoke vesting");
+        toast.success("Vesting schedules revoked successfully");
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Revoke failed";
       toast.error(msg);
+      console.error(err);
     } finally {
       setIsProcessing(false);
     }
@@ -546,7 +606,7 @@ export default function VestingPage() {
                   </div>
                   <div className="flex gap-2">
                     <Button
-                      onClick={() => handleRevoke(batch.schedules)}
+                      onClick={() => handleRevoke(batch.schedules, batch.id)}
                       variant="destructive"
                       className="w-full"
                       disabled={isProcessing}

--- a/lib/stellar/index.ts
+++ b/lib/stellar/index.ts
@@ -30,10 +30,13 @@ export {
   buildDepositTransaction,
   buildClaimTransaction,
   buildRevokeTransaction,
+  buildBatchRevokeTransaction,
+  sortRevokeRequestsDescending,
   buildTransferVestingRightsTransaction,
   buildBumpInstanceTtlTransaction,
   buildBumpVestingTtlTransaction,
 } from './vesting';
+export type { VestingRevokeRequest } from './vesting';
 export {
   parseVestingClaimedPayload,
   parseVestingDeposited,

--- a/lib/stellar/vesting.ts
+++ b/lib/stellar/vesting.ts
@@ -420,6 +420,72 @@ export async function buildRevokeTransaction(
   return buildSorobanTransaction(contractId, operation, network, publicKey);
 }
 
+/** One (recipient, index) pair for {@link buildBatchRevokeTransaction}. */
+export interface VestingRevokeRequest {
+  recipient: string;
+  index: number;
+}
+
+/**
+ * Encode a contract `RevokeRequest { recipient, index }` as an ScMap.
+ * Map keys are sorted alphabetically (`index` before `recipient`) as required
+ * by the Soroban XDR encoding rules.
+ */
+function revokeRequestToScVal(request: VestingRevokeRequest): xdr.ScVal {
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("index"),
+      val: nativeToScVal(request.index, { type: "u32" }),
+    }),
+    new xdr.ScMapEntry({
+      key: xdr.ScVal.scvSymbol("recipient"),
+      val: new Address(request.recipient).toScVal(),
+    }),
+  ]);
+}
+
+/**
+ * Sort revoke requests so each recipient's indices appear in strictly
+ * descending order — required by `batch_revoke` / `revoke_batch` (#308/#505).
+ * Recipients are grouped for a stable, deterministic order.
+ */
+export function sortRevokeRequestsDescending(
+  requests: VestingRevokeRequest[],
+): VestingRevokeRequest[] {
+  return [...requests].sort((a, b) => {
+    if (a.recipient !== b.recipient) {
+      return a.recipient < b.recipient ? -1 : 1;
+    }
+    return b.index - a.index;
+  });
+}
+
+/**
+ * Build an unsigned transaction to revoke multiple vesting schedules in one
+ * `batch_revoke(caller, requests)` call. Requests are sorted into the
+ * strictly-descending-per-recipient order the contract requires.
+ */
+export async function buildBatchRevokeTransaction(
+  contractId: string,
+  requests: VestingRevokeRequest[],
+  network: "testnet" | "mainnet",
+  publicKey: string,
+): Promise<string> {
+  if (requests.length === 0) {
+    throw new Error("batch_revoke requires at least one (recipient, index) pair");
+  }
+
+  const sorted = sortRevokeRequestsDescending(requests);
+  const contract = new Contract(contractId);
+  const operation = contract.call(
+    "batch_revoke",
+    new Address(publicKey).toScVal(),
+    xdr.ScVal.scvVec(sorted.map(revokeRequestToScVal)),
+  );
+
+  return buildSorobanTransaction(contractId, operation, network, publicKey);
+}
+
 /**
  * Build an unsigned transaction to bump the contract instance TTL.
  */

--- a/tests/vesting-claim-revoke.test.ts
+++ b/tests/vesting-claim-revoke.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression: vesting claim/revoke must use client-side Soroban builders with
+ * the full contract ABI (recipient + index + amount / caller + indices), not
+ * POST to missing `/api/vesting-claim` or `/api/vesting-revoke` routes.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { Contract, Keypair, xdr, scValToNative } from "stellar-sdk";
+
+const VALID_CONTRACT_ID =
+  "CAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQMCJ";
+
+const VESTING_PAGE = path.join(
+  process.cwd(),
+  "app",
+  "dashboard",
+  "vesting",
+  "page.tsx",
+);
+const PAGE_SOURCE = readFileSync(VESTING_PAGE, "utf8");
+
+vi.mock("stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("stellar-sdk")>();
+
+  class FakeServer {
+    constructor(_url: string, _opts?: { allowHttp?: boolean }) {}
+
+    async getAccount(id: string) {
+      return new actual.Account(id, "12345");
+    }
+
+    async simulateTransaction() {
+      return {
+        transactionData: { resourceFee: () => 100n },
+        minResourceFee: "100",
+        latestLedger: 1,
+      };
+    }
+  }
+
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: FakeServer,
+      assembleTransaction: vi.fn((tx: unknown) => ({
+        build: () => tx,
+      })),
+      Api: {
+        ...(actual.rpc?.Api ?? {}),
+        isSimulationError: vi.fn(() => false),
+      },
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("vesting page claim/revoke wiring", () => {
+  test("does not POST to missing /api/vesting-claim or /api/vesting-revoke", () => {
+    expect(PAGE_SOURCE).not.toMatch(/\/api\/vesting-claim/);
+    expect(PAGE_SOURCE).not.toMatch(/\/api\/vesting-revoke/);
+  });
+
+  test("imports client-side claim and revoke builders", () => {
+    expect(PAGE_SOURCE).toMatch(/buildClaimTransaction/);
+    expect(PAGE_SOURCE).toMatch(/buildRevokeTransaction/);
+    expect(PAGE_SOURCE).toMatch(/buildBatchRevokeTransaction/);
+  });
+
+  test("passes schedule index into claim and revoke builders", () => {
+    expect(PAGE_SOURCE).toMatch(
+      /buildClaimTransaction\(\s*contractId,\s*schedule\.recipient,\s*schedule\.index,\s*schedule\.claimableAmount/s,
+    );
+    expect(PAGE_SOURCE).toMatch(
+      /buildRevokeTransaction\(\s*contractId,\s*schedules\[0\]\.recipient,\s*schedules\[0\]\.index/s,
+    );
+    expect(PAGE_SOURCE).toMatch(/index:\s*s\.index/);
+  });
+
+  test("tracks per-recipient on-chain schedule index on VestingSchedule", () => {
+    expect(PAGE_SOURCE).toMatch(/index:\s*number/);
+    expect(PAGE_SOURCE).toMatch(/recipientNextIndex/);
+  });
+});
+
+describe("buildClaimTransaction ABI (recipient, index, amount)", () => {
+  test("claim passes recipient, index, and amount in order", async () => {
+    const callSpy = vi.spyOn(Contract.prototype, "call");
+    const { buildClaimTransaction } = await import("../lib/stellar/vesting");
+
+    const recipient = Keypair.random().publicKey();
+    const signer = Keypair.random().publicKey();
+
+    await buildClaimTransaction(
+      VALID_CONTRACT_ID,
+      recipient,
+      2,
+      "1.5",
+      "testnet",
+      signer,
+    ).catch(() => undefined);
+
+    expect(callSpy).toHaveBeenCalled();
+    const claimCall = callSpy.mock.calls.find(([fn]) => fn === "claim");
+    expect(claimCall).toBeDefined();
+    const [, ...args] = claimCall!;
+    expect(args).toHaveLength(3);
+    expect(scValToNative(args[0] as xdr.ScVal)).toBe(recipient);
+    expect(Number(scValToNative(args[1] as xdr.ScVal))).toBe(2);
+    expect(scValToNative(args[2] as xdr.ScVal)).toBe(15_000_000n);
+    callSpy.mockRestore();
+  });
+});
+
+describe("buildRevokeTransaction / buildBatchRevokeTransaction ABI", () => {
+  test("single revoke passes caller, recipient, and index", async () => {
+    const callSpy = vi.spyOn(Contract.prototype, "call");
+    const { buildRevokeTransaction } = await import("../lib/stellar/vesting");
+
+    const recipient = Keypair.random().publicKey();
+    const caller = Keypair.random().publicKey();
+
+    await buildRevokeTransaction(
+      VALID_CONTRACT_ID,
+      recipient,
+      4,
+      "testnet",
+      caller,
+    ).catch(() => undefined);
+
+    const revokeCall = callSpy.mock.calls.find(([fn]) => fn === "revoke");
+    expect(revokeCall).toBeDefined();
+    const [, ...args] = revokeCall!;
+    expect(args).toHaveLength(3);
+    expect(scValToNative(args[0] as xdr.ScVal)).toBe(caller);
+    expect(scValToNative(args[1] as xdr.ScVal)).toBe(recipient);
+    expect(Number(scValToNative(args[2] as xdr.ScVal))).toBe(4);
+    callSpy.mockRestore();
+  });
+
+  test("batch_revoke passes caller and exact schedule indices (descending)", async () => {
+    const callSpy = vi.spyOn(Contract.prototype, "call");
+    const {
+      buildBatchRevokeTransaction,
+      sortRevokeRequestsDescending,
+    } = await import("../lib/stellar/vesting");
+
+    const recipientA = Keypair.random().publicKey();
+    const recipientB = Keypair.random().publicKey();
+    const caller = Keypair.random().publicKey();
+
+    const requests = [
+      { recipient: recipientA, index: 0 },
+      { recipient: recipientA, index: 2 },
+      { recipient: recipientA, index: 1 },
+      { recipient: recipientB, index: 0 },
+    ];
+
+    const sorted = sortRevokeRequestsDescending(requests);
+    // Same-recipient indices must be strictly descending.
+    const aIndices = sorted
+      .filter((r) => r.recipient === recipientA)
+      .map((r) => r.index);
+    expect(aIndices).toEqual([2, 1, 0]);
+
+    await buildBatchRevokeTransaction(
+      VALID_CONTRACT_ID,
+      requests,
+      "testnet",
+      caller,
+    ).catch(() => undefined);
+
+    const batchCall = callSpy.mock.calls.find(([fn]) => fn === "batch_revoke");
+    expect(batchCall).toBeDefined();
+    const [, callerArg, requestsArg] = batchCall!;
+    expect(scValToNative(callerArg as xdr.ScVal)).toBe(caller);
+
+    const decoded = scValToNative(requestsArg as xdr.ScVal) as Array<{
+      recipient: string;
+      index: number | bigint;
+    }>;
+    expect(decoded).toHaveLength(4);
+
+    const decodedA = decoded.filter((r) => r.recipient === recipientA);
+    expect(decodedA.map((r) => Number(r.index))).toEqual([2, 1, 0]);
+
+    const decodedB = decoded.filter((r) => r.recipient === recipientB);
+    expect(decodedB.map((r) => Number(r.index))).toEqual([0]);
+
+    callSpy.mockRestore();
+  });
+
+  test("batch_revoke rejects an empty request list before RPC", async () => {
+    const { buildBatchRevokeTransaction } = await import(
+      "../lib/stellar/vesting"
+    );
+    const caller = Keypair.random().publicKey();
+
+    await expect(
+      buildBatchRevokeTransaction(VALID_CONTRACT_ID, [], "testnet", caller),
+    ).rejects.toThrow(/at least one/);
+  });
+});


### PR DESCRIPTION
## Summary

Vesting **Claim** and **Revoke** controls on the dashboard always failed because they POSTed to API routes that do not exist (`/api/vesting-claim`, `/api/vesting-revoke`), and even if those routes had existed the payloads were missing fields required by the deployed contract ABI.

This PR fixes that by routing claim/revoke through the existing client-side Soroban builders (same pattern as deposit): assemble + simulate → wallet-sign → submit via Soroban RPC. Calls now include the schedule indices and other ABI-required arguments.

## Problem

- `handleClaim` called `POST /api/vesting-claim`
- `handleRevoke` called `POST /api/vesting-revoke`
- Neither route exists under `app/api`, so Next.js returned **404** and the UI showed a generic failure
- Claim omitted the schedule `index` required by `claim(recipient, index, amount)`
- Revoke sent only recipient addresses and omitted the per-schedule indices needed to identify schedules on-chain

**Severity:** Medium  
**Location:** `app/dashboard/vesting/page.tsx`

## Solution

### Dashboard vesting page (`app/dashboard/vesting/page.tsx`)

- Removed fetches to the missing claim/revoke API routes
- **Claim** now builds an unsigned tx with `buildClaimTransaction(contractId, recipient, index, amount, network, publicKey, asset)`, then signs and submits
- **Revoke** now:
  - 1 schedule → `buildRevokeTransaction(...)` → `revoke(caller, recipient, index)`
  - 2+ schedules → `buildBatchRevokeTransaction(...)` → `batch_revoke(caller, requests)`
- Added an explicit per-recipient on-chain `index` on `VestingSchedule` (not CSV row order). Indices are assigned the same way the contract appends via `push_vesting` within a fresh batch
- Extracted shared `signAndSubmitXdr` helper used by deposit, claim, and revoke (wallet sign + RPC submit + short confirmation poll)
- On success, claim updates local schedule state; revoke removes the affected batch from local state

### Soroban builders (`lib/stellar/vesting.ts`)

- Added `VestingRevokeRequest`, `sortRevokeRequestsDescending`, and `buildBatchRevokeTransaction`
- Batch revoke requests are encoded as `RevokeRequest { recipient, index }` ScMaps and sorted so each recipient’s indices are **strictly descending**, matching contract requirements (`#308` / `#505`)
- Empty batch revoke input is rejected before any RPC call
- New helpers exported from `lib/stellar/index.ts`

## Contract ABI alignment

| Action | Contract function | Arguments now supplied |
|---|---|---|
| Claim | `claim` | `recipient`, `index`, `amount` (+ asset decimals via existing builder) |
| Single revoke | `revoke` | `caller` (connected wallet), `recipient`, `index` |
| Multi revoke | `batch_revoke` | `caller`, `Vec<RevokeRequest { recipient, index }>` (descending per recipient) |

## Files changed

- `app/dashboard/vesting/page.tsx` — claim/revoke client flow + schedule index tracking
- `lib/stellar/vesting.ts` — batch revoke builder + request sorting/encoding
- `lib/stellar/index.ts` — public exports
- `tests/vesting-claim-revoke.test.ts` — regression coverage for this failure mode

## Acceptance criteria

- [x] Claim invokes `claim` with `recipient`, `index`, and `amount`
- [x] Revoke invokes the correct revoke function with `caller` and exact schedule indices
- [x] Regression test added covering this exact scenario
- [x] Existing vesting-related tests continue to pass

## Test plan

**Automated**
- [x] `npx vitest run tests/vesting-claim-revoke.test.ts`
- [x] `npx vitest run tests/vesting.test.ts tests/vesting-token-decimals.test.ts tests/vesting-events.test.ts tests/vesting-contract-config.test.ts`
- [x] `npm run typecheck`

**Manual (testnet + connected wallet)**
- [x] Open Dashboard → Vesting → Claims, claim a schedule with claimable balance
- [x] Confirm the browser does **not** call `/api/vesting-claim` (no 404)
- [x] Confirm Freighter (or connected wallet) prompts to sign a Soroban `claim` transaction including recipient, index, and amount
- [x] On Manage, revoke a batch with a single schedule and confirm a `revoke` tx is signed/submitted
- [x] Revoke a batch with multiple schedules and confirm a `batch_revoke` tx is signed/submitted
- [x] Confirm success toast on confirmed submit, and warning toast if still pending after poll
- [x] Confirm error toast + no false success when simulation/submission fails
- [x] Confirm deposit flow still works after shared `signAndSubmitXdr` refactor

## Notes / follow-ups

- Schedule indices in the UI are tracked for batches created in the current session. If a recipient already has prior on-chain schedules outside this session, resolving absolute indices would require an on-chain lookup (out of scope for this fix).
- No new server API routes were added; mediation stays client-side to match deposit and avoid incomplete server payloads.



Closes #716 