### PR TITLE
fix: prevent overlapping batch submissions during active jobs

### DIFF
--- a/components/dashboard/BatchReview.tsx
+++ b/components/dashboard/BatchReview.tsx
@@ -42,6 +42,7 @@ interface BatchReviewProps {
   onSkipToggle?: (index: number) => void;
   onConvertToggle?: (index: number) => void;
   onSubmit?: (filteredPayments: PaymentInstruction[]) => Promise<void>;
+  hasActiveJob?: boolean;
 }
 
 export function BatchReview(props: BatchReviewProps) {
@@ -54,10 +55,13 @@ export function BatchReview(props: BatchReviewProps) {
   const onSkipToggle = props.onSkipToggle ?? context.onSkipToggle;
   const onConvertToggle = props.onConvertToggle ?? context.onConvertToggle;
   const onSubmit = props.onSubmit ?? context.onSubmit;
+  // Reflects the job's full lifecycle (queued -> processing -> terminal), not
+  // just whether the initial /api/batch-submit request is in flight, so the
+  // button stays locked until the background job actually finishes (#698).
+  const isSubmitting = props.hasActiveJob ?? context.hasActiveJob;
   const { publicKey } = useWallet();
   const { balances, loading: balancesLoading } = useBalances();
   const [selectedAsset, setSelectedAsset] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Determine unique assets in payments
@@ -153,19 +157,14 @@ export function BatchReview(props: BatchReviewProps) {
   );
 
   const handleSubmit = async () => {
-    if (!publicKey) {
+    if (!publicKey || isSubmitting) {
       return;
     }
     const filteredPayments = payments.filter(
       (_, idx) =>
         !skippedIndices.includes(idx) && !convertedIndices.includes(idx),
     );
-    setIsSubmitting(true);
-    try {
-      await onSubmit(filteredPayments);
-    } finally {
-      setIsSubmitting(false);
-    }
+    await onSubmit(filteredPayments);
   };
 
   // Debounced trustline refetch (300ms) when recipient list or asset changes

--- a/contexts/BatchFlowContext.tsx
+++ b/contexts/BatchFlowContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from "react";
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useWallet } from "@/contexts/WalletContext";
@@ -9,6 +9,7 @@ import { batchHistoryKeys, dashboardMetricsKeys } from "@/lib/query-keys";
 import { parsePaymentFile, analyzeParsedPayments } from "@/lib/stellar/parser";
 import { getBatchSummary } from "@/lib/stellar/summary";
 import { canonicalizeIdempotencyPayload } from "@/lib/idempotency";
+import { isSubmissionBlocked } from "@/lib/stellar/job-lifecycle";
 import type {
   ParsedPaymentFile,
   BatchResult,
@@ -65,6 +66,7 @@ interface BatchFlowContextType {
   setSummary: (summary: any) => void;
   isSubmitting: boolean;
   setIsSubmitting: (submitting: boolean) => void;
+  hasActiveJob: boolean;
   result: BatchResult | null;
   setResult: (res: BatchResult | null) => void;
   jobId: string | null;
@@ -420,8 +422,19 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
     setStep(2);
   }, [manualPayments]);
 
+  const hasActiveJob = useMemo(
+    () => isSubmissionBlocked({ isSubmitting, jobId, jobStatus }),
+    [isSubmitting, jobId, jobStatus],
+  );
+
   const onSubmit = useCallback(async (filteredPayments: PaymentInstruction[]) => {
     if (!publicKey) return;
+    if (isSubmissionBlocked({ isSubmitting, jobId, jobStatus })) {
+      toast.error(
+        "A batch submission is already in progress. Please wait for it to finish before submitting again.",
+      );
+      return;
+    }
     setIsSubmitting(true);
     try {
       const response = await fetch("/api/batch-submit", {
@@ -458,7 +471,7 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
           : "Failed to submit batch",
       );
     }
-  }, [publicKey, network, startPolling]);
+  }, [publicKey, network, startPolling, isSubmitting, jobId, jobStatus]);
 
   return (
     <BatchFlowContext.Provider
@@ -479,6 +492,7 @@ export function BatchFlowProvider({ children }: { children: React.ReactNode }) {
         setSummary,
         isSubmitting,
         setIsSubmitting,
+        hasActiveJob,
         result,
         setResult,
         jobId,

--- a/lib/stellar/job-lifecycle.ts
+++ b/lib/stellar/job-lifecycle.ts
@@ -1,0 +1,25 @@
+import type { JobStatus } from "./types";
+
+const ACTIVE_JOB_STATUSES: ReadonlySet<JobStatus> = new Set(["queued", "processing"]);
+
+export function isActiveJobStatus(status: JobStatus): boolean {
+  return ACTIVE_JOB_STATUSES.has(status);
+}
+
+/**
+ * A batch job counts as "active" from the moment submission starts (before
+ * a jobId even exists) through queued/processing, and stops being active
+ * once it reaches a terminal status. UI that gates re-submission should key
+ * off this, not a component-local flag that clears as soon as the initial
+ * queue request resolves (#698).
+ */
+export function isSubmissionBlocked(params: {
+  isSubmitting: boolean;
+  jobId: string | null;
+  jobStatus: JobStatus;
+}): boolean {
+  return (
+    params.isSubmitting ||
+    (params.jobId !== null && isActiveJobStatus(params.jobStatus))
+  );
+}

--- a/tests/batch-submit-lock.test.ts
+++ b/tests/batch-submit-lock.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression guard for #698.
+ *
+ * The "Submit Batch" button used to re-enable as soon as the initial
+ * /api/batch-submit request resolved, even though the payment job kept
+ * running (queued -> processing) in the background. That let a user tweak
+ * the review selection and fire a second, overlapping submission with a
+ * different idempotency key, producing duplicate payments.
+ *
+ * `isSubmissionBlocked` is the pure decision function both BatchFlowContext
+ * (to guard re-entrant onSubmit calls) and BatchReview (to disable the
+ * button) key off of. It stays blocked from the moment submission starts
+ * until the job reaches a terminal status, regardless of anything else
+ * (like review-selection edits) changing in the meantime.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  isActiveJobStatus,
+  isSubmissionBlocked,
+} from "../lib/stellar/job-lifecycle";
+import type { JobStatus } from "../lib/stellar/types";
+
+describe("isActiveJobStatus", () => {
+  test("queued and processing are active", () => {
+    expect(isActiveJobStatus("queued")).toBe(true);
+    expect(isActiveJobStatus("processing")).toBe(true);
+  });
+
+  test("completed and failed are terminal, not active", () => {
+    expect(isActiveJobStatus("completed")).toBe(false);
+    expect(isActiveJobStatus("failed")).toBe(false);
+  });
+});
+
+describe("isSubmissionBlocked", () => {
+  test("allows submission from a fresh, never-submitted state", () => {
+    expect(
+      isSubmissionBlocked({ isSubmitting: false, jobId: null, jobStatus: "queued" }),
+    ).toBe(false);
+  });
+
+  test("blocks a second submit while the initial request is still in flight (no jobId yet)", () => {
+    expect(
+      isSubmissionBlocked({ isSubmitting: true, jobId: null, jobStatus: "queued" }),
+    ).toBe(true);
+  });
+
+  test("stays blocked while the job is queued", () => {
+    expect(
+      isSubmissionBlocked({ isSubmitting: true, jobId: "job-1", jobStatus: "queued" }),
+    ).toBe(true);
+  });
+
+  test("stays blocked while the job is processing", () => {
+    expect(
+      isSubmissionBlocked({ isSubmitting: true, jobId: "job-1", jobStatus: "processing" }),
+    ).toBe(true);
+  });
+
+  test("a completed job re-enables submission", () => {
+    expect(
+      isSubmissionBlocked({ isSubmitting: false, jobId: "job-1", jobStatus: "completed" }),
+    ).toBe(false);
+  });
+
+  test("a failed job re-enables submission", () => {
+    expect(
+      isSubmissionBlocked({ isSubmitting: false, jobId: "job-1", jobStatus: "failed" }),
+    ).toBe(false);
+  });
+
+  test("stays blocked across every active status even if isSubmitting has already flipped false", () => {
+    // Guards against relying on isSubmitting alone: once a jobId exists, an
+    // active jobStatus alone must be enough to keep submission locked.
+    const activeStatuses: JobStatus[] = ["queued", "processing"];
+    for (const jobStatus of activeStatuses) {
+      expect(
+        isSubmissionBlocked({ isSubmitting: false, jobId: "job-1", jobStatus }),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("BatchReview source (#698)", () => {
+  const SOURCE = readFileSync(
+    path.join(process.cwd(), "components", "dashboard", "BatchReview.tsx"),
+    "utf8",
+  );
+
+  test("does not track submission with a component-local useState that could clear early", () => {
+    // The regression was a local `const [isSubmitting, setIsSubmitting] =
+    // useState(false)` that cleared as soon as the initial fetch resolved,
+    // out of sync with the background job. Pin that it's gone.
+    expect(SOURCE).not.toMatch(/useState\(false\)/);
+    expect(SOURCE).not.toMatch(/setIsSubmitting/);
+  });
+
+  test("derives the submit lock from the context's job lifecycle", () => {
+    expect(SOURCE).toMatch(/context\.hasActiveJob/);
+  });
+
+  test("guards handleSubmit against a second call while already blocked", () => {
+    const handleSubmitMatch = SOURCE.match(
+      /const handleSubmit = async \(\) => \{[\s\S]*?\n {2}\};/,
+    );
+    expect(handleSubmitMatch).not.toBeNull();
+    expect(handleSubmitMatch![0]).toMatch(/if \(!publicKey \|\| isSubmitting\)/);
+  });
+});
+
+describe("BatchFlowContext source (#698)", () => {
+  const SOURCE = readFileSync(
+    path.join(process.cwd(), "contexts", "BatchFlowContext.tsx"),
+    "utf8",
+  );
+
+  test("onSubmit guards against overlapping submissions before queuing a new job", () => {
+    const onSubmitMatch = SOURCE.match(
+      /const onSubmit = useCallback\(async[\s\S]*?\n {2}\}, \[[^\]]*\]\);/,
+    );
+    expect(onSubmitMatch).not.toBeNull();
+    expect(onSubmitMatch![0]).toMatch(/isSubmissionBlocked\(/);
+  });
+
+  test("exposes hasActiveJob computed from isSubmissionBlocked", () => {
+    expect(SOURCE).toMatch(/hasActiveJob = useMemo/);
+  });
+});


### PR DESCRIPTION
Closes #698.
---
What & Why

This PR fixes Issue #698: the "Submit Batch" button re-enabled as soon as the initial /api/batch-submit request returned, even though the payment job kept running in the background (queued → processing). Because the idempotency key is derived from the batch contents, a user could edit the review selection (skip/convert a recipient) and fire a second, overlapping submission before the first job finished, which the backend treats as an entirely new job, risking duplicate payments.

The fix moves the submit lock from a component-local isSubmitting flag (which cleared too early) onto BatchFlowContext's actual job lifecycle. A new hasActiveJob flag, backed by a pure isSubmissionBlocked helper, stays true from the moment submission starts until the job reaches a terminal status (completed/failed). onSubmit in the context also guards itself so a re-entrant call while a job is active is rejected with a toast instead of silently queuing a duplicate.

No backend changes, no changes to polling behavior/frequency, no changes to the successful-submission flow.

Closes #698

---
Touched surface

- [x] components/ — BatchReview.tsx (submit button lock)
- [x] contexts/ — BatchFlowContext.tsx (job lifecycle state)
- [x] lib/ — new lib/stellar/job-lifecycle.ts pure helper
- [x] tests/ — new regression tests
- [ ] app/ (API routes) — untouched, no backend changes
- [ ] cli/, contracts/, services/, scripts/ — untouched
- [ ] docs/ — untouched
- [ ] CI / config — untouched

---
Settlement & refund semantics

This PR does not touch transaction building, signing, or broadcast logic (lib/stellar/batch-worker.ts, batcher.ts, submission API routes are all untouched). It only prevents the client from being able to trigger a second submission request while a prior batch job is still active — closing a real duplicate-payment risk at the UI layer, not changing how funds move once a job is queued.

---
Tests run

- [x] npx tsc --noEmit — clean
- [x] npx vitest run tests/ — 534/535 passing; the 1 failure (worker-source-verification.test.ts, #504) is pre-existing and unrelated — confirmed it fails identically on main before this change
- [ ] npm run lint — not run; this repo's ESLint config currently throws (Converting circular structure to JSON in @eslint/eslintrc) on main regardless of this PR, confirmed pre-existing
- [ ] npm run test:e2e (Playwright) — not run; no browser environment available in this session

Free-form outcome:

Added lib/stellar/job-lifecycle.ts (isActiveJobStatus, isSubmissionBlocked) —
pure, DOM-free helpers following this repo's existing test convention
(no @testing-library/react in devDependencies; see demo-page-hooks.test.ts /
batch-error-boundary.test.ts for precedent).

New tests (tests/batch-submit-lock.test.ts, 14 cases) cover:
- submission allowed from a fresh state
- blocked while the initial request is in flight (before jobId exists)
- blocked while queued / processing
- re-enabled on completed / failed
- static source assertions pinning that BatchReview no longer shadows the
  context's lifecycle with a local useState, and that onSubmit/handleSubmit
  both guard against re-entrant calls

Did not manually exercise this in a running browser this session — the fix
is verified via the regression tests and a manual code trace of the
onSubmit/startPolling state transitions, not a live click-through.

---
UI / evidence artefacts

- [x] Frontend visible change → "Submit Batch" button now stays disabled and reads "Submitting..." for the full job lifecycle, not just the initial request. No screenshot attached — this is a timing/state-lifecycle fix, not a visual change, and I did not run the app in a browser this session (see note above).
- [ ] Coordinator/API change — none
- [ ] Metrics / KPI change
- [ ] Status table / README change
- [ ] None of the above

---
Secrets, logging, and PII risk

- [x] No secrets, private keys, RPC credentials, .env content, or wallet mnemonics added
- [x] No new console.*/logger.* statements exposing sensitive information (only a user-facing toast.error with a generic message)
- [x] No new build/dev flags introduced
- [ ] None of the above

---
Public proof links (SCF / investor evidence)

n/a

---
Breaking change & rollback

- [ ] Breaking change? No — purely client-side, no API contract changes, fully backwards compatible.
- [ ] Migration or feature flag required? No

---
Reviewer checklist (for the PR author to self-verify)

- [x] PR description and code comments are in English
- [x] Linked issue (#698)
- [x] No unrelated drive-by changes — diff is limited to the two files named in the issue plus one new helper module and one new test file
- [x] Tests touch the same files as the source change
- [x] PR is reversible: a single git revert restores prior state
