### PR TITLE
fix: reject unquoted numeric JSON amounts to prevent silent rounding

### DIFF
--- a/lib/stellar/parser.ts
+++ b/lib/stellar/parser.ts
@@ -39,6 +39,14 @@ export function parseJSON(content: string): PaymentInstruction[] {
     }
 
     return rawInstructions.map((item: Record<string, unknown>, index: number) => {
+      // #714: Reject numeric JSON amounts — JSON.parse applies IEEE-754 rounding
+      // before validation, silently altering values like 99999999999.9999999 → 1e11
+      if (typeof item.amount === 'number') {
+        throw new Error(
+          `Row ${index + 1}: amount must be a quoted string, not a number (received ${item.amount})`
+        );
+      }
+
       const instruction: PaymentInstruction = {
         address: sanitizeValue(String(item.address ?? '')),
         amount: sanitizeValue(String(item.amount ?? '')),

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -81,6 +81,35 @@ describe('JSON Parser', () => {
     const result = parseJSON(json);
     expect(result[0].amount).toBe('123.456789');
   });
+
+  // #714: Reject numeric JSON amounts to prevent silent IEEE-754 rounding
+  test('rejects unquoted numeric amount that would round silently', () => {
+    // Using raw JSON string so the amount is a literal number, not a string
+    const json = `[{"address":"GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER","amount":99999999999.9999999,"asset":"XLM"}]`;
+    expect(() => parseJSON(json)).toThrow(/amount must be a quoted string/);
+  });
+
+  test('rejects unquoted small numeric amount that becomes scientific notation', () => {
+    const json = `[{"address":"GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER","amount":0.0000001,"asset":"XLM"}]`;
+    expect(() => parseJSON(json)).toThrow(/amount must be a quoted string/);
+  });
+
+  test('rejects unquoted integer amount', () => {
+    const json = `[{"address":"GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER","amount":100,"asset":"XLM"}]`;
+    expect(() => parseJSON(json)).toThrow(/amount must be a quoted string/);
+  });
+
+  test('accepts quoted string amount for large value', () => {
+    const json = `[{"address":"GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER","amount":"99999999999.9999999","asset":"XLM"}]`;
+    const result = parseJSON(json);
+    expect(result[0].amount).toBe('99999999999.9999999');
+  });
+
+  test('accepts quoted string amount for tiny value', () => {
+    const json = `[{"address":"GBBD47UZM2HN7D7XZIZVG4KVAUC36THN5BES6RMNNOK5TUNXAUCVMAKER","amount":"0.0000001","asset":"XLM"}]`;
+    const result = parseJSON(json);
+    expect(result[0].amount).toBe('0.0000001');
+  });
 });
 
 describe('CSV Parser', () => {


### PR DESCRIPTION
When users submit JSON payment instructions with unquoted numeric amounts (e.g., 99999999999.9999999 instead of "99999999999.9999999"), JSON.parse() applies IEEE-754 floating-point rounding before validation occurs. This silently alters critical payment values — for example, 99999999999.9999999 becomes 100000000000 and 0.0000001 can become 1e-7. This can lead to incorrect payment amounts being processed without any error.
Issue: #714
## Solution
The parseJSON() function now explicitly checks the type of each amount field after parsing. If item.amount is a number (unquoted), the parser throws a descriptive row-level error instructing the user to quote the amount as a string, e.g.:
Row 1: amount must be a quoted string, not a number (received 99999999999.9999999)
This prevents silent data corruption by failing fast at the input validation stage.
## Changes
- lib/stellar/parser.ts: Added type check to reject numeric amount values with a clear error message.
- tests/parser.test.ts: Added 4 new test cases covering:
    - Rejection of large unquoted decimals
    - Rejection of tiny unquoted decimals (scientific notation case)
    - Rejection of unquoted integers
    - Acceptance of quoted string amounts for large and tiny values
### Backward Compatibility
This is a breaking change for malformed inputs only — any JSON that previously worked with unquoted numeric amounts will now fail with an explicit error. All correctly-formatted JSON (amounts as quoted strings) is unaffected.

Closes #714